### PR TITLE
Update color_conversion threshold

### DIFF
--- a/hahomematic/custom_platforms/light.py
+++ b/hahomematic/custom_platforms/light.py
@@ -456,7 +456,7 @@ def _convert_color(color: tuple[float, float] | None) -> str:
         bsl_color = "WHITE"
     elif 30 < hue <= 90:
         bsl_color = "YELLOW"
-    elif 90 < hue <= 160:
+    elif 90 < hue <= 150:
         bsl_color = "GREEN"
     elif 150 < hue <= 210:
         bsl_color = "TURQUOISE"


### PR DESCRIPTION
The range for "green" was `90 < hue < 160`, whereas the next color (turquoise) is `150 < hue < 210` which looks like a typo. All (other) intervals are `base_color +/- 30` but in the case of green, the max value was "+40" which feels wrong. Also the old pyhomematic integration had `90 < hue < 150` for green.