### PR TITLE
Warn when device creation is interrupted

### DIFF
--- a/aiohomematic/central/coordinators/device.py
+++ b/aiohomematic/central/coordinators/device.py
@@ -373,59 +373,82 @@ class DeviceCoordinator(FirmwareDataRefresherProtocol):
             )
         _LOGGER.debug("CREATE_DEVICES: Starting to create devices for %s", self._central_info.name)
 
+        expected_device_count = sum(len(addresses) for addresses in new_device_addresses.values())
         new_devices = set[DeviceProtocol]()
 
-        for interface_id, device_addresses in new_device_addresses.items():
-            for device_address in device_addresses:
-                # Do we check for duplicates here? For now, we do.
-                if self.device_registry.has_device(address=device_address):
-                    continue
-                device: DeviceProtocol | None = None
-                try:
-                    context = DeviceContext(
-                        interface_id=interface_id,
-                        device_address=device_address,
-                        central_info=self._central_info,
-                        config_provider=self._config_provider,
-                        file_operations=self._file_operations,
-                        device_data_refresher=self,
-                        device_description_provider=self._device_description_provider,
-                        device_details_provider=self._device_details_provider,
-                        paramset_description_provider=self._paramset_description_provider,
-                        parameter_visibility_provider=self._parameter_visibility_provider,
-                        event_bus_provider=self._event_bus_provider,
-                        event_publisher=self._event_publisher,
-                        event_subscription_manager=self._event_subscription_manager,
-                        task_scheduler=self._task_scheduler,
-                        client_provider=self._client_provider,
-                        data_cache_provider=self._data_cache_provider,
-                        data_point_provider=self._data_point_provider,
-                        channel_lookup=self,
-                    )
-                    device = Device(context=context)
-                except Exception as exc:  # noqa: BLE001 - device creation must not abort bulk device processing
-                    _LOGGER.error(  # i18n-log: ignore
-                        "CREATE_DEVICES failed: %s [%s] Unable to create device: %s, %s",
-                        type(exc).__name__,
-                        extract_exc_args(exc=exc),
-                        interface_id,
-                        device_address,
-                    )
-                try:
-                    if device:
-                        create_data_points_and_events(device=device)
-                        create_custom_data_points(device=device)
-                        create_week_profile_data_point(device=device)
-                        new_devices.add(device)
-                        await self.device_registry.add_device(device=device)
-                except Exception as exc:  # noqa: BLE001 - data point creation must not abort bulk device processing
-                    _LOGGER.error(  # i18n-log: ignore
-                        "CREATE_DEVICES failed: %s [%s] Unable to create data points: %s, %s",
-                        type(exc).__name__,
-                        extract_exc_args(exc=exc),
-                        interface_id,
-                        device_address,
-                    )
+        # The per-device ``except Exception`` blocks below deliberately swallow recoverable errors
+        # so a single broken device does not abort bulk processing. They do NOT catch
+        # ``BaseException`` (e.g. ``asyncio.CancelledError`` raised when Home Assistant cancels a
+        # slow config-entry setup, or when the event loop is blocked past its timeout). Such an
+        # interruption would otherwise abandon device creation silently: already-built devices stay
+        # in the registry but are never dispatched (no ``DEVICES_CREATED`` event), leaving the
+        # integration with zero entities and no diagnostic in the log. The ``try/finally`` makes the
+        # interruption observable without altering its propagation.
+        devices_created = False
+        try:
+            for interface_id, device_addresses in new_device_addresses.items():
+                for device_address in device_addresses:
+                    # Do we check for duplicates here? For now, we do.
+                    if self.device_registry.has_device(address=device_address):
+                        continue
+                    device: DeviceProtocol | None = None
+                    try:
+                        context = DeviceContext(
+                            interface_id=interface_id,
+                            device_address=device_address,
+                            central_info=self._central_info,
+                            config_provider=self._config_provider,
+                            file_operations=self._file_operations,
+                            device_data_refresher=self,
+                            device_description_provider=self._device_description_provider,
+                            device_details_provider=self._device_details_provider,
+                            paramset_description_provider=self._paramset_description_provider,
+                            parameter_visibility_provider=self._parameter_visibility_provider,
+                            event_bus_provider=self._event_bus_provider,
+                            event_publisher=self._event_publisher,
+                            event_subscription_manager=self._event_subscription_manager,
+                            task_scheduler=self._task_scheduler,
+                            client_provider=self._client_provider,
+                            data_cache_provider=self._data_cache_provider,
+                            data_point_provider=self._data_point_provider,
+                            channel_lookup=self,
+                        )
+                        device = Device(context=context)
+                    except Exception as exc:  # noqa: BLE001 - device creation must not abort bulk device processing
+                        _LOGGER.error(  # i18n-log: ignore
+                            "CREATE_DEVICES failed: %s [%s] Unable to create device: %s, %s",
+                            type(exc).__name__,
+                            extract_exc_args(exc=exc),
+                            interface_id,
+                            device_address,
+                        )
+                    try:
+                        if device:
+                            create_data_points_and_events(device=device)
+                            create_custom_data_points(device=device)
+                            create_week_profile_data_point(device=device)
+                            new_devices.add(device)
+                            await self.device_registry.add_device(device=device)
+                    except Exception as exc:  # noqa: BLE001 - data point creation must not abort bulk device processing
+                        _LOGGER.error(  # i18n-log: ignore
+                            "CREATE_DEVICES failed: %s [%s] Unable to create data points: %s, %s",
+                            type(exc).__name__,
+                            extract_exc_args(exc=exc),
+                            interface_id,
+                            device_address,
+                        )
+            devices_created = True
+        finally:
+            if not devices_created:
+                _LOGGER.warning(  # i18n-log: ignore
+                    "CREATE_DEVICES interrupted: built %d of %d device(s) for %s before the run was "
+                    "aborted (cancelled setup or unexpected error); already-built devices were not "
+                    "dispatched and will be retried on the next connection",
+                    len(new_devices),
+                    expected_device_count,
+                    self._central_info.name,
+                )
+
         _LOGGER.debug("CREATE_DEVICES: Finished creating devices for %s", self._central_info.name)
 
         if new_devices:

--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel, ConfigDict
 
 from aiohomematic_contract import DataPointCategory, DataPointType
 
-VERSION: Final = "2026.6.0"
+VERSION: Final = "2026.6.1"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,23 @@
+# Version 2026.6.1 (2026-06-04)
+
+## What's Changed
+
+### Fixed
+
+- **Device creation could be abandoned silently when interrupted.**
+  `DeviceCoordinator.create_devices()` builds devices in a loop and only
+  dispatches them (via the `DEVICES_CREATED` system event) after the loop
+  finishes. The per-device error handling caught `Exception` but not
+  `BaseException`, so a `CancelledError` mid-loop — e.g. when Home Assistant
+  cancels a slow config-entry setup, or when the event loop is blocked past its
+  timeout — abandoned the run with **no log entry**: already-built devices
+  stayed in the registry but were never dispatched, leaving the integration
+  with zero entities and no diagnostic. The loop is now wrapped in a
+  `try/finally` that logs a clear warning (with build progress) when the run is
+  interrupted, without altering exception propagation. This makes the failure
+  observable; the underlying interruption still needs to be addressed at its
+  source (#3213).
+
 # Version 2026.6.0 (2026-06-01)
 
 ## What's Changed

--- a/tests/test_central_device_coordinator.py
+++ b/tests/test_central_device_coordinator.py
@@ -2,12 +2,14 @@
 # Copyright (c) 2021-2026
 """Tests for aiohomematic.central.device_coordinator."""
 
+import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from aiohomematic.central.coordinators import DeviceCoordinator
-from aiohomematic.const import DeviceDescription
+from aiohomematic.const import DeviceDescription, SourceOfDeviceCreation
 
 
 class _FakeChannel:
@@ -1567,3 +1569,130 @@ class TestIdentifyMissingDeviceDescriptions:
             paramset_description_provider=central.cache_coordinator.paramset_descriptions,
             task_scheduler=central.looper,
         )  # type: ignore[arg-type]
+
+
+class _BuildableDevice:
+    """Fake device returned by a patched ``Device`` constructor during create_devices tests."""
+
+    def __init__(self, *, address: str, interface_id: str) -> None:
+        """Initialize a buildable fake device."""
+        self.address = address
+        self.interface_id = interface_id
+        self.finalize_init_called = False
+
+    async def finalize_init(self) -> None:
+        """Record that finalize_init was awaited."""
+        self.finalize_init_called = True
+
+
+def _make_create_devices_coordinator() -> tuple[DeviceCoordinator, _FakeCentral]:
+    """Create a DeviceCoordinator wired with the prerequisites of ``create_devices``."""
+    central = _FakeCentral()
+    # create_devices guards on has_clients and dispatches via event_coordinator.
+    central.client_coordinator.has_clients = True  # type: ignore[attr-defined]
+    central.event_coordinator = MagicMock()  # type: ignore[attr-defined]
+
+    coordinator = DeviceCoordinator(
+        central_info=central,
+        client_provider=central,
+        config_provider=central,
+        coordinator_provider=central,
+        data_cache_provider=central.cache_coordinator.data_cache,
+        data_point_provider=central,
+        device_description_provider=central.cache_coordinator.device_descriptions,
+        device_details_provider=central.cache_coordinator.device_details,
+        event_bus_provider=central,
+        event_publisher=central,
+        event_subscription_manager=central,
+        file_operations=central,
+        parameter_visibility_provider=central.cache_coordinator.parameter_visibility,
+        paramset_description_provider=central.cache_coordinator.paramset_descriptions,
+        task_scheduler=central.looper,
+    )  # type: ignore[arg-type]
+    return coordinator, central
+
+
+class TestDeviceCoordinatorCreateDevicesInterruption:
+    """
+    Cover interruption handling of ``DeviceCoordinator.create_devices``.
+
+    Regression guard for issue #3213: when device creation is interrupted by a
+    ``CancelledError`` (e.g. Home Assistant cancelling a slow config-entry setup, or the
+    event loop being blocked past its timeout), creation must not fail silently. The
+    interruption is logged and propagates; already-built devices are not dispatched.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_devices_completes_without_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """An uninterrupted run dispatches devices and emits no interruption warning."""
+        coordinator, central = _make_create_devices_coordinator()
+
+        with (
+            patch(
+                "aiohomematic.central.coordinators.device.Device",
+                side_effect=lambda *, context: _BuildableDevice(
+                    address=context.device_address, interface_id=context.interface_id
+                ),
+            ),
+            patch("aiohomematic.central.coordinators.device.create_data_points_and_events"),
+            patch("aiohomematic.central.coordinators.device.create_custom_data_points"),
+            patch("aiohomematic.central.coordinators.device.create_week_profile_data_point"),
+            patch("aiohomematic.central.coordinators.device._get_new_data_points", return_value={}),
+            patch("aiohomematic.central.coordinators.device._get_new_event_groups", return_value=()),
+            caplog.at_level(logging.WARNING, logger="aiohomematic.central.coordinators.device"),
+        ):
+            await coordinator.create_devices(
+                new_device_addresses={"test-interface": {"VCU0000001", "VCU0000002"}},
+                source=SourceOfDeviceCreation.CACHE,
+            )
+
+        assert not any("CREATE_DEVICES interrupted" in r.getMessage() for r in caplog.records)
+        # All devices dispatched and registered.
+        central.event_coordinator.publish_system_event.assert_called_once()  # type: ignore[attr-defined]
+        assert len(central.device_registry.get_device_addresses()) == 2
+
+    @pytest.mark.asyncio
+    async def test_create_devices_logs_warning_when_cancelled_mid_loop(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A CancelledError mid-loop must surface a warning and propagate (not vanish silently)."""
+        coordinator, central = _make_create_devices_coordinator()
+
+        # add_device succeeds for the first device, then a CancelledError interrupts the run
+        # (mirrors the production log where the loop died at ``await add_device`` of device 40/88).
+        add_calls = {"count": 0}
+        real_add = central.device_registry.add_device
+
+        async def _add_device_then_cancel(*, device: object) -> None:
+            add_calls["count"] += 1
+            if add_calls["count"] == 2:
+                raise asyncio.CancelledError
+            await real_add(device=device)  # type: ignore[arg-type]
+
+        central.device_registry.add_device = _add_device_then_cancel  # type: ignore[assignment]
+
+        with (
+            patch(
+                "aiohomematic.central.coordinators.device.Device",
+                side_effect=lambda *, context: _BuildableDevice(
+                    address=context.device_address, interface_id=context.interface_id
+                ),
+            ),
+            patch("aiohomematic.central.coordinators.device.create_data_points_and_events"),
+            patch("aiohomematic.central.coordinators.device.create_custom_data_points"),
+            patch("aiohomematic.central.coordinators.device.create_week_profile_data_point"),
+            caplog.at_level(logging.WARNING, logger="aiohomematic.central.coordinators.device"),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await coordinator.create_devices(
+                new_device_addresses={"test-interface": {"VCU0000001", "VCU0000002", "VCU0000003"}},
+                source=SourceOfDeviceCreation.CACHE,
+            )
+
+        # The interruption is observable instead of silent.
+        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("CREATE_DEVICES interrupted" in msg and "of 3" in msg for msg in warnings), warnings
+
+        # Already-built devices were NOT dispatched to consumers (no DEVICES_CREATED event).
+        central.event_coordinator.publish_system_event.assert_not_called()  # type: ignore[attr-defined]
+
+        # Exactly one device made it into the registry before the interruption (stranded).
+        assert len(central.device_registry.get_device_addresses()) == 1


### PR DESCRIPTION
Wrap DeviceCoordinator.create_devices() device-construction loop in a try/finally and track progress so an interruption (e.g. CancelledError) no longer aborts silently. Compute expected device count, set a devices_created flag, and emit a warning with built/expected counts if the run is aborted; the interruption still propagates so cancellations are not swallowed. Bump package VERSION to 2026.6.1, add changelog entry documenting the fix, and add unit tests that verify normal completion and that a mid-loop CancelledError logs the warning and leaves already-built devices in the registry.