### PR TITLE
Add additional temperature sensor to IP thermostats

### DIFF
--- a/hahomematic/devices/entity_definition.py
+++ b/hahomematic/devices/entity_definition.py
@@ -256,6 +256,7 @@ entity_definition: dict[str, dict[int | EntityDefinition, Any]] = {
                     FIELD_ACTIVE_PROFILE: "ACTIVE_PROFILE",
                     FIELD_HUMIDITY: "HUMIDITY",
                     FIELD_LEVEL: "LEVEL",
+                    FIELD_TEMPERATURE: "ACTUAL_TEMPERATURE"
                 },
                 9: {
                     FIELD_STATE: "STATE",


### PR DESCRIPTION
This allows e.g. the new 'area' card to show the temperatue, since it
can't read the climate values, and offers less need for fiddling with
template sensors.

Tested locally, seems to work good enough.