### PR TITLE
fixes, typing, enums and more

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+Version 0.0.17 (2021-12-05)
+- Remove variables that are covered by other sensors (CCU only)
+- Remove dummy from service message (HmIP-RF always sends 0001D3C98DD4B6:3 unreach)
+- Rename Bidcos thermostats to SimpleRfThermostat and RfThermostat
+- Use more Enums (like HA does): HmPlatform, HmEventType
+- Use assignment expressions
+- Add more type hints (fix most mypy errors)
+
 Version 0.0.16 (2021-12-02)
 - Don't use default entities for climate groups (already included in device)
 

--- a/hahomematic/central_unit.py
+++ b/hahomematic/central_unit.py
@@ -148,8 +148,7 @@ class CentralUnit:
         if ":" not in address:
             return False
         d_address = address.split(":")[0]
-        channels = self.address_parameter_cache.get((d_address, parameter))
-        if channels:
+        if channels := self.address_parameter_cache.get((d_address, parameter)):
             return len(set(channels)) > 1
         return False
 
@@ -350,8 +349,7 @@ class CentralUnit:
             )
 
         device_address = address.split(":")[0]
-        virtual_remote: HmDevice = self._get_virtual_remote(device_address)
-        if virtual_remote:
+        if virtual_remote := self._get_virtual_remote(device_address):
             virtual_remote_channel = virtual_remote.action_events.get(
                 (address, parameter)
             )
@@ -388,10 +386,8 @@ class CentralUnit:
         """Get entity by address and parameter."""
         if ":" in address:
             device_address = address.split(":")[0]
-            device = self.hm_devices.get(device_address)
-            if device:
-                entity = device.entities.get((address, parameter))
-                if entity:
+            if device := self.hm_devices.get(device_address):
+                if entity := device.entities.get((address, parameter)):
                     return entity
         return None
 
@@ -431,8 +427,7 @@ class CentralUnit:
         parameters = set()
         for entity in self.hm_entities.values():
             if isinstance(entity, GenericEntity):
-                parameter = getattr(entity, "parameter", None)
-                if parameter:
+                if parameter := getattr(entity, "parameter", None):
                     parameters.add(entity.parameter)
 
         return sorted(parameters)
@@ -440,11 +435,9 @@ class CentralUnit:
     def get_used_parameters(self, address):
         """Return used parameters"""
         parameters = set()
-        device = self.hm_devices.get(address)
-        if device:
+        if device := self.hm_devices.get(address):
             for entity in device.entities.values():
-                parameter = getattr(entity, "parameter", None)
-                if parameter:
+                if parameter := getattr(entity, "parameter", None):
                     parameters.add(entity.parameter)
 
         return sorted(parameters)

--- a/hahomematic/central_unit.py
+++ b/hahomematic/central_unit.py
@@ -32,6 +32,7 @@ from hahomematic.const import (
     HM_VIRTUAL_REMOTE_HMIP,
     LOCALHOST,
     PRIMARY_PORTS,
+    HmPlatform,
 )
 from hahomematic.data import INSTANCES
 from hahomematic.device import HmDevice, create_devices
@@ -356,7 +357,7 @@ class CentralUnit:
             )
             await virtual_remote_channel.send_value(True)
 
-    def get_hm_entities_by_platform(self, platform):
+    def get_hm_entities_by_hmplatform(self, platform: HmPlatform):
         """
         Return all hm-entities by platform
         """

--- a/hahomematic/central_unit.py
+++ b/hahomematic/central_unit.py
@@ -303,7 +303,12 @@ class CentralUnit:
 
     async def get_service_messages(self):
         """Get service messages from CCU / Homegear."""
-        await self.get_primary_client().get_service_messages()
+        service_messages = []
+        for client in self.clients.values():
+            if client.port in PRIMARY_PORTS:
+                if client_messages := await client.get_service_messages():
+                    service_messages.extend(client_messages)
+        return service_messages
 
     # pylint: disable=invalid-name
     async def set_install_mode(

--- a/hahomematic/central_unit.py
+++ b/hahomematic/central_unit.py
@@ -120,7 +120,7 @@ class CentralUnit:
         if self.model is not BACKEND_PYDEVCCU:
             self.hub = HmHub(
                 self,
-                use_entities=self.central_config.enable_sensors_for_own_system_variables,
+                use_entities=self.central_config.enable_sensors_for_system_variables,
             )
             await self.hub.fetch_data()
         else:
@@ -714,7 +714,7 @@ class CentralConfig:
         json_port=None,
         json_tls=DEFAULT_TLS,
         enable_virtual_channels=False,
-        enable_sensors_for_own_system_variables=False,
+        enable_sensors_for_system_variables=False,
     ):
         self.entry_id = entry_id
         self.loop = loop
@@ -731,9 +731,7 @@ class CentralConfig:
         self.json_port = json_port
         self.json_tls = json_tls
         self.enable_virtual_channels = enable_virtual_channels
-        self.enable_sensors_for_own_system_variables = (
-            enable_sensors_for_own_system_variables
-        )
+        self.enable_sensors_for_system_variables = enable_sensors_for_system_variables
 
     def get_central(self) -> CentralUnit:
         """Identify the used client."""
@@ -744,6 +742,8 @@ def _remove_dummy_service_message(service_messages):
     """Remove dummy SM, that hmip server always sends."""
     new_service_messages = []
     for client_messages in service_messages:
-        if "0001D3C98DD4B6:3" not in [client_message[0] for client_message in client_messages]:
+        if "0001D3C98DD4B6:3" not in [
+            client_message[0] for client_message in client_messages
+        ]:
             new_service_messages.append(client_messages)
     return new_service_messages

--- a/hahomematic/central_unit.py
+++ b/hahomematic/central_unit.py
@@ -307,8 +307,8 @@ class CentralUnit:
         for client in self.clients.values():
             if client.port in PRIMARY_PORTS:
                 if client_messages := await client.get_service_messages():
-                    service_messages.extend(client_messages)
-        return service_messages
+                    service_messages.append(client_messages)
+        return _remove_dummy_service_message(service_messages)
 
     # pylint: disable=invalid-name
     async def set_install_mode(
@@ -738,3 +738,12 @@ class CentralConfig:
     def get_central(self) -> CentralUnit:
         """Identify the used client."""
         return CentralUnit(self)
+
+
+def _remove_dummy_service_message(service_messages):
+    """Remove dummy SM, that hmip server always sends."""
+    new_service_messages = []
+    for client_messages in service_messages:
+        if "0001D3C98DD4B6:3" not in [client_message[0] for client_message in client_messages]:
+            new_service_messages.append(client_messages)
+    return new_service_messages

--- a/hahomematic/client.py
+++ b/hahomematic/client.py
@@ -177,6 +177,7 @@ class Client(ABC):
         de_init_status = await self.proxy_de_init()
         if de_init_status is not PROXY_DE_INIT_FAILED:
             return await self.proxy_init()
+        return PROXY_DE_INIT_FAILED
 
     def stop(self):
         """Stop depending services."""
@@ -268,12 +269,13 @@ class Client(ABC):
         except ProxyException:
             _LOGGER.exception("set_install_mode: ProxyException")
 
-    async def get_install_mode(self):
+    async def get_install_mode(self) -> int:
         """Get remaining time in seconds install mode is active from CCU / Homegear."""
         try:
             return await self.proxy.getInstallMode()
         except ProxyException:
             _LOGGER.exception("get_install_mode: ProxyException")
+        return 0
 
     async def get_all_metadata(self, address):
         """Get all metadata of device."""

--- a/hahomematic/const.py
+++ b/hahomematic/const.py
@@ -3,10 +3,12 @@ Constants used by hahomematic.
 """
 from __future__ import annotations
 
+from datetime import datetime
 from enum import Enum
 
 DEFAULT_ENCODING = "UTF-8"
-
+HA_DOMAIN = "hahm"
+INIT_DATETIME = datetime.strptime("01.01.1970 00:00:00", "%d.%m.%Y %H:%M:%S")
 LOCALHOST = "localhost"
 IP_LOCALHOST_V4 = "127.0.0.1"
 IP_LOCALHOST_V6 = "::1"
@@ -58,8 +60,6 @@ RELEVANT_PARAMSETS = [
     PARAMSET_VALUES,
     # PARAMSET_MASTER,
 ]
-
-HA_DOMAIN = "hahm"
 
 HH_EVENT_DELETE_DEVICES = "deleteDevices"
 HH_EVENT_DEVICES_CREATED = "devicesCreated"
@@ -296,14 +296,6 @@ class HmPlatform(Enum):
     SWITCH = "switch"
     TEXT = "text"
 
-    @classmethod
-    def value_of(cls, value):
-        for k, v in cls.__members__.items():
-            if k == value:
-                return v
-        else:
-            raise ValueError(f"'{cls.__name__}' enum not found for '{value}'")
-
     def __str__(self) -> str:
         """Return self.value."""
         return str(self.value)
@@ -319,6 +311,7 @@ class HmEventType(Enum):
     def __str__(self) -> str:
         """Return self.value."""
         return str(self.value)
+
 
 AVAILABLE_HM_PLATFORMS = [
     HmPlatform.BINARY_SENSOR,

--- a/hahomematic/const.py
+++ b/hahomematic/const.py
@@ -3,6 +3,8 @@ Constants used by hahomematic.
 """
 from __future__ import annotations
 
+from enum import Enum
+
 DEFAULT_ENCODING = "UTF-8"
 
 LOCALHOST = "localhost"
@@ -84,10 +86,6 @@ EVENT_PRESS_LONG_RELEASE = "PRESS_LONG_RELEASE"
 EVENT_PRESS_LONG_START = "PRESS_LONG_START"
 EVENT_SEQUENCE_OK = "SEQUENCE_OK"
 EVENT_UN_REACH = "UNREACH"
-
-EVENT_ALARM = "homematic.alarm"
-EVENT_KEYPRESS = "homematic.keypress"
-EVENT_IMPULSE = "homematic.impulse"
 
 CLICK_EVENTS = [
     EVENT_PRESS,
@@ -274,35 +272,63 @@ DEFAULT_INIT_TIMEOUT = 90
 DEFAULT_TLS = False
 DEFAULT_VERIFY_TLS = False
 
-HA_PLATFORM_ACTION = "action"
-HA_PLATFORM_BINARY_SENSOR = "binary_sensor"
-HA_PLATFORM_BUTTON = "button"
-HA_PLATFORM_CLIMATE = "climate"
-HA_PLATFORM_COVER = "cover"
-HA_PLATFORM_EVENT = "event"
-HA_PLATFORM_LIGHT = "light"
-HA_PLATFORM_LOCK = "lock"
-HA_PLATFORM_NUMBER = "number"
-HA_PLATFORM_SELECT = "select"
-HA_PLATFORM_SENSOR = "sensor"
-HA_PLATFORM_SWITCH = "switch"
-HA_PLATFORM_TEXT = "text"
-
-HA_PLATFORMS = [
-    HA_PLATFORM_BINARY_SENSOR,
-    HA_PLATFORM_BUTTON,
-    HA_PLATFORM_CLIMATE,
-    HA_PLATFORM_COVER,
-    HA_PLATFORM_LIGHT,
-    HA_PLATFORM_LOCK,
-    HA_PLATFORM_NUMBER,
-    HA_PLATFORM_SELECT,
-    HA_PLATFORM_SENSOR,
-    HA_PLATFORM_SWITCH,
-]
-
 HM_ENTITY_UNIT_REPLACE = {'"': "", "100%": "%", "% rF": "%"}
 
 HM_VIRTUAL_REMOTE_HM = "BidCoS-RF"
 HM_VIRTUAL_REMOTE_HMIP = "HmIP-RCV-1"
 HM_VIRTUAL_REMOTES = [HM_VIRTUAL_REMOTE_HM, HM_VIRTUAL_REMOTE_HMIP]
+
+
+class HmPlatform(Enum):
+    """Enum with platforms relevant for Home Assistant."""
+
+    ACTION = "action"
+    BINARY_SENSOR = "binary_sensor"
+    BUTTON = "button"
+    CLIMATE = "climate"
+    COVER = "cover"
+    EVENT = "event"
+    LIGHT = "light"
+    LOCK = "lock"
+    NUMBER = "number"
+    SELECT = "select"
+    SENSOR = "sensor"
+    SWITCH = "switch"
+    TEXT = "text"
+
+    @classmethod
+    def value_of(cls, value):
+        for k, v in cls.__members__.items():
+            if k == value:
+                return v
+        else:
+            raise ValueError(f"'{cls.__name__}' enum not found for '{value}'")
+
+    def __str__(self) -> str:
+        """Return self.value."""
+        return str(self.value)
+
+
+class HmEventType(Enum):
+    """Enum with hahm event types."""
+
+    ALARM = "homematic.alarm"
+    KEYPRESS = "homematic.keypress"
+    IMPULSE = "homematic.impulse"
+
+    def __str__(self) -> str:
+        """Return self.value."""
+        return str(self.value)
+
+AVAILABLE_HM_PLATFORMS = [
+    HmPlatform.BINARY_SENSOR,
+    HmPlatform.BUTTON,
+    HmPlatform.CLIMATE,
+    HmPlatform.COVER,
+    HmPlatform.LIGHT,
+    HmPlatform.LOCK,
+    HmPlatform.NUMBER,
+    HmPlatform.SELECT,
+    HmPlatform.SENSOR,
+    HmPlatform.SWITCH,
+]

--- a/hahomematic/data.py
+++ b/hahomematic/data.py
@@ -10,6 +10,5 @@ INSTANCES = {}
 def get_client_by_interface_id(interface_id):
     """Return client by interface_id"""
     for central in INSTANCES.values():
-        client = central.clients.get(interface_id)
-        if client:
+        if client := central.clients.get(interface_id):
             return client

--- a/hahomematic/data.py
+++ b/hahomematic/data.py
@@ -3,8 +3,10 @@ Module to store data required for operation.
 """
 from __future__ import annotations
 
+import hahomematic.central_unit as hm_central
+
 # {instance_name, central_unit}
-INSTANCES = {}
+INSTANCES: dict[str, hm_central.CentralUnit] = {}
 
 
 def get_client_by_interface_id(interface_id):

--- a/hahomematic/devices/climate.py
+++ b/hahomematic/devices/climate.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from hahomematic.const import ATTR_HM_MAX, ATTR_HM_MIN, HmPlatform
 from hahomematic.devices.device_description import (
@@ -469,7 +470,7 @@ class IPThermostat(CustomEntity):
             await self._send_value(FIELD_BOOST_MODE, False)
 
 
-def make_simple_thermostat(device, address, group_base_channels: [int]):
+def make_simple_thermostat(device, address, group_base_channels: list[int]):
     """Creates SimpleRfThermostat entities."""
     return make_custom_entity(
         device,
@@ -480,7 +481,7 @@ def make_simple_thermostat(device, address, group_base_channels: [int]):
     )
 
 
-def make_thermostat(device, address, group_base_channels: [int]):
+def make_thermostat(device, address, group_base_channels: list[int]):
     """Creates RfThermostat entities."""
     return make_custom_entity(
         device,
@@ -491,7 +492,7 @@ def make_thermostat(device, address, group_base_channels: [int]):
     )
 
 
-def make_thermostat_group(device, address, group_base_channels: [int]):
+def make_thermostat_group(device, address, group_base_channels: list[int]):
     """Creates RfThermostat group entities."""
     return make_custom_entity(
         device,
@@ -502,7 +503,7 @@ def make_thermostat_group(device, address, group_base_channels: [int]):
     )
 
 
-def make_ip_thermostat(device, address, group_base_channels: [int]):
+def make_ip_thermostat(device, address, group_base_channels: list[int]):
     """Creates IPThermostat entities."""
     return make_custom_entity(
         device,
@@ -513,7 +514,7 @@ def make_ip_thermostat(device, address, group_base_channels: [int]):
     )
 
 
-def make_ip_thermostat_group(device, address, group_base_channels: [int]):
+def make_ip_thermostat_group(device, address, group_base_channels: list[int]):
     """Creates IPThermostat group entities."""
     return make_custom_entity(
         device,
@@ -526,7 +527,7 @@ def make_ip_thermostat_group(device, address, group_base_channels: [int]):
 
 # Case for device model is not relevant
 # device_type and sub_type(IP-only) can be used here
-DEVICES = {
+DEVICES: dict[str, tuple[Any, list[int]]] = {
     "BC-RT-TRX-CyG*": (make_thermostat, []),
     "BC-RT-TRX-CyN*": (make_thermostat, []),
     "BC-TC-C-WM*": (make_thermostat, []),

--- a/hahomematic/devices/climate.py
+++ b/hahomematic/devices/climate.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from hahomematic.const import ATTR_HM_MAX, ATTR_HM_MIN, HA_PLATFORM_CLIMATE
+from hahomematic.const import ATTR_HM_MAX, ATTR_HM_MIN, HmPlatform
 from hahomematic.devices.device_description import (
     FIELD_AUTO_MODE,
     FIELD_BOOST_MODE,
@@ -16,7 +16,7 @@ from hahomematic.devices.device_description import (
     FIELD_SET_POINT_MODE,
     FIELD_SETPOINT,
     FIELD_TEMPERATURE,
-    Devices,
+    DeviceDescription,
     make_custom_entity,
 )
 from hahomematic.entity import CustomEntity
@@ -65,7 +65,7 @@ class SimpleThermostat(CustomEntity):
             device_enum=device_enum,
             device_desc=device_desc,
             entity_desc=entity_desc,
-            platform=HA_PLATFORM_CLIMATE,
+            platform=HmPlatform.CLIMATE,
             channel_no=channel_no,
         )
         _LOGGER.debug(
@@ -168,7 +168,7 @@ class Thermostat(CustomEntity):
             device_enum=device_enum,
             device_desc=device_desc,
             entity_desc=entity_desc,
-            platform=HA_PLATFORM_CLIMATE,
+            platform=HmPlatform.CLIMATE,
             channel_no=channel_no,
         )
         _LOGGER.debug(
@@ -331,7 +331,7 @@ class IPThermostat(CustomEntity):
             device_enum=device_enum,
             device_desc=device_desc,
             entity_desc=entity_desc,
-            platform=HA_PLATFORM_CLIMATE,
+            platform=HmPlatform.CLIMATE,
             channel_no=channel_no,
         )
         _LOGGER.debug(
@@ -475,7 +475,7 @@ def make_simple_thermostat(device, address, group_base_channels: [int]):
         device,
         address,
         SimpleThermostat,
-        Devices.SIMPLE_RF_THERMOSTAT,
+        DeviceDescription.SIMPLE_RF_THERMOSTAT,
         group_base_channels,
     )
 
@@ -483,28 +483,44 @@ def make_simple_thermostat(device, address, group_base_channels: [int]):
 def make_thermostat(device, address, group_base_channels: [int]):
     """Creates Thermostat entities."""
     return make_custom_entity(
-        device, address, Thermostat, Devices.RF_THERMOSTAT, group_base_channels
+        device,
+        address,
+        Thermostat,
+        DeviceDescription.RF_THERMOSTAT,
+        group_base_channels,
     )
 
 
 def make_thermostat_group(device, address, group_base_channels: [int]):
     """Creates Thermostat group entities."""
     return make_custom_entity(
-        device, address, Thermostat, Devices.RF_THERMOSTAT_GROUP, group_base_channels
+        device,
+        address,
+        Thermostat,
+        DeviceDescription.RF_THERMOSTAT_GROUP,
+        group_base_channels,
     )
 
 
 def make_ip_thermostat(device, address, group_base_channels: [int]):
     """Creates IPThermostat entities."""
     return make_custom_entity(
-        device, address, IPThermostat, Devices.IP_THERMOSTAT, group_base_channels
+        device,
+        address,
+        IPThermostat,
+        DeviceDescription.IP_THERMOSTAT,
+        group_base_channels,
     )
 
 
 def make_ip_thermostat_group(device, address, group_base_channels: [int]):
     """Creates IPThermostat group entities."""
     return make_custom_entity(
-        device, address, IPThermostat, Devices.IP_THERMOSTAT_GROUP, group_base_channels
+        device,
+        address,
+        IPThermostat,
+        DeviceDescription.IP_THERMOSTAT_GROUP,
+        group_base_channels,
     )
 
 

--- a/hahomematic/devices/climate.py
+++ b/hahomematic/devices/climate.py
@@ -45,7 +45,7 @@ SUPPORT_TARGET_TEMPERATURE = 1
 SUPPORT_PRESET_MODE = 16
 
 
-class SimpleThermostat(CustomEntity):
+class SimpleRfThermostat(CustomEntity):
     """Simple classic HomeMatic thermostat HM-CC-TC."""
 
     def __init__(
@@ -69,7 +69,7 @@ class SimpleThermostat(CustomEntity):
             channel_no=channel_no,
         )
         _LOGGER.debug(
-            "SimpleThermostat.__init__(%s, %s, %s)",
+            "SimpleRfThermostat.__init__(%s, %s, %s)",
             self._device.interface_id,
             address,
             unique_id,
@@ -148,7 +148,7 @@ class SimpleThermostat(CustomEntity):
         await self._send_value(FIELD_SETPOINT, float(temperature))
 
 
-class Thermostat(CustomEntity):
+class RfThermostat(CustomEntity):
     """Classic HomeMatic thermostat like HM-CC-RT-DN."""
 
     def __init__(
@@ -172,7 +172,7 @@ class Thermostat(CustomEntity):
             channel_no=channel_no,
         )
         _LOGGER.debug(
-            "Thermostat.__init__(%s, %s, %s)",
+            "RfThermostat.__init__(%s, %s, %s)",
             self._device.interface_id,
             address,
             unique_id,
@@ -470,33 +470,33 @@ class IPThermostat(CustomEntity):
 
 
 def make_simple_thermostat(device, address, group_base_channels: [int]):
-    """Creates SimpleThermostat entities."""
+    """Creates SimpleRfThermostat entities."""
     return make_custom_entity(
         device,
         address,
-        SimpleThermostat,
+        SimpleRfThermostat,
         DeviceDescription.SIMPLE_RF_THERMOSTAT,
         group_base_channels,
     )
 
 
 def make_thermostat(device, address, group_base_channels: [int]):
-    """Creates Thermostat entities."""
+    """Creates RfThermostat entities."""
     return make_custom_entity(
         device,
         address,
-        Thermostat,
+        RfThermostat,
         DeviceDescription.RF_THERMOSTAT,
         group_base_channels,
     )
 
 
 def make_thermostat_group(device, address, group_base_channels: [int]):
-    """Creates Thermostat group entities."""
+    """Creates RfThermostat group entities."""
     return make_custom_entity(
         device,
         address,
-        Thermostat,
+        RfThermostat,
         DeviceDescription.RF_THERMOSTAT_GROUP,
         group_base_channels,
     )
@@ -541,6 +541,6 @@ DEVICES = {
     "HmIP-WTH*": (make_ip_thermostat, []),
     "HmIPW-STH*": (make_ip_thermostat, []),
     "HmIPW-WTH*": (make_ip_thermostat, []),
-    "Thermostat AA*": (make_ip_thermostat, []),
+    "RfThermostat AA*": (make_ip_thermostat, []),
     "ZEL STG RM FWT": (make_simple_thermostat, []),
 }

--- a/hahomematic/devices/cover.py
+++ b/hahomematic/devices/cover.py
@@ -256,35 +256,35 @@ class HmGarage(CustomEntity):
         await self._send_value(FIELD_DOOR_COMMAND, GARAGE_DOOR_COMMAND_PARTIAL_OPEN)
 
 
-def make_ip_cover(device, address, group_base_channels: [int]):
+def make_ip_cover(device, address, group_base_channels: list[int]):
     """Creates homematic ip cover entities."""
     return make_custom_entity(
         device, address, HmCover, DeviceDescription.IP_COVER, group_base_channels
     )
 
 
-def make_rf_cover(device, address, group_base_channels: [int]):
+def make_rf_cover(device, address, group_base_channels: list[int]):
     """Creates homematic classic cover entities."""
     return make_custom_entity(
         device, address, HmCover, DeviceDescription.RF_COVER, group_base_channels
     )
 
 
-def make_ip_blind(device, address, group_base_channels: [int]):
+def make_ip_blind(device, address, group_base_channels: list[int]):
     """Creates homematic ip cover entities."""
     return make_custom_entity(
         device, address, HmBlind, DeviceDescription.IP_COVER, group_base_channels
     )
 
 
-def make_ip_garage(device, address, group_base_channels: [int]):
+def make_ip_garage(device, address, group_base_channels: list[int]):
     """Creates homematic ip garage entities."""
     return make_custom_entity(
         device, address, HmGarage, DeviceDescription.IP_GARAGE, group_base_channels
     )
 
 
-def make_rf_blind(device, address, group_base_channels: [int]):
+def make_rf_blind(device, address, group_base_channels: list[int]):
     """Creates homematic classic cover entities."""
     return make_custom_entity(
         device, address, HmBlind, DeviceDescription.RF_COVER, group_base_channels
@@ -293,7 +293,7 @@ def make_rf_blind(device, address, group_base_channels: [int]):
 
 # Case for device model is not relevant
 # device_type and sub_type(IP-only) can be used here
-DEVICES = {
+DEVICES: dict[str, tuple[Any, list[int]]] = {
     "HmIP-BROLL": (make_ip_cover, [3]),
     "HmIP-FROLL": (make_ip_cover, [3]),
     "HmIP-BBL": (make_ip_blind, [3]),

--- a/hahomematic/devices/cover.py
+++ b/hahomematic/devices/cover.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from hahomematic.const import HA_PLATFORM_COVER
+from hahomematic.const import HmPlatform
 from hahomematic.devices.device_description import (
     FIELD_CHANNEL_LEVEL,
     FIELD_CHANNEL_LEVEL_2,
@@ -14,7 +14,7 @@ from hahomematic.devices.device_description import (
     FIELD_LEVEL,
     FIELD_LEVEL_2,
     FIELD_STOP,
-    Devices,
+    DeviceDescription,
     make_custom_entity,
 )
 from hahomematic.entity import CustomEntity
@@ -60,7 +60,7 @@ class HmCover(CustomEntity):
             device_enum=device_enum,
             device_desc=device_desc,
             entity_desc=entity_desc,
-            platform=HA_PLATFORM_COVER,
+            platform=HmPlatform.COVER,
             channel_no=channel_no,
         )
         _LOGGER.debug(
@@ -197,7 +197,7 @@ class HmGarage(CustomEntity):
             device_enum=device_enum,
             device_desc=device_desc,
             entity_desc=entity_desc,
-            platform=HA_PLATFORM_COVER,
+            platform=HmPlatform.COVER,
             channel_no=channel_no,
         )
         _LOGGER.debug(
@@ -259,35 +259,35 @@ class HmGarage(CustomEntity):
 def make_ip_cover(device, address, group_base_channels: [int]):
     """Creates homematic ip cover entities."""
     return make_custom_entity(
-        device, address, HmCover, Devices.IP_COVER, group_base_channels
+        device, address, HmCover, DeviceDescription.IP_COVER, group_base_channels
     )
 
 
 def make_rf_cover(device, address, group_base_channels: [int]):
     """Creates homematic classic cover entities."""
     return make_custom_entity(
-        device, address, HmCover, Devices.RF_COVER, group_base_channels
+        device, address, HmCover, DeviceDescription.RF_COVER, group_base_channels
     )
 
 
 def make_ip_blind(device, address, group_base_channels: [int]):
     """Creates homematic ip cover entities."""
     return make_custom_entity(
-        device, address, HmBlind, Devices.IP_COVER, group_base_channels
+        device, address, HmBlind, DeviceDescription.IP_COVER, group_base_channels
     )
 
 
 def make_ip_garage(device, address, group_base_channels: [int]):
     """Creates homematic ip garage entities."""
     return make_custom_entity(
-        device, address, HmGarage, Devices.IP_GARAGE, group_base_channels
+        device, address, HmGarage, DeviceDescription.IP_GARAGE, group_base_channels
     )
 
 
 def make_rf_blind(device, address, group_base_channels: [int]):
     """Creates homematic classic cover entities."""
     return make_custom_entity(
-        device, address, HmBlind, Devices.RF_COVER, group_base_channels
+        device, address, HmBlind, DeviceDescription.RF_COVER, group_base_channels
     )
 
 

--- a/hahomematic/devices/device_description.py
+++ b/hahomematic/devices/device_description.py
@@ -67,7 +67,7 @@ FIELD_VOLTAGE = "voltage"
 _LOGGER = logging.getLogger(__name__)
 
 
-class Devices(Enum):
+class DeviceDescription(Enum):
     """Enum for device_descriptions."""
 
     IP_COVER = "IPCover"
@@ -84,6 +84,10 @@ class Devices(Enum):
     RF_THERMOSTAT = "RfThermostat"
     RF_THERMOSTAT_GROUP = "RfThermostatGroup"
     SIMPLE_RF_THERMOSTAT = "SimpleRfThermostat"
+
+    def __str__(self) -> str:
+        """Return self.value."""
+        return str(self.value)
 
 
 SCHEMA_DD_FIELD_DETAILS = Schema({Optional(str): str, Optional(str): str})
@@ -112,7 +116,7 @@ SCHEMA_DEVICE_DESCRIPTION = Schema(
         Required(DD_DEFAULT_ENTITIES): SCHEMA_DD_FIELD,
         Required(DD_DEVICES): Schema(
             {
-                Required(Devices): SCHEMA_DD_DEVICE_GROUPS,
+                Required(DeviceDescription): SCHEMA_DD_DEVICE_GROUPS,
             }
         ),
     }
@@ -134,7 +138,7 @@ device_description = {
         }
     },
     DD_DEVICES: {
-        Devices.IP_COVER: {
+        DeviceDescription.IP_COVER: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [1],
                 DD_VIRT_CHANNEL: [],
@@ -151,7 +155,7 @@ device_description = {
                 },
             },
         },
-        Devices.IP_DIMMER: {
+        DeviceDescription.IP_DIMMER: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [1],
                 DD_VIRT_CHANNEL: [2, 3],
@@ -165,7 +169,7 @@ device_description = {
                 },
             },
         },
-        Devices.IP_GARAGE: {
+        DeviceDescription.IP_GARAGE: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [1],
                 DD_VIRT_CHANNEL: [],
@@ -176,7 +180,7 @@ device_description = {
                 DD_FIELDS: {},
             },
         },
-        Devices.IP_LIGHT_BSL: {
+        DeviceDescription.IP_LIGHT_BSL: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [1],
                 DD_VIRT_CHANNEL: [2, 3],
@@ -192,7 +196,7 @@ device_description = {
                 },
             },
         },
-        Devices.IP_LIGHT_SWITCH: {
+        DeviceDescription.IP_LIGHT_SWITCH: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [1],
                 DD_VIRT_CHANNEL: [2, 3],
@@ -216,7 +220,7 @@ device_description = {
                 },
             },
         },
-        Devices.IP_LOCK: {
+        DeviceDescription.IP_LOCK: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [],
                 DD_VIRT_CHANNEL: [],
@@ -229,7 +233,7 @@ device_description = {
                 },
             },
         },
-        Devices.IP_THERMOSTAT: {
+        DeviceDescription.IP_THERMOSTAT: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [1],
                 DD_VIRT_CHANNEL: [],
@@ -254,7 +258,7 @@ device_description = {
                 },
             },
         },
-        Devices.IP_THERMOSTAT_GROUP: {
+        DeviceDescription.IP_THERMOSTAT_GROUP: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [1],
                 DD_VIRT_CHANNEL: [],
@@ -271,7 +275,7 @@ device_description = {
             },
             DD_INCLUDE_DEFAULT_ENTITIES: False,
         },
-        Devices.RF_COVER: {
+        DeviceDescription.RF_COVER: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [1, 2, 3, 4],
                 DD_VIRT_CHANNEL: [],
@@ -282,7 +286,7 @@ device_description = {
                 },
             },
         },
-        Devices.RF_DIMMER: {
+        DeviceDescription.RF_DIMMER: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [1, 2, 3, 4],
                 DD_VIRT_CHANNEL: [],
@@ -292,7 +296,7 @@ device_description = {
                 DD_FIELDS: {},
             },
         },
-        Devices.RF_LOCK: {
+        DeviceDescription.RF_LOCK: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [],
                 DD_VIRT_CHANNEL: [],
@@ -305,7 +309,7 @@ device_description = {
                 },
             },
         },
-        Devices.RF_THERMOSTAT: {
+        DeviceDescription.RF_THERMOSTAT: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [1, 2, 3, 4],
                 DD_VIRT_CHANNEL: [],
@@ -322,7 +326,7 @@ device_description = {
                 },
             },
         },
-        Devices.RF_THERMOSTAT_GROUP: {
+        DeviceDescription.RF_THERMOSTAT_GROUP: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [1, 2, 3, 4],
                 DD_VIRT_CHANNEL: [],
@@ -340,7 +344,7 @@ device_description = {
             },
             DD_INCLUDE_DEFAULT_ENTITIES: False,
         },
-        Devices.SIMPLE_RF_THERMOSTAT: {
+        DeviceDescription.SIMPLE_RF_THERMOSTAT: {
             DD_DEVICE_GROUP: {
                 DD_PHY_CHANNEL: [],
                 DD_VIRT_CHANNEL: [],
@@ -375,7 +379,7 @@ def make_custom_entity(
     device,
     address,
     custom_entity_class,
-    device_enum: Devices,
+    device_enum: DeviceDescription,
     group_base_channels: [int],
 ):
     """
@@ -458,7 +462,7 @@ def get_default_entities():
     return copy(device_description[DD_DEFAULT_ENTITIES])
 
 
-def get_include_default_entities(device_enum: Devices) -> True:
+def get_include_default_entities(device_enum: DeviceDescription) -> True:
     """Return if default entities should be included."""
     device = _get_device(device_enum)
     if device:
@@ -466,7 +470,7 @@ def get_include_default_entities(device_enum: Devices) -> True:
     return DEFAULT_INCLUDE_DEFAULT_ENTITIES
 
 
-def _get_device(device_enum: Devices):
+def _get_device(device_enum: DeviceDescription):
     """Return device from device_descriptions."""
     device = device_description[DD_DEVICES].get(device_enum)
     if device:
@@ -474,7 +478,7 @@ def _get_device(device_enum: Devices):
     return None
 
 
-def _get_device_group(device_enum: Devices, base_channel_no: int):
+def _get_device_group(device_enum: DeviceDescription, base_channel_no: int):
     """Return the device group."""
     device = _get_device(device_enum)
     group = {}
@@ -501,7 +505,7 @@ def _get_device_group(device_enum: Devices, base_channel_no: int):
     return group
 
 
-def _get_device_entities(device_enum: Devices, base_channel_no: int):
+def _get_device_entities(device_enum: DeviceDescription, base_channel_no: int):
     """Return the device entities."""
     additional_entities = (
         device_description[DD_DEVICES]

--- a/hahomematic/devices/device_description.py
+++ b/hahomematic/devices/device_description.py
@@ -380,7 +380,7 @@ def make_custom_entity(
     address,
     custom_entity_class,
     device_enum: DeviceDescription,
-    group_base_channels: [int],
+    group_base_channels: list[int],
 ):
     """
     Creates custom_entities.
@@ -462,7 +462,7 @@ def get_default_entities():
     return copy(device_description[DD_DEFAULT_ENTITIES])
 
 
-def get_include_default_entities(device_enum: DeviceDescription) -> True:
+def get_include_default_entities(device_enum: DeviceDescription) -> bool:
     """Return if default entities should be included."""
     device = _get_device(device_enum)
     if device:

--- a/hahomematic/devices/light.py
+++ b/hahomematic/devices/light.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 import logging
 from typing import Any
 
-from hahomematic.const import HA_PLATFORM_LIGHT
+from hahomematic.const import HmPlatform
 from hahomematic.devices.device_description import (
     FIELD_CHANNEL_COLOR,
     FIELD_CHANNEL_LEVEL,
@@ -13,7 +13,7 @@ from hahomematic.devices.device_description import (
     FIELD_COLOR,
     FIELD_LEVEL,
     FIELD_STATE,
-    Devices,
+    DeviceDescription,
     make_custom_entity,
 )
 from hahomematic.entity import CustomEntity
@@ -52,7 +52,7 @@ class BaseHmLight(CustomEntity):
             device_enum=device_enum,
             device_desc=device_desc,
             entity_desc=entity_desc,
-            platform=HA_PLATFORM_LIGHT,
+            platform=HmPlatform.LIGHT,
             channel_no=channel_no,
         )
         _LOGGER.debug(
@@ -302,28 +302,28 @@ def _convert_color(color: tuple) -> str:
 def make_ip_dimmer(device, address, group_base_channels: [int]):
     """Creates homematic ip dimmer entities."""
     return make_custom_entity(
-        device, address, HmDimmer, Devices.IP_DIMMER, group_base_channels
+        device, address, HmDimmer, DeviceDescription.IP_DIMMER, group_base_channels
     )
 
 
 def make_rf_dimmer(device, address, group_base_channels: [int]):
     """Creates homematic classic dimmer entities."""
     return make_custom_entity(
-        device, address, HmDimmer, Devices.RF_DIMMER, group_base_channels
+        device, address, HmDimmer, DeviceDescription.RF_DIMMER, group_base_channels
     )
 
 
 def make_ip_light(device, address, group_base_channels: [int]):
     """Creates homematic classic light entities."""
     return make_custom_entity(
-        device, address, HmLight, Devices.IP_LIGHT_SWITCH, group_base_channels
+        device, address, HmLight, DeviceDescription.IP_LIGHT_SWITCH, group_base_channels
     )
 
 
 def make_ip_light_bsl(device, address, group_base_channels: [int]):
     """Creates HmIP-BSL entities."""
     return make_custom_entity(
-        device, address, IPLightBSL, Devices.IP_LIGHT_BSL, group_base_channels
+        device, address, IPLightBSL, DeviceDescription.IP_LIGHT_BSL, group_base_channels
     )
 
 

--- a/hahomematic/devices/light.py
+++ b/hahomematic/devices/light.py
@@ -69,7 +69,7 @@ class BaseHmLight(CustomEntity):
         ...
 
     @property
-    def brightness(self) -> int:
+    def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
         return None
 
@@ -299,28 +299,28 @@ def _convert_color(color: tuple) -> str:
     return bsl_color
 
 
-def make_ip_dimmer(device, address, group_base_channels: [int]):
+def make_ip_dimmer(device, address, group_base_channels: list[int]):
     """Creates homematic ip dimmer entities."""
     return make_custom_entity(
         device, address, HmDimmer, DeviceDescription.IP_DIMMER, group_base_channels
     )
 
 
-def make_rf_dimmer(device, address, group_base_channels: [int]):
+def make_rf_dimmer(device, address, group_base_channels: list[int]):
     """Creates homematic classic dimmer entities."""
     return make_custom_entity(
         device, address, HmDimmer, DeviceDescription.RF_DIMMER, group_base_channels
     )
 
 
-def make_ip_light(device, address, group_base_channels: [int]):
+def make_ip_light(device, address, group_base_channels: list[int]):
     """Creates homematic classic light entities."""
     return make_custom_entity(
         device, address, HmLight, DeviceDescription.IP_LIGHT_SWITCH, group_base_channels
     )
 
 
-def make_ip_light_bsl(device, address, group_base_channels: [int]):
+def make_ip_light_bsl(device, address, group_base_channels: list[int]):
     """Creates HmIP-BSL entities."""
     return make_custom_entity(
         device, address, IPLightBSL, DeviceDescription.IP_LIGHT_BSL, group_base_channels
@@ -329,7 +329,7 @@ def make_ip_light_bsl(device, address, group_base_channels: [int]):
 
 # Case for device model is not relevant
 # device_type and sub_type(IP-only) can be used here
-DEVICES = {
+DEVICES: dict[str, tuple[Any, list[int]]] = {
     "HmIP-BSL": (make_ip_light_bsl, [7, 11]),
     "HmIP-BSM": (make_ip_light, [3]),
     "HmIP-BDT": (make_ip_dimmer, [3]),

--- a/hahomematic/devices/lock.py
+++ b/hahomematic/devices/lock.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from hahomematic.const import HA_PLATFORM_LOCK
+from hahomematic.const import HmPlatform
 from hahomematic.devices.device_description import (
     FIELD_LOCK_STATE,
     FIELD_LOCK_TARGET_LEVEL,
     FIELD_OPEN,
     FIELD_STATE,
-    Devices,
+    DeviceDescription,
     make_custom_entity,
 )
 from hahomematic.entity import CustomEntity
@@ -43,7 +43,7 @@ class IpLock(CustomEntity):
             device_enum=device_enum,
             device_desc=device_desc,
             entity_desc=entity_desc,
-            platform=HA_PLATFORM_LOCK,
+            platform=HmPlatform.LOCK,
             channel_no=channel_no,
         )
         _LOGGER.debug(
@@ -96,7 +96,7 @@ class RfLock(CustomEntity):
             device_enum=device_enum,
             device_desc=device_desc,
             entity_desc=entity_desc,
-            platform=HA_PLATFORM_LOCK,
+            platform=HmPlatform.LOCK,
             channel_no=channel_no,
         )
         _LOGGER.debug(
@@ -132,14 +132,14 @@ class RfLock(CustomEntity):
 def make_ip_lock(device, address, group_base_channels: [int]):
     """Creates homematic ip lock entities."""
     return make_custom_entity(
-        device, address, IpLock, Devices.IP_LOCK, group_base_channels
+        device, address, IpLock, DeviceDescription.IP_LOCK, group_base_channels
     )
 
 
 def make_rf_lock(device, address, group_base_channels: [int]):
     """Creates homematic rf lock entities."""
     return make_custom_entity(
-        device, address, RfLock, Devices.RF_LOCK, group_base_channels
+        device, address, RfLock, DeviceDescription.RF_LOCK, group_base_channels
     )
 
 

--- a/hahomematic/devices/lock.py
+++ b/hahomematic/devices/lock.py
@@ -129,14 +129,14 @@ class RfLock(CustomEntity):
         await self._send_value(FIELD_OPEN, True)
 
 
-def make_ip_lock(device, address, group_base_channels: [int]):
+def make_ip_lock(device, address, group_base_channels: list[int]):
     """Creates homematic ip lock entities."""
     return make_custom_entity(
         device, address, IpLock, DeviceDescription.IP_LOCK, group_base_channels
     )
 
 
-def make_rf_lock(device, address, group_base_channels: [int]):
+def make_rf_lock(device, address, group_base_channels: list[int]):
     """Creates homematic rf lock entities."""
     return make_custom_entity(
         device, address, RfLock, DeviceDescription.RF_LOCK, group_base_channels
@@ -145,7 +145,7 @@ def make_rf_lock(device, address, group_base_channels: [int]):
 
 # Case for device model is not relevant
 # device_type and sub_type(IP-only) can be used here
-DEVICES = {
+DEVICES: dict[str, tuple[Any, list[int]]] = {
     "HmIP-DLD": (make_ip_lock, []),
     "HM-Sec-Key*": (make_rf_lock, []),
 }

--- a/hahomematic/devices/switch.py
+++ b/hahomematic/devices/switch.py
@@ -84,7 +84,7 @@ class HmSwitch(CustomEntity):
         return state_attr
 
 
-def make_ip_switch(device, address, group_base_channels: [int]):
+def make_ip_switch(device, address, group_base_channels: list[int]):
     """Creates homematic ip switch entities."""
     return make_custom_entity(
         device,
@@ -97,7 +97,7 @@ def make_ip_switch(device, address, group_base_channels: [int]):
 
 # Case for device model is not relevant
 # device_type and sub_type(IP-only) can be used here
-DEVICES = {
+DEVICES: dict[str, tuple[Any, list[int]]] = {
     "HmIP-FSM*": (make_ip_switch, [1]),
     "HmIP-FSI*": (make_ip_switch, [2]),
     "HmIP-PS*": (make_ip_switch, [2]),

--- a/hahomematic/devices/switch.py
+++ b/hahomematic/devices/switch.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from hahomematic.const import HA_PLATFORM_SWITCH
+from hahomematic.const import HmPlatform
 from hahomematic.devices.device_description import (
     FIELD_CHANNEL_STATE,
     FIELD_STATE,
-    Devices,
+    DeviceDescription,
     make_custom_entity,
 )
 from hahomematic.entity import CustomEntity
@@ -38,7 +38,7 @@ class HmSwitch(CustomEntity):
             device_enum=device_enum,
             device_desc=device_desc,
             entity_desc=entity_desc,
-            platform=HA_PLATFORM_SWITCH,
+            platform=HmPlatform.SWITCH,
             channel_no=channel_no,
         )
         _LOGGER.debug(
@@ -87,7 +87,11 @@ class HmSwitch(CustomEntity):
 def make_ip_switch(device, address, group_base_channels: [int]):
     """Creates homematic ip switch entities."""
     return make_custom_entity(
-        device, address, HmSwitch, Devices.IP_LIGHT_SWITCH, group_base_channels
+        device,
+        address,
+        HmSwitch,
+        DeviceDescription.IP_LIGHT_SWITCH,
+        group_base_channels,
     )
 
 

--- a/hahomematic/entity.py
+++ b/hahomematic/entity.py
@@ -26,14 +26,10 @@ from hahomematic.const import (
     DATA_LOAD_FAIL,
     DATA_LOAD_SUCCESS,
     DATA_NO_LOAD,
-    EVENT_ALARM,
     EVENT_CONFIG_PENDING,
-    EVENT_IMPULSE,
-    EVENT_KEYPRESS,
     EVENT_UN_REACH,
     FLAG_SERVICE,
     FLAG_VISIBLE,
-    HA_PLATFORM_EVENT,
     HIDDEN_PARAMETERS,
     HM_ENTITY_UNIT_REPLACE,
     OPERATION_READ,
@@ -42,10 +38,14 @@ from hahomematic.const import (
     TYPE_FLOAT,
     TYPE_INTEGER,
     TYPE_STRING,
+    HmEventType,
+    HmPlatform,
 )
+import hahomematic.device as hm_device
 from hahomematic.devices.device_description import (
     DD_FIELDS,
     DD_FIELDS_REP,
+    DeviceDescription,
     get_default_entities,
     get_include_default_entities,
 )
@@ -113,7 +113,13 @@ class CallbackEntity(ABC):
 class BaseEntity(ABC):
     """Base class for regular entities."""
 
-    def __init__(self, device, unique_id, address, platform):
+    def __init__(
+        self,
+        device: hm_device.HmDevice,
+        unique_id: str,
+        address: str,
+        platform: HmPlatform,
+    ):
         """
         Initialize the entity.
         """
@@ -164,7 +170,15 @@ class BaseParameterEntity(BaseEntity):
     Base class for stateless entities.
     """
 
-    def __init__(self, device, unique_id, address, parameter, parameter_data, platform):
+    def __init__(
+        self,
+        device: hm_device.HmDevice,
+        unique_id: str,
+        address: str,
+        parameter: str,
+        parameter_data: dict[str, Any],
+        platform: HmPlatform,
+    ):
         """
         Initialize the entity.
         """
@@ -276,7 +290,15 @@ class GenericEntity(BaseParameterEntity, CallbackEntity):
     Base class for generic entities.
     """
 
-    def __init__(self, device, unique_id, address, parameter, parameter_data, platform):
+    def __init__(
+        self,
+        device: hm_device.HmDevice,
+        unique_id: str,
+        address: str,
+        parameter: str,
+        parameter_data: dict[str, Any],
+        platform: HmPlatform,
+    ):
         """
         Initialize the entity.
         """
@@ -388,14 +410,14 @@ class CustomEntity(BaseEntity, CallbackEntity):
 
     def __init__(
         self,
-        device,
-        unique_id,
-        address,
-        device_enum,
-        device_desc,
-        entity_desc,
-        platform,
-        channel_no=None,
+        device: hm_device.HmDevice,
+        unique_id: str,
+        address: str,
+        device_enum: DeviceDescription,
+        device_desc: dict[str, Any],
+        entity_desc: dict[str, Any],
+        platform: HmPlatform,
+        channel_no: int | None = None,
     ):
         """
         Initialize the entity.
@@ -513,13 +535,12 @@ class BaseEvent(BaseParameterEntity):
 
     def __init__(
         self,
-        device,
-        unique_id,
-        address,
-        parameter,
-        parameter_data,
-        event_type,
-        platform,
+        device: hm_device.HmDevice,
+        unique_id: str,
+        address: str,
+        parameter: str,
+        parameter_data: dict[str, Any],
+        event_type: HmEventType,
     ):
         """
         Initialize the event handler.
@@ -530,7 +551,7 @@ class BaseEvent(BaseParameterEntity):
             address=address,
             parameter=parameter,
             parameter_data=parameter_data,
-            platform=platform,
+            platform=HmPlatform.EVENT,
         )
 
         self.name = get_entity_name(
@@ -632,7 +653,14 @@ class AlarmEvent(BaseEvent):
     class for handling alarm events.
     """
 
-    def __init__(self, device, unique_id, address, parameter, parameter_data):
+    def __init__(
+        self,
+        device: hm_device.HmDevice,
+        unique_id: str,
+        address: str,
+        parameter: str,
+        parameter_data: dict[str, Any],
+    ):
         """
         Initialize the event handler.
         """
@@ -642,8 +670,7 @@ class AlarmEvent(BaseEvent):
             address=address,
             parameter=parameter,
             parameter_data=parameter_data,
-            event_type=EVENT_ALARM,
-            platform=HA_PLATFORM_EVENT,
+            event_type=HmEventType.ALARM,
         )
 
     def get_event_data(self, value=None):
@@ -678,7 +705,14 @@ class ClickEvent(BaseEvent):
     class for handling click events.
     """
 
-    def __init__(self, device, unique_id, address, parameter, parameter_data):
+    def __init__(
+        self,
+        device: hm_device.HmDevice,
+        unique_id: str,
+        address: str,
+        parameter: str,
+        parameter_data: dict[str, Any],
+    ):
         """
         Initialize the event handler.
         """
@@ -688,8 +722,7 @@ class ClickEvent(BaseEvent):
             address=address,
             parameter=parameter,
             parameter_data=parameter_data,
-            event_type=EVENT_KEYPRESS,
-            platform=HA_PLATFORM_EVENT,
+            event_type=HmEventType.KEYPRESS,
         )
 
     def get_event_data(self, value=None):
@@ -718,7 +751,14 @@ class ImpulseEvent(BaseEvent):
     class for handling impulse events.
     """
 
-    def __init__(self, device, unique_id, address, parameter, parameter_data):
+    def __init__(
+        self,
+        device: hm_device.HmDevice,
+        unique_id: str,
+        address: str,
+        parameter: str,
+        parameter_data: dict[str, Any],
+    ):
         """
         Initialize the event handler.
         """
@@ -728,8 +768,7 @@ class ImpulseEvent(BaseEvent):
             address=address,
             parameter=parameter,
             parameter_data=parameter_data,
-            event_type=EVENT_IMPULSE,
-            platform=HA_PLATFORM_EVENT,
+            event_type=HmEventType.IMPULSE,
         )
 
     def get_event_data(self, value=None):

--- a/hahomematic/hub.py
+++ b/hahomematic/hub.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from abc import ABC
-import datetime
+from datetime import datetime
 import logging
 from typing import Any
 
-from hahomematic.const import HA_DOMAIN
+from hahomematic.const import HA_DOMAIN, INIT_DATETIME
 from hahomematic.helpers import generate_unique_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ class BaseHubEntity(ABC):
         self.unique_id = unique_id
         self.name = name
         self._state = state
-        self.last_update = None
+        self.last_update: datetime = INIT_DATETIME
         self._update_callbacks = []
         self._remove_callbacks = []
         self.create_in_ha = True
@@ -109,7 +109,7 @@ class BaseHubEntity(ABC):
             _callback(self.unique_id)
 
     def _set_last_update(self) -> None:
-        self.last_update = datetime.datetime.now()
+        self.last_update = datetime.now()
 
 
 class HmSystemVariable(BaseHubEntity):
@@ -160,7 +160,7 @@ class HmHub(BaseHubEntity):
         self._use_entities = use_entities
 
     @property
-    def device_info(self) -> dict[str, str]:
+    def device_info(self) -> dict[str, Any]:
         """Return device specific attributes."""
         return {
             "config_entry_id": self._central.entry_id,
@@ -250,7 +250,7 @@ class HmDummyHub(BaseHubEntity):
         self._use_entities = use_entities
 
     @property
-    def device_info(self) -> dict[str, str]:
+    def device_info(self) -> dict[str, Any]:
         """Return device specific attributes."""
         return {
             "config_entry_id": self._central.entry_id,

--- a/hahomematic/hub.py
+++ b/hahomematic/hub.py
@@ -189,8 +189,8 @@ class HmHub(BaseHubEntity):
 
     async def _update_hub_state(self):
         """Retrieve latest state."""
-        service_message = await self._central.get_service_messages()
-        state = 0 if service_message is None else len(service_message)
+        service_messages = await self._central.get_service_messages()
+        state = 0 if service_messages is None else len(service_messages)
 
         if self._state != state:
             self._state = state

--- a/hahomematic/internal/action.py
+++ b/hahomematic/internal/action.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from hahomematic.const import DATA_LOAD_SUCCESS, HA_PLATFORM_ACTION
+from hahomematic.const import DATA_LOAD_SUCCESS, HmPlatform
 from hahomematic.entity import GenericEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ class HmAction(GenericEntity):
             address=address,
             parameter=parameter,
             parameter_data=parameter_data,
-            platform=HA_PLATFORM_ACTION,
+            platform=HmPlatform.ACTION,
         )
 
     @property

--- a/hahomematic/internal/text.py
+++ b/hahomematic/internal/text.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from hahomematic.const import ATTR_HM_VALUE, HA_PLATFORM_TEXT
+from hahomematic.const import ATTR_HM_VALUE, HmPlatform
 from hahomematic.entity import GenericEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ class HmText(GenericEntity):
             address=address,
             parameter=parameter,
             parameter_data=parameter_data,
-            platform=HA_PLATFORM_TEXT,
+            platform=HmPlatform.TEXT,
         )
 
     @property

--- a/hahomematic/json_rpc_client.py
+++ b/hahomematic/json_rpc_client.py
@@ -61,7 +61,7 @@ class JsonRpcAioHttpClient:
         self._session_id = await self._renew_login(self._session_id)
         return self._session_id is not None
 
-    async def _renew_login(self, session_id) -> str:
+    async def _renew_login(self, session_id) -> str | None:
         """Renew JSON-RPC session or perform login."""
         try:
             response = await self._post(
@@ -78,9 +78,9 @@ class JsonRpcAioHttpClient:
             )
             return None
 
-    async def _login(self) -> str:
+    async def _login(self) -> str | None:
         """Login to CCU and return session."""
-        session_id = False
+        session_id = None
         try:
             params = {
                 ATTR_USERNAME: self._username,

--- a/hahomematic/platforms/binary_sensor.py
+++ b/hahomematic/platforms/binary_sensor.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 
-from hahomematic.const import HA_PLATFORM_BINARY_SENSOR
+from hahomematic.const import HmPlatform
 from hahomematic.entity import GenericEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class HmBinarySensor(GenericEntity):
             address=address,
             parameter=parameter,
             parameter_data=parameter_data,
-            platform=HA_PLATFORM_BINARY_SENSOR,
+            platform=HmPlatform.BINARY_SENSOR,
         )
 
     @property

--- a/hahomematic/platforms/button.py
+++ b/hahomematic/platforms/button.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 
-from hahomematic.const import HA_PLATFORM_BUTTON
+from hahomematic.const import HmPlatform
 from hahomematic.entity import BaseParameterEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class HmButton(BaseParameterEntity):
             address=address,
             parameter=parameter,
             parameter_data=parameter_data,
-            platform=HA_PLATFORM_BUTTON,
+            platform=HmPlatform.BUTTON,
         )
 
     async def press(self) -> None:

--- a/hahomematic/platforms/number.py
+++ b/hahomematic/platforms/number.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 
-from hahomematic.const import ATTR_HM_VALUE, HA_PLATFORM_NUMBER
+from hahomematic.const import ATTR_HM_VALUE, HmPlatform
 from hahomematic.entity import GenericEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class HmNumber(GenericEntity):
             address=address,
             parameter=parameter,
             parameter_data=parameter_data,
-            platform=HA_PLATFORM_NUMBER,
+            platform=HmPlatform.NUMBER,
         )
 
     @property

--- a/hahomematic/platforms/select.py
+++ b/hahomematic/platforms/select.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 
-from hahomematic.const import HA_PLATFORM_SELECT
+from hahomematic.const import HmPlatform
 from hahomematic.entity import GenericEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class HmSelect(GenericEntity):
             address=address,
             parameter=parameter,
             parameter_data=parameter_data,
-            platform=HA_PLATFORM_SELECT,
+            platform=HmPlatform.SELECT,
         )
 
     @property

--- a/hahomematic/platforms/sensor.py
+++ b/hahomematic/platforms/sensor.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 
-from hahomematic.const import HA_PLATFORM_SENSOR
+from hahomematic.const import HmPlatform
 from hahomematic.entity import GenericEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class HmSensor(GenericEntity):
             address=address,
             parameter=parameter,
             parameter_data=parameter_data,
-            platform=HA_PLATFORM_SENSOR,
+            platform=HmPlatform.SENSOR,
         )
 
     @property

--- a/hahomematic/platforms/switch.py
+++ b/hahomematic/platforms/switch.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 
-from hahomematic.const import HA_PLATFORM_SWITCH, TYPE_ACTION
+from hahomematic.const import TYPE_ACTION, HmPlatform
 from hahomematic.entity import GenericEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class HmSwitch(GenericEntity):
             address=address,
             parameter=parameter,
             parameter_data=parameter_data,
-            platform=HA_PLATFORM_SWITCH,
+            platform=HmPlatform.SWITCH,
         )
 
     @property

--- a/hahomematic/xml_rpc_server.py
+++ b/hahomematic/xml_rpc_server.py
@@ -181,8 +181,7 @@ class RPCFunctions:
                     del central.devices_raw_dict[interface_id][address]
                     del central.paramsets_cache[interface_id][address]
                     del central.names_cache[interface_id][address]
-                    ha_device = central.hm_devices.get(address)
-                    if ha_device:
+                    if ha_device := central.hm_devices.get(address):
                         ha_device.remove_event_subscriptions()
                         del central.hm_devices[address]
                 except KeyError:
@@ -317,8 +316,7 @@ class XMLRPCServer(threading.Thread):
     def get_central(self, interface_id) -> hm_central.CentralUnit:
         """Return a central by interface_id"""
         for central in self._centrals.values():
-            client = central.clients.get(interface_id)
-            if client:
+            if client := central.clients.get(interface_id):
                 return central
 
     @property
@@ -341,8 +339,7 @@ def _set_xml_rpc_server(xml_rpc_server: XMLRPCServer) -> None:
 
 def register_xml_rpc_server(local_ip=IP_ANY_V4, local_port=PORT_ANY) -> XMLRPCServer:
     """Register the xml rpc server."""
-    xml_rpc = get_xml_rpc_server()
-    if not xml_rpc:
+    if (xml_rpc := get_xml_rpc_server()) is None:
         xml_rpc = XMLRPCServer(local_ip, local_port)
         xml_rpc.start()
         _set_xml_rpc_server(xml_rpc)

--- a/hahomematic/xml_rpc_server.py
+++ b/hahomematic/xml_rpc_server.py
@@ -28,7 +28,7 @@ from hahomematic.device import create_devices
 
 _LOGGER = logging.getLogger(__name__)
 
-_XML_RPC_SERVER: XMLRPCServer = None
+_XML_RPC_SERVER: XMLRPCServer | None = None
 
 
 # pylint: disable=invalid-name
@@ -313,11 +313,12 @@ class XMLRPCServer(threading.Thread):
         if self._centrals.get(central.instance_name):
             del self._centrals[central.instance_name]
 
-    def get_central(self, interface_id) -> hm_central.CentralUnit:
+    def get_central(self, interface_id) -> hm_central.CentralUnit | None:
         """Return a central by interface_id"""
         for central in self._centrals.values():
-            if client := central.clients.get(interface_id):
+            if central.clients.get(interface_id):
                 return central
+        return None
 
     @property
     def no_central_registered(self) -> bool:
@@ -325,12 +326,12 @@ class XMLRPCServer(threading.Thread):
         return len(self._centrals) == 0
 
 
-def get_xml_rpc_server() -> XMLRPCServer:
+def get_xml_rpc_server() -> XMLRPCServer | None:
     """Return the XMLRPCServer."""
     return _XML_RPC_SERVER
 
 
-def _set_xml_rpc_server(xml_rpc_server: XMLRPCServer) -> None:
+def _set_xml_rpc_server(xml_rpc_server: XMLRPCServer | None) -> None:
     """Add a XMLRPCServer."""
     # pylint: disable=global-statement
     global _XML_RPC_SERVER
@@ -350,7 +351,7 @@ async def un_register_xml_rpc_server() -> bool:
     """Unregister the xml rpc server."""
     xml_rpc = get_xml_rpc_server()
     _LOGGER.info("XMLRPCServer.stop: Shutting down server")
-    if xml_rpc.no_central_registered:
+    if xml_rpc and xml_rpc.no_central_registered:
         await xml_rpc.stop()
         _set_xml_rpc_server(None)
         _LOGGER.info("XMLRPCServer.stop: Server stopped")

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def readme():
 
 PACKAGE_NAME = "hahomematic"
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = "0.0.16"
+VERSION = "0.0.17"
 
 PACKAGES = find_packages(exclude=["tests", "tests.*", "dist", "build"])
 


### PR DESCRIPTION
- Remove variables that are covered by other sensors (CCU only)
- Remove dummy from service message (HmIP-RF always sends 0001D3C98DD4B6:3 unreach)
- Rename Bidcos thermostats to SimpleRfThermostat and RfThermostat
- Use more Enums (like HA does): HmPlatform, HmEventType
- Use assignment expressions
- Add more type hints (fix most mypy errors)