### PR TITLE
cover: use channel level for current_state

### DIFF
--- a/hahomematic/devices/cover.py
+++ b/hahomematic/devices/cover.py
@@ -57,7 +57,10 @@ class HmCover(CustomEntity):
     @property
     def _channel_level(self) -> float:
         """return the channel level state of the cover"""
-        return self._get_entity_value(FIELD_CHANNEL_LEVEL)
+        channel_level = self._get_entity_value(FIELD_CHANNEL_LEVEL)
+        if channel_level:
+            return channel_level
+        return self._level
 
     @property
     def current_cover_position(self) -> int | None:
@@ -65,8 +68,8 @@ class HmCover(CustomEntity):
         Return current position of cover.
         HA:  0 means closed and 100 is fully open
         """
-        if self._level is not None:
-            return int(self._level * 100)
+        if self._channel_level is not None:
+            return int(self._channel_level * 100)
         return None
 
     async def async_set_cover_position(self, position) -> None:
@@ -79,8 +82,8 @@ class HmCover(CustomEntity):
     @property
     def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
-        if self._level is not None:
-            return self._level == HM_OPEN
+        if self._channel_level is not None:
+            return self._channel_level == HM_OPEN
         return None
 
     async def async_open_cover(self) -> None:
@@ -113,7 +116,10 @@ class HmBlind(HmCover):
     @property
     def _channel_level_2(self) -> float:
         """return the channel level of the tilt"""
-        return self._get_entity_value(FIELD_CHANNEL_LEVEL_2)
+        channel_level_2 = self._get_entity_value(FIELD_CHANNEL_LEVEL_2)
+        if channel_level_2:
+            return channel_level_2
+        return self._level_2
 
     @property
     def current_cover_tilt_position(self) -> int | None:
@@ -121,8 +127,8 @@ class HmBlind(HmCover):
         Return current tilt position of cover.
         HA:  0 means closed and 100 is fully open
         """
-        if self._level_2 is not None:
-            return int(self._level_2 * 100)
+        if self._channel_level_2 is not None:
+            return int(self._channel_level_2 * 100)
         return None
 
     async def async_set_cover_tilt_position(self, position) -> None:
@@ -162,12 +168,12 @@ def make_ip_cover(device, address):
 
 def make_ip_multi_cover(device, address):
     """Helper to create homematic ip cover entities."""
-    return make_custom_entity(device, address, HmCover, Devices.IP_COVER)
+    return make_custom_entity(device, address, HmCover, Devices.IP_MULTI_COVER)
 
 
 def make_ip_wired_multi_cover(device, address):
     """Helper to create homematic ip cover entities."""
-    return make_custom_entity(device, address, HmCover, Devices.IP_COVER)
+    return make_custom_entity(device, address, HmCover, Devices.IP_WIRED_MULTI_COVER)
 
 
 def make_rf_cover(device, address):
@@ -191,6 +197,7 @@ DEVICES = {
     "HmIP-BBL": make_ip_blind,
     "HmIP-FBL": make_ip_blind,
     "HmIP-DRBLI4": make_ip_multi_cover,
+    "HmIPW-DRBL4": make_ip_wired_multi_cover,
     "HM-LC-Bl1*": make_rf_blind,
     "HM-LC-Ja1PBU-FM": make_rf_blind,
     "ZEL STG RM FEP 230V": make_rf_blind,

--- a/hahomematic/devices/device_description.py
+++ b/hahomematic/devices/device_description.py
@@ -63,11 +63,13 @@ class Devices(Enum):
     IP_PLUG_SWITCH = "IPKeySwitch"
     IP_LIGHT = "IPLight"
     IP_LIGHT_BSL = "IPLightBSL"
+    IP_MULTI_COVER = "IPMultiCover"
     IP_MULTI_DIMMER = "IPMultiDimmer"
     IP_MULTI_SWITCH = "IPMultiSwitch"
     IP_SWITCH = "IPSwitch"
     IP_SWITCH_BSL = "IPSwitchBSL"
     IP_THERMOSTAT = "IPThermostat"
+    IP_WIRED_MULTI_COVER = "IPWiredMultiCover"
     IP_WIRED_MULTI_DIMMER = "IPWiredMultiDimmer"
     IP_WIRED_MULTI_SWITCH = "IPWiredMultiSwitch"
     RF_COVER = "RfCover"
@@ -112,6 +114,7 @@ SCHEMA_DEVICE_DESCRIPTION = Schema(
 device_description = {
     DD_DEFAULT_ENTITIES: {
         0: {
+            FIELD_TEMPERATURE: "ACTUAL_TEMPERATURE",
             FIELD_DUTY_CYCLE: "DUTY_CYCLE",
             FIELD_DUTYCYCLE: "DUTYCYCLE",
             FIELD_LOW_BAT: "LOW_BAT",
@@ -310,14 +313,14 @@ device_description = {
         },
         Devices.IP_WIRED_MULTI_SWITCH: {
             DD_DEVICE_GROUP: {
-                DD_GROUP_BASE_CHANNEL: [1, 5, 9, 13],
-                DD_PHY_CHANNEL: [2],
-                DD_VIRT_CHANNEL: [3, 4],
+                DD_GROUP_BASE_CHANNEL: [1, 5, 9, 13, 17, 21, 25, 29],
+                DD_PHY_CHANNEL: [1],
+                DD_VIRT_CHANNEL: [2, 3],
                 DD_FIELDS_REP: {
                     FIELD_STATE: "STATE",
                 },
                 DD_FIELDS: {
-                    1: {
+                    0: {
                         FIELD_CHANNEL_STATE: "STATE",
                     },
                 },
@@ -382,7 +385,7 @@ device_description = {
         Devices.IP_COVER: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [4],
-                DD_VIRT_CHANNEL: [5, 6],
+                DD_VIRT_CHANNEL: [],
                 DD_FIELDS_REP: {
                     FIELD_LEVEL: "LEVEL",
                     FIELD_LEVEL_2: "LEVEL_2",
@@ -390,6 +393,42 @@ device_description = {
                 },
                 DD_FIELDS: {
                     3: {
+                        FIELD_CHANNEL_LEVEL: "LEVEL",
+                        FIELD_CHANNEL_LEVEL_2: "LEVEL_2",
+                    },
+                },
+            },
+        },
+        Devices.IP_MULTI_COVER: {
+            DD_DEVICE_GROUP: {
+                DD_GROUP_BASE_CHANNEL: [9, 13, 17, 21],
+                DD_PHY_CHANNEL: [1],
+                DD_VIRT_CHANNEL: [],
+                DD_FIELDS_REP: {
+                    FIELD_LEVEL: "LEVEL",
+                    FIELD_LEVEL_2: "LEVEL_2",
+                    FIELD_STOP: "STOP",
+                },
+                DD_FIELDS: {
+                    0: {
+                        FIELD_CHANNEL_LEVEL: "LEVEL",
+                        FIELD_CHANNEL_LEVEL_2: "LEVEL_2",
+                    },
+                },
+            },
+        },
+        Devices.IP_WIRED_MULTI_COVER: {
+            DD_DEVICE_GROUP: {
+                DD_GROUP_BASE_CHANNEL: [1 ,5, 9, 13],
+                DD_PHY_CHANNEL: [1],
+                DD_VIRT_CHANNEL: [],
+                DD_FIELDS_REP: {
+                    FIELD_LEVEL: "LEVEL",
+                    FIELD_LEVEL_2: "LEVEL_2",
+                    FIELD_STOP: "STOP",
+                },
+                DD_FIELDS: {
+                    0: {
                         FIELD_CHANNEL_LEVEL: "LEVEL",
                         FIELD_CHANNEL_LEVEL_2: "LEVEL_2",
                     },

--- a/hahomematic/devices/switch.py
+++ b/hahomematic/devices/switch.py
@@ -108,5 +108,5 @@ DEVICES = {
     "HmIP-PS*": make_ip_plug_switch,
     "HmIP-BSL": make_ip_switch_bsl,
     "HmIP-DRSI4": make_ip_multi_switch,
-    "HmIPW-DRS4": make_ip_wired_multi_switch,
+    "HmIPW-DRS*": make_ip_wired_multi_switch,
 }


### PR DESCRIPTION
Wie [in](https://github.com/danielperna84/hahomematic/discussions/39) geschrieben:
Beispiel BROLL:
Status wird über Ch:3 (Sensor) anzeigen und die Steuerung über Ch:4.
Des weitern habe ich die virtuellen Kanäle (Ch:5+6) deaktiviert.