### PR TITLE
add hdm cover activity values

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Version 2024.2.2 (2024-02-10)
 
 - Add option to un ignore mechanism to ignore the automatic creation of custom entities by device type
+- Add hdm cover activity by @sander76
 
 # Version 2024.2.1 (2024-02-02)
 

--- a/hahomematic/platforms/custom/cover.py
+++ b/hahomematic/platforms/custom/cover.py
@@ -49,6 +49,13 @@ class CoverActivity(StrEnum):
     OPENING = "UP"
 
 
+class HdmCoverActivity(IntEnum):
+    """Enum with Hdm specific cover activities."""
+
+    CLOSING = 2
+    OPENING = 1
+
+
 class CoverPosition(IntEnum):
     """Enum with cover positions."""
 
@@ -145,14 +152,20 @@ class CeCover(CustomEntity):
     def is_opening(self) -> bool | None:
         """Return if the cover is opening."""
         if self._e_direction.value is not None:
-            return str(self._e_direction.value) == CoverActivity.OPENING
+            return (
+                str(self._e_direction.value) == CoverActivity.OPENING
+                or self._e_direction.value == HdmCoverActivity.OPENING
+            )
         return None
 
     @value_property
     def is_closing(self) -> bool | None:
         """Return if the cover is closing."""
         if self._e_direction.value is not None:
-            return str(self._e_direction.value) == CoverActivity.CLOSING
+            return (
+                str(self._e_direction.value) == CoverActivity.CLOSING
+                or self._e_direction.value == HdmCoverActivity.CLOSING
+            )
         return None
 
     @bind_collector


### PR DESCRIPTION
hdm based blinds (basically all "ease" blinds https://homematic-ip.com/en/product/ease-powered-homematic-ip) seem to report different `ACTIVITY_STATE` values compared to other HMIP blinds. Instead of using "OPENING" and "CLOSING" it uses 1 and 2 integers as displayed in my screenshots below.

opening:
![opening](https://github.com/danielperna84/hahomematic/assets/1688712/4621e6dd-f49c-464a-92a8-02470c16ac3b)

closing:
![closing](https://github.com/danielperna84/hahomematic/assets/1688712/84010c1f-f2c9-455c-a56c-eb19ef2fc347)

See my suggested changes. Happy to change if needed.
Also, is there a way to test this locally ? (I have ease blinds available.)

Sander.