### PR TITLE
fix(support): strip CCU type prefix from values before conversion

### DIFF
--- a/aiohomematic/model/support.py
+++ b/aiohomematic/model/support.py
@@ -562,9 +562,32 @@ def _convert_value_cached(*, value: Any, target_type: ParameterType, value_list:
     return _convert_value_noncached(value=value, target_type=target_type, value_list=value_list)
 
 
+_TYPE_PREFIXES: Final = ("INTEGER ", "FLOAT ", "STRING ", "BOOL ", "ENUM ")
+
+
+def _strip_type_prefix(*, value: Any) -> Any:
+    """Strip a CCU type prefix (e.g. 'INTEGER 0') from a string value.
+
+    The OpenCCU/CCU3 ``VirtualDevices`` interface occasionally returns
+    paramset values as type-prefixed strings such as ``'INTEGER 0'``,
+    ``'FLOAT 1.5'`` or ``'STRING foo'`` — most reliably reproduced when
+    reading week-profile entries from HmIP-HEATING virtual devices
+    (``INT0000xxx``). When such a value reaches a numeric conversion the
+    library raises ``ValueError: could not convert string to float`` and
+    the device's ``on_config_changed`` handler aborts, leaving downstream
+    entities permanently ``unavailable``.
+    """
+    if isinstance(value, str):
+        for prefix in _TYPE_PREFIXES:
+            if value.startswith(prefix):
+                return value[len(prefix):]
+    return value
+
+
 def _convert_value_noncached(*, value: Any, target_type: ParameterType, value_list: tuple[str, ...] | None) -> Any:
     if value is None:
         return None
+    value = _strip_type_prefix(value=value)
     if target_type == ParameterType.BOOL:
         if value_list:
             # relevant for ENUMs retyped to a BOOL

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -460,6 +460,24 @@ class TestValueConversion:
         assert convert_value(value="1", target_type=ParameterType.STRING, value_list=None) == "1"
         assert convert_value(value=True, target_type=ParameterType.ACTION, value_list=None) is True
 
+    @pytest.mark.asyncio
+    async def test_convert_value_strips_ccu_type_prefix(self) -> None:
+        """Type-prefixed strings from CCU3 VirtualDevices must convert without error.
+
+        Reproduces the failure mode where reading week-profile paramsets from
+        HmIP-HEATING virtual devices yields ``'INTEGER 0'`` or ``'FLOAT 1.5'``
+        instead of the bare value. Without prefix-stripping, ``int(float(value))``
+        raises ``ValueError`` and downstream ``on_config_changed`` handlers abort.
+        """
+        assert convert_value(value="INTEGER 0", target_type=ParameterType.INTEGER, value_list=None) == 0
+        assert convert_value(value="INTEGER 1440", target_type=ParameterType.INTEGER, value_list=None) == 1440
+        assert convert_value(value="FLOAT 1.5", target_type=ParameterType.FLOAT, value_list=None) == 1.5
+        assert convert_value(value="STRING foo", target_type=ParameterType.STRING, value_list=None) == "foo"
+        assert convert_value(value="BOOL true", target_type=ParameterType.BOOL, value_list=None) is True
+        # Bare values without a prefix continue to convert as before
+        assert convert_value(value="42", target_type=ParameterType.INTEGER, value_list=None) == 42
+        assert convert_value(value="INTEGERish", target_type=ParameterType.STRING, value_list=None) == "INTEGERish"
+
 
 class TestElementMatching:
     """Tests for element matching."""


### PR DESCRIPTION
Closes #3230

## Problem

`_convert_value_noncached` raises `ValueError: could not convert string to float: 'INTEGER 0'` when the CCU3 `VirtualDevices` backend returns a type-prefixed string such as `'INTEGER 0'`, `'INTEGER 1440'`, or `'FLOAT 1.5'`. This is most reliably reproduced when reading week-profile paramsets on HmIP-HEATING virtual devices (`INT0000xxx`).

The exception bubbles out of `data_point.event` → `device.on_config_changed` → `week_profile.reload_and_cache_schedule`. The device's config-change handler aborts mid-reload and downstream entities driven by that device stay `unavailable` indefinitely. In my setup this hid every CCU-driven `climate.*_regelung` from the HASS HomeKit bridge.

## Fix

Strip a recognised type prefix (`INTEGER `, `FLOAT `, `STRING `, `BOOL `, `ENUM `) from string values at the start of `_convert_value_noncached`, before any numeric conversion happens. The strip lives in a new `_strip_type_prefix` helper and runs once at function entry, so both the `_convert_value_cached` (lru-cached) and the non-cached fallback path benefit from it.

Bare values without a recognised prefix are returned unchanged, so existing behaviour is preserved. Strings that merely start with a prefix-shaped substring but no trailing space (e.g. `'INTEGERish'`) are likewise unaffected — only the exact `'<TYPE> '` form with a trailing space triggers the strip.

## Tests

Added a new test method `test_convert_value_strips_ccu_type_prefix` in `TestValueConversion` covering:

- `'INTEGER 0'`, `'INTEGER 1440'` → INTEGER
- `'FLOAT 1.5'` → FLOAT
- `'STRING foo'` → STRING
- `'BOOL true'` → BOOL
- regression: `'42'` → INTEGER (bare value still works)
- regression: `'INTEGERish'` → STRING (no false-positive strip)

## Notes / alternative shapes

Happy to move the strip out of `_convert_value_noncached` and into `interface_client._convert_read_value` if you prefer the cache to store canonicalised values. The current shape was chosen because it is the minimal touch and naturally covers every entry path, including any future caller that bypasses the read-side helper.

If you would rather scope the strip to the `VirtualDevices` interface only, the helper takes named arguments and is straightforward to gate on a caller-supplied flag — let me know and I'll adjust.

## Compatibility

Pure additive change. No public API modified, no behaviour change for existing inputs. The added `_strip_type_prefix` helper and `_TYPE_PREFIXES` constant are module-private.

## Heads up — unrelated devel breakage

While preparing this PR I ran into a pre-existing syntax error in `aiohomematic/i18n.py` line 197 (`except ValueError, IndexError, KeyError, TypeError:` — Python 2 syntax). It blocks `import aiohomematic` and therefore `pytest` from running locally on devel. It's unrelated to this PR, but you may want to know — happy to fix it in a separate PR if useful.