### PR TITLE
Add option to cover entities that the current default behaviour can be disabled

### DIFF
--- a/aiohomematic/central/__init__.py
+++ b/aiohomematic/central/__init__.py
@@ -105,6 +105,7 @@ from aiohomematic.const import (
     DEFAULT_SYSVAR_MARKERS,
     DEFAULT_TLS,
     DEFAULT_UN_IGNORES,
+    DEFAULT_USE_RAW_DEVICES,
     DEFAULT_VERIFY_TLS,
     DEVICE_FIRMWARE_CHECK_INTERVAL,
     DEVICE_FIRMWARE_DELIVERING_CHECK_INTERVAL,
@@ -1854,6 +1855,7 @@ class CentralConfig:
         sysvar_markers: tuple[DescriptionMarker | str, ...] = DEFAULT_SYSVAR_MARKERS,
         tls: bool = DEFAULT_TLS,
         un_ignore_list: frozenset[str] = DEFAULT_UN_IGNORES,
+        use_raw_devices: bool = DEFAULT_USE_RAW_DEVICES,
         verify_tls: bool = DEFAULT_VERIFY_TLS,
     ) -> None:
         """Init the client config."""
@@ -1884,6 +1886,7 @@ class CentralConfig:
         self.sysvar_markers: Final = sysvar_markers
         self.tls: Final = tls
         self.un_ignore_list: Final = un_ignore_list
+        self.use_raw_devices: Final = use_raw_devices
         self.username: Final = username
         self.verify_tls: Final = verify_tls
 

--- a/aiohomematic/central/__init__.py
+++ b/aiohomematic/central/__init__.py
@@ -105,7 +105,7 @@ from aiohomematic.const import (
     DEFAULT_SYSVAR_MARKERS,
     DEFAULT_TLS,
     DEFAULT_UN_IGNORES,
-    DEFAULT_USE_RAW_DEVICES,
+    DEFAULT_USE_GROUP_CHANNEL_FOR_COVER_STATE,
     DEFAULT_VERIFY_TLS,
     DEVICE_FIRMWARE_CHECK_INTERVAL,
     DEVICE_FIRMWARE_DELIVERING_CHECK_INTERVAL,
@@ -1855,7 +1855,7 @@ class CentralConfig:
         sysvar_markers: tuple[DescriptionMarker | str, ...] = DEFAULT_SYSVAR_MARKERS,
         tls: bool = DEFAULT_TLS,
         un_ignore_list: frozenset[str] = DEFAULT_UN_IGNORES,
-        use_raw_devices: bool = DEFAULT_USE_RAW_DEVICES,
+        use_group_channel_for_cover_state: bool = DEFAULT_USE_GROUP_CHANNEL_FOR_COVER_STATE,
         verify_tls: bool = DEFAULT_VERIFY_TLS,
     ) -> None:
         """Init the client config."""
@@ -1886,7 +1886,7 @@ class CentralConfig:
         self.sysvar_markers: Final = sysvar_markers
         self.tls: Final = tls
         self.un_ignore_list: Final = un_ignore_list
-        self.use_raw_devices: Final = use_raw_devices
+        self.use_group_channel_for_cover_state: Final = use_group_channel_for_cover_state
         self.username: Final = username
         self.verify_tls: Final = verify_tls
 

--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -45,6 +45,7 @@ DEFAULT_SYSVAR_MARKERS: Final[tuple[DescriptionMarker | str, ...]] = ()
 DEFAULT_SYS_SCAN_INTERVAL: Final = 30
 DEFAULT_TLS: Final = False
 DEFAULT_UN_IGNORES: Final[frozenset[str]] = frozenset()
+DEFAULT_USE_RAW_DEVICES: Final = False
 DEFAULT_VERIFY_TLS: Final = False
 
 # Default encoding for json service calls, persistent cache

--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -45,7 +45,7 @@ DEFAULT_SYSVAR_MARKERS: Final[tuple[DescriptionMarker | str, ...]] = ()
 DEFAULT_SYS_SCAN_INTERVAL: Final = 30
 DEFAULT_TLS: Final = False
 DEFAULT_UN_IGNORES: Final[frozenset[str]] = frozenset()
-DEFAULT_USE_RAW_DEVICES: Final = False
+DEFAULT_USE_GROUP_CHANNEL_FOR_COVER_STATE: Final = True
 DEFAULT_VERIFY_TLS: Final = False
 
 # Default encoding for json service calls, persistent cache

--- a/aiohomematic/model/custom/cover.py
+++ b/aiohomematic/model/custom/cover.py
@@ -100,6 +100,7 @@ class CustomDpCover(CustomDataPoint):
         "_dp_group_level",
         "_dp_level",
         "_dp_stop",
+        "_use_group_channel_for_cover_state",
     )
     _category = DataPointCategory.COVER
     _closed_level: float = _CLOSED_LEVEL
@@ -118,11 +119,16 @@ class CustomDpCover(CustomDataPoint):
         self._dp_group_level: DpSensor[float | None] = self._get_data_point(
             field=Field.GROUP_LEVEL, data_point_type=DpSensor[float | None]
         )
+        self._use_group_channel_for_cover_state = self.central.config.use_group_channel_for_cover_state
 
     @property
     def _group_level(self) -> float:
         """Return the channel level of the cover."""
-        if self._dp_group_level.value is not None and self.usage == DataPointUsage.CDP_PRIMARY:
+        if (
+            self._dp_group_level.value is not None
+            and self.usage == DataPointUsage.CDP_PRIMARY
+            and self._use_group_channel_for_cover_state
+        ):
             return float(self._dp_group_level.value)
         return self._dp_level.value if self._dp_level.value is not None else self._closed_level
 
@@ -276,7 +282,11 @@ class CustomDpBlind(CustomDpCover):
     @property
     def _group_tilt_level(self) -> float:
         """Return the group level of the tilt."""
-        if self._dp_group_level_2.value is not None and self.usage == DataPointUsage.CDP_PRIMARY:
+        if (
+            self._dp_group_level_2.value is not None
+            and self.usage == DataPointUsage.CDP_PRIMARY
+            and self._use_group_channel_for_cover_state
+        ):
             return float(self._dp_group_level_2.value)
         return self._dp_level_2.value if self._dp_level_2.value is not None else self._closed_level
 

--- a/aiohomematic/model/custom/cover.py
+++ b/aiohomematic/model/custom/cover.py
@@ -125,9 +125,9 @@ class CustomDpCover(CustomDataPoint):
     def _group_level(self) -> float:
         """Return the channel level of the cover."""
         if (
-            self._dp_group_level.value is not None
+            self._use_group_channel_for_cover_state
+            and self._dp_group_level.value is not None
             and self.usage == DataPointUsage.CDP_PRIMARY
-            and self._use_group_channel_for_cover_state
         ):
             return float(self._dp_group_level.value)
         return self._dp_level.value if self._dp_level.value is not None else self._closed_level
@@ -283,9 +283,9 @@ class CustomDpBlind(CustomDpCover):
     def _group_tilt_level(self) -> float:
         """Return the group level of the tilt."""
         if (
-            self._dp_group_level_2.value is not None
+            self._use_group_channel_for_cover_state
+            and self._dp_group_level_2.value is not None
             and self.usage == DataPointUsage.CDP_PRIMARY
-            and self._use_group_channel_for_cover_state
         ):
             return float(self._dp_group_level_2.value)
         return self._dp_level_2.value if self._dp_level_2.value is not None else self._closed_level


### PR DESCRIPTION
- Currently the primary cover entity of a group uses the level of the state channel and not its own level to display a correct level. (recommended) 
- Only HM experts should use this option, that like to control all three writeable channels of a cover group. 

Related to #2203