### PR TITLE
replace special character replacement by simple UriEncode() method

### DIFF
--- a/hahomematic/rega_scripts/get_program_descriptions.fn
+++ b/hahomematic/rega_scripts/get_program_descriptions.fn
@@ -4,23 +4,16 @@
 !#
 
 string id;
-string sDeadList = ^"	\^;
-string sDeadSign;
 boolean dpFirst = true;
 Write("[");
 foreach(id, dom.GetObject(ID_PROGRAMS).EnumIDs()) {
   object prg = dom.GetObject(id);
     string description = "";
     if (prg) {
-      string sPrg_Desc = prg.PrgInfo();
-      if (sPrg_Desc) {
-        description = sPrg_Desc.Replace("	", " ");
-        foreach(sDeadSign, sDeadList) {
-          if (sPrg_Desc.Contains(sDeadSign)) {
-            description = "ignored because of problematic character(s)";
-          }
-        }
-      }
+      ! use UriEncode() to ensure special characters " and \
+      ! and others are properly encoded using URI/URL percentage
+      ! encoding
+      description = prg.PrgInfo().UriEncode();
 
       if (dpFirst) {
         dpFirst = false;

--- a/hahomematic/rega_scripts/get_system_variable_descriptions.fn
+++ b/hahomematic/rega_scripts/get_system_variable_descriptions.fn
@@ -4,23 +4,16 @@
 !#
 
 string id;
-string sDeadList = ^"	\^;
-string sDeadSign;
 boolean dpFirst = true;
 Write("[");
 foreach(id, dom.GetObject(ID_SYSTEM_VARIABLES).EnumIDs()) {
     object sv = dom.GetObject(id);
     string description = "";
     if (sv) {
-      string sSV_Desc = sv.DPInfo();
-      if (sSV_Desc) {
-        description = sSV_Desc.Replace("	", " ");
-        foreach(sDeadSign, sDeadList) {
-          if (sSV_Desc.Contains(sDeadSign)) {
-            description = "ignored because of problematic character(s)";
-          }
-        }
-      }
+      ! use UriEncode() to ensure special characters " and \
+      ! and others are properly encoded using URI/URL percentage
+      ! encoding
+      description = sv.DPInfo().UriEncode();
 
       if (dpFirst) {
         dpFirst = false;


### PR DESCRIPTION
This PR replaces the special character replacement by simple `UriEncode()` method, thus uses it to encode special characters using standard %XX URI/URL encoding so that the used JSON structure will always be valid. Pleas note that this still requires proper string decoding in the respective python code using something like urllib.pars.unquote() (cf.
https://docs.python.org/3/library/urllib.parse.html#urllib.parse.unquote). This refs https://github.com/danielperna84/hahomematic/discussions/1906.