### PR TITLE
fix(rega): skip empty values in fetch_all_device_data instead of coercing to 0 (#3228)

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.6.2"
+VERSION: Final = "2026.6.3"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/rega_scripts/fetch_all_device_data.fn
+++ b/aiohomematic/rega_scripts/fetch_all_device_data.fn
@@ -60,12 +60,18 @@ if (oInterface) {
                                             }
                                             bHasValue = true;
                                         } else {
+                                            !# Empty value = not measured yet (e.g. ACTUAL_TEMPERATURE right
+                                            !# after a CCU restart). Skip the data point instead of coercing
+                                            !# to "0": emitting 0 wrote an implausible placeholder into the
+                                            !# cache that the integration could not tell apart from a real
+                                            !# reading. Leaving it out yields a cache miss, so the value stays
+                                            !# unset (is_valid stays False) until a real measurement arrives.
                                             if (vDPValue == "") {
-                                                sValue = "0";
+                                                bHasValue = false;
                                             } else {
                                                 sValue = vDPValue;
+                                                bHasValue = true;
                                             }
-                                            bHasValue = true;
                                         }
                                     }
                                     if (bHasValue) {

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,27 @@
+# Version 2026.6.3 (2026-06-18)
+
+## What's Changed
+
+### Fixed
+
+- **Sensors no longer report a spurious `0` after a CCU restart** (#3228): the
+  `fetch_all_device_data.fn` ReGa bulk-load script coerced an **empty**
+  (not-yet-measured) numeric value into `"0"`. After a restart a data point
+  such as `ACTUAL_TEMPERATURE` can already carry a timestamp but no real reading
+  yet; the script then emitted `0`, which was cached and shown as a confirmed
+  value (e.g. `0 °C`, or `0`/closed for a cover's `LEVEL`). The script now
+  **skips** empty values instead of coercing them to `0`, so the data point
+  stays unset (`is_valid` stays `False`) and Home Assistant keeps the restored
+  last value until the device delivers a real measurement. A real `0` reading is
+  unaffected (it is numeric `0`, not an empty value).
+
 # Version 2026.6.2 (2026-06-10)
 
 ## What's Changed
 
 ### Reverted
 
-- PR #3214: Feature/contract extraction 
-
+- PR #3214: Feature/contract extraction
 
 # Version 2026.6.1 (2026-06-04)
 

--- a/tests/contract/test_fetch_all_device_data_script_contract.py
+++ b/tests/contract/test_fetch_all_device_data_script_contract.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""
+Contract test for the ``fetch_all_device_data.fn`` ReGa bulk-load script.
+
+Guards against re-introducing the empty-value -> ``"0"`` coercion (issue #3228).
+
+A not-yet-measured numeric data point (e.g. ``ACTUAL_TEMPERATURE`` right after a
+CCU restart) reports an empty value over the ReGa object model. The script must
+SKIP such a data point — leaving it absent from the bulk result, which yields a
+cache miss so the value stays unset and ``is_valid`` stays ``False`` — instead of
+emitting a literal ``0``. Emitting ``0`` wrote an implausible placeholder that
+the integration could not tell apart from a real reading and recorded as
+``0 °C``. The script runs on the CCU and cannot be executed in Python, so this
+contract pins the source-level invariant.
+"""
+
+from pathlib import Path
+import re
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "aiohomematic" / "rega_scripts" / "fetch_all_device_data.fn"
+
+
+def _normalized_source() -> str:
+    """Return the script with runs of whitespace collapsed to single spaces."""
+    return re.sub(r"\s+", " ", _SCRIPT.read_text(encoding="utf-8"))
+
+
+class TestFetchAllDeviceDataScript:
+    """Contract for the bulk-load script's empty-value handling."""
+
+    def test_empty_numeric_value_is_not_coerced_to_zero(self) -> None:
+        """An empty numeric value must not be emitted as ``0`` (#3228)."""
+        assert 'if (vDPValue == "") { sValue = "0"' not in _normalized_source()
+
+    def test_empty_numeric_value_is_skipped(self) -> None:
+        """An empty numeric value must be skipped via ``bHasValue = false``."""
+        assert 'if (vDPValue == "") { bHasValue = false' in _normalized_source()
+
+    def test_script_exists(self) -> None:
+        """The bulk-load script ships with the package."""
+        assert _SCRIPT.is_file()


### PR DESCRIPTION
The fetch_all_device_data.fn bulk-load script coerced an empty (not-yet-measured) numeric value into "0". After a CCU restart a data point such as ACTUAL_TEMPERATURE can already carry a timestamp but no real reading yet; the script then emitted 0, which was cached and shown as a confirmed value (e.g. 0 °C, or 0/closed for a cover's LEVEL).

The script now skips empty values, so the data point stays unset (is_valid stays False) and Home Assistant keeps the restored last value until the device delivers a real measurement. A real 0 reading is unaffected (it is numeric 0, not an empty value).

Add a contract test pinning the script invariant; bump VERSION to 2026.6.3 and update the changelog.

Fixes #3228