### PR TITLE
add ConnectionChecker/ move Proxy to Client

### DIFF
--- a/hahomematic/config.py
+++ b/hahomematic/config.py
@@ -1,11 +1,13 @@
 """
 Global configuration parameters.
 """
+from datetime import timedelta
 
 from hahomematic.const import DEFAULT_INIT_TIMEOUT, DEFAULT_TIMEOUT
 
+CACHE_DIR = None
+CONNECTION_CHECKER_INTERVAL = timedelta(seconds=30)
+INIT_TIMEOUT = DEFAULT_INIT_TIMEOUT
 JSON_EXECUTOR_MAX_WORKERS = 4
 PROXY_EXECUTOR_MAX_WORKERS = 1
 TIMEOUT = DEFAULT_TIMEOUT
-INIT_TIMEOUT = DEFAULT_INIT_TIMEOUT
-CACHE_DIR = None

--- a/hahomematic/proxy.py
+++ b/hahomematic/proxy.py
@@ -4,60 +4,9 @@ Implementation of a locking ServerProxy for XML-RPC communication.
 
 import logging
 import ssl
-import threading
 import xmlrpc.client
-from concurrent.futures import ThreadPoolExecutor
 
 _LOGGER = logging.getLogger(__name__)
-
-
-# pylint: disable=too-few-public-methods
-# noinspection PyProtectedMember,PyUnresolvedReferences
-class LockingServerProxy(xmlrpc.client.ServerProxy):
-    """
-    ServerProxy implementation with lock when request is executing.
-    """
-
-    def __init__(self, is_async: bool, *args, **kwargs):
-        """
-        Initialize new proxy for server and get local ip
-        """
-        self._is_async = is_async
-        self._tls = kwargs.pop("tls", False)
-        self._verify_tls = kwargs.pop("verify_tls", True)
-        self.lock = threading.Lock()
-        if self._tls and not self._verify_tls and self._verify_tls is not None:
-            kwargs["context"] = ssl._create_unverified_context()
-        xmlrpc.client.ServerProxy.__init__(self, encoding="ISO-8859-1", *args, **kwargs)
-
-    async def __async_request(self, *args, **kwargs):
-        """
-        Call method on server side
-        """
-
-        with self.lock:
-            parent = xmlrpc.client.ServerProxy
-            # pylint: disable=protected-access
-            return parent._ServerProxy__request(self, *args, **kwargs)
-
-    def __sync_request(self, *args, **kwargs):
-        """
-        Call method on server side
-        """
-
-        with self.lock:
-            parent = xmlrpc.client.ServerProxy
-            # pylint: disable=protected-access
-            return parent._ServerProxy__request(self, *args, **kwargs)
-
-    def __getattr__(self, *args, **kwargs):
-        """
-        Magic method dispatcher
-        """
-        if self._is_async:
-            return xmlrpc.client._Method(self.__async_request, *args, **kwargs)
-        else:
-            return xmlrpc.client._Method(self.__sync_request, *args, **kwargs)
 
 
 # pylint: disable=too-few-public-methods
@@ -67,9 +16,7 @@ class ThreadPoolServerProxy(xmlrpc.client.ServerProxy):
     ServerProxy implementation with lock when request is executing.
     """
 
-    def __init__(
-        self, executor_func, *args, **kwargs
-    ):
+    def __init__(self, executor_func, *args, **kwargs):
         """
         Initialize new proxy for server and get local ip
         """
@@ -86,83 +33,12 @@ class ThreadPoolServerProxy(xmlrpc.client.ServerProxy):
         """
         parent = xmlrpc.client.ServerProxy
         # pylint: disable=protected-access
-        return await self._executor_func(parent._ServerProxy__request, self, *args, **kwargs)
+        return await self._executor_func(
+            parent._ServerProxy__request, self, *args, **kwargs
+        )
 
     def __getattr__(self, *args, **kwargs):
         """
         Magic method dispatcher
         """
         return xmlrpc.client._Method(self.__async_request, *args, **kwargs)
-
-
-# # pylint: disable=too-few-public-methods
-# # noinspection PyProtectedMember,PyUnresolvedReferences
-# class AsyncLockingServerProxy(aiohttp_xmlrpc.client.ServerProxy):
-#     """
-#     ServerProxy implementation with lock when request is executing.
-#     """
-#
-#     def __init__(self, *args, **kwargs):
-#         """
-#         Initialize new proxy for server and get local ip
-#         """
-#         self._tls = kwargs.pop("tls", False)
-#         self._verify_tls = kwargs.pop("verify_tls", True)
-#         self.lock = threading.Lock()
-#         if self._tls and not self._verify_tls and self._verify_tls is not None:
-#             kwargs["context"] = ssl._create_unverified_context()
-#         aiohttp_xmlrpc.client.ServerProxy.__init__(
-#             self, url=args[0], encoding="ISO-8859-1"
-#         )
-#
-#     async def __remote_call(self, method_name, *args, **kwargs):
-#         with self.lock:
-#             parent = aiohttp_xmlrpc.client.ServerProxy
-#             # pylint: disable=protected-access
-#             return await parent._ServerProxy__remote_call(
-#                 self, method_name, *args, **kwargs
-#             )
-#
-#     def __getitem__(self, method_name):
-#         def method(*args, **kwargs):
-#             return self.__remote_call(method_name, *args, **kwargs)
-#
-#         return method
-#
-#     def __getattr__(self, method_name):
-#         return self[method_name]
-
-
-# # pylint: disable=too-few-public-methods
-# # noinspection PyProtectedMember,PyUnresolvedReferences
-# class AsyncThreadPoolServerProxy(aiohttp_xmlrpc.client.ServerProxy):
-#     """
-#     ServerProxy implementation with lock when request is executing.
-#     """
-#
-#     def __init__(self, proxy_executor: ThreadPoolExecutor, *args, **kwargs):
-#         """
-#         Initialize new proxy for server and get local ip
-#         """
-#         self._proxy_executor = proxy_executor
-#         self._tls = kwargs.pop("tls", False)
-#         self._verify_tls = kwargs.pop("verify_tls", True)
-#         if self._tls and not self._verify_tls and self._verify_tls is not None:
-#             kwargs["context"] = ssl._create_unverified_context()
-#         aiohttp_xmlrpc.client.ServerProxy.__init__(
-#             self, url=args[0], encoding="ISO-8859-1"
-#         )
-#
-#     async def __remote_call(self, method_name, *args, **kwargs):
-#         parent = aiohttp_xmlrpc.client.ServerProxy
-#         # pylint: disable=protected-access
-#         return await self._proxy_executor.submit(parent._ServerProxy__remote_call, self, method_name, *args, **kwargs).result()
-#
-#     def __getitem__(self, method_name):
-#         def method(*args, **kwargs):
-#             return self.__remote_call(method_name, *args, **kwargs)
-#
-#         return method
-#
-#     def __getattr__(self, method_name):
-#         return self[method_name]


### PR DESCRIPTION
- move proxy to client: 
In den HM Doku steht: Für jede dieser Schnittstellen stellt die HomeMatic Zentrale einen XML-RPC-Server zur Verfügung.
- add ConnectionChecker to automatically reconnect after connection failure.