### PR TITLE
fix(model): load *_STATUS on init, keep last value on UNKNOWN (#3228)

### DIFF
--- a/aiohomematic/model/data_point.py
+++ b/aiohomematic/model/data_point.py
@@ -1167,14 +1167,27 @@ class BaseParameterDataPoint[
         if not self.is_readable:
             return
 
-        self.write_value(
-            value=await self._device.value_cache.get_value(
-                dpk=self.dpk,
-                call_source=call_source,
-                direct_call=direct_call,
-            ),
-            write_at=datetime.now(),
+        value = await self._device.value_cache.get_value(
+            dpk=self.dpk,
+            call_source=call_source,
+            direct_call=direct_call,
         )
+        # Load the paired *_STATUS first so the freshly loaded value can be judged
+        # before it is written (#3228). Without the status, the getValue fallback's
+        # default 0 (e.g. ACTUAL_TEMPERATURE after a CCU restart) is treated as a
+        # confirmed reading.
+        if (status_dpk := self._status_dpk) is not None:
+            await self._load_status_value(status_dpk=status_dpk, call_source=call_source, direct_call=direct_call)
+            # After a CCU restart getValue returns the default (e.g. 0 for a
+            # not-yet-measured ACTUAL_TEMPERATURE) with status UNKNOWN. Don't
+            # overwrite an already known value with that placeholder; keep the last
+            # value instead (#3228). Restoring a real value (cover/dimmer LEVEL,
+            # #2630) is unaffected: its status stays valid (is_status_valid keeps
+            # UNKNOWN valid) and the value is simply retained until a confirmed
+            # reading arrives.
+            if self._status_value == ParameterStatus.UNKNOWN and self.is_refreshed:
+                return
+        self.write_value(value=value, write_at=datetime.now())
 
     async def on_config_changed(self) -> None:
         """Do what is needed on device config change."""
@@ -1468,6 +1481,16 @@ class BaseParameterDataPoint[
         if self._optimistic.is_active:
             return self._optimistic.value
         return self._value
+
+    async def _load_status_value(self, *, status_dpk: DataPointKey, call_source: CallSource, direct_call: bool) -> None:
+        """Load the paired ``*_STATUS`` value so the value's validity can be judged on init (#3228)."""
+        status_value = await self._device.value_cache.get_value(
+            dpk=status_dpk,
+            call_source=call_source,
+            direct_call=direct_call,
+        )
+        if status_value is not None and status_value != NO_CACHE_ENTRY:
+            self.update_status(status_value=status_value)
 
     def _publish_rollback_event(
         self,

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,20 @@
   maintains a `needs-raw-data` triage label (added when the diagnostics/log are
   missing or an AI analysis is detected, removed once the data is provided).
 
+### Fixed
+
+- **Fix sensors still showing an implausible `0` after a CCU restart via the
+  `getValue` path (#3228).** The `2026.6.3` ReGa-script fix only covered the
+  bulk-load path; the placeholder actually arrives through the per-parameter
+  `getValue` fallback (e.g. for virtual heating groups), which returns the
+  parameter default (`0`) with `*_STATUS = UNKNOWN` while the CCU has no measured
+  value yet. The paired `*_STATUS` parameter is now loaded on init (previously it
+  was only updated via later events), and a freshly loaded default whose status is
+  `UNKNOWN` no longer overwrites an already known value — the last value is kept
+  until a confirmed reading arrives. Restoring a real value after restart
+  (cover/dimmer `LEVEL`, #2630) is unaffected: `UNKNOWN` stays valid and the value
+  is simply retained.
+
 # Version 2026.6.3 (2026-06-18)
 
 ## What's Changed

--- a/tests/test_central.py
+++ b/tests/test_central.py
@@ -835,17 +835,19 @@ class TestCentralCallbacksAndServices:
         await central.load_and_refresh_data_point_data(interface=Interface.BIDCOS_RF, paramset_key=ParamsetKey.MASTER)
         assert len(mock_client.method_calls) == init_len_method_calls
         await central.load_and_refresh_data_point_data(interface=Interface.BIDCOS_RF, paramset_key=ParamsetKey.VALUES)
-        assert len(mock_client.method_calls) == init_len_method_calls + 19
+        # +8 over the plain value loads: each readable data point with a paired
+        # *_STATUS parameter now also loads that status on init (#3228).
+        assert len(mock_client.method_calls) == init_len_method_calls + 27
 
         await central.hub_coordinator.get_system_variable(legacy_name="SysVar_Name")
         assert mock_client.method_calls[-1] == call.get_system_variable(name="SysVar_Name")
 
-        assert len(mock_client.method_calls) == init_len_method_calls + 20
+        assert len(mock_client.method_calls) == init_len_method_calls + 28
         await central.hub_coordinator.set_system_variable(legacy_name="alarm", value=True)
         assert mock_client.method_calls[-1] == call.set_system_variable(legacy_name="alarm", value=True)
-        assert len(mock_client.method_calls) == init_len_method_calls + 21
+        assert len(mock_client.method_calls) == init_len_method_calls + 29
         await central.hub_coordinator.set_system_variable(legacy_name="SysVar_Name", value=True)
-        assert len(mock_client.method_calls) == init_len_method_calls + 21
+        assert len(mock_client.method_calls) == init_len_method_calls + 29
 
         await central.client_coordinator.get_client(interface_id=const.INTERFACE_ID).set_value(
             channel_address="123",
@@ -859,7 +861,7 @@ class TestCentralCallbacksAndServices:
             parameter="LEVEL",
             value=1.0,
         )
-        assert len(mock_client.method_calls) == init_len_method_calls + 22
+        assert len(mock_client.method_calls) == init_len_method_calls + 30
 
         with pytest.raises(AioHomematicException):
             await central.client_coordinator.get_client(interface_id="NOT_A_VALID_INTERFACE_ID").set_value(
@@ -868,7 +870,7 @@ class TestCentralCallbacksAndServices:
                 parameter="LEVEL",
                 value=1.0,
             )
-        assert len(mock_client.method_calls) == init_len_method_calls + 22
+        assert len(mock_client.method_calls) == init_len_method_calls + 30
 
         await central.client_coordinator.get_client(interface_id=const.INTERFACE_ID).put_paramset(
             channel_address="123",
@@ -878,14 +880,14 @@ class TestCentralCallbacksAndServices:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="123", paramset_key_or_link_address=ParamsetKey.VALUES, values={"LEVEL": 1.0}
         )
-        assert len(mock_client.method_calls) == init_len_method_calls + 23
+        assert len(mock_client.method_calls) == init_len_method_calls + 31
         with pytest.raises(AioHomematicException):
             await central.client_coordinator.get_client(interface_id="NOT_A_VALID_INTERFACE_ID").put_paramset(
                 channel_address="123",
                 paramset_key_or_link_address=ParamsetKey.VALUES,
                 values={"LEVEL": 1.0},
             )
-        assert len(mock_client.method_calls) == init_len_method_calls + 23
+        assert len(mock_client.method_calls) == init_len_method_calls + 31
 
         assert (
             central.query_facade.get_generic_data_point(

--- a/tests/test_model_data_point.py
+++ b/tests/test_model_data_point.py
@@ -4,12 +4,12 @@
 
 from datetime import datetime
 from typing import cast
-from unittest.mock import MagicMock, call
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
 from aiohomematic.central.events import DataPointStateChangedEvent, DeviceLifecycleEvent, DeviceLifecycleEventType
-from aiohomematic.const import CallSource, DataPointUsage, Interface, ParamsetKey
+from aiohomematic.const import CallSource, DataPointUsage, Interface, ParameterStatus, ParamsetKey
 from aiohomematic.model.custom import CustomDpSwitch, get_required_parameters
 from aiohomematic.model.generic import DpSensor, DpSwitch
 from aiohomematic.store.visibility import check_ignore_parameters_is_clean
@@ -182,6 +182,46 @@ class TestDataPointLoading:
             (TEST_DEVICES, True, None, None),
         ],
     )
+    async def test_init_keeps_known_value_when_status_unknown(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """
+        A not-yet-measured default (status UNKNOWN) must not overwrite a known value on init (#3228).
+
+        After a CCU restart the getValue fallback returns the default (e.g. 0) with
+        status UNKNOWN. The last known value must be retained instead of being
+        replaced by the placeholder.
+        """
+        central, _, _ = central_client_factory_with_homegear_client
+        level: DpSensor = cast(
+            DpSensor,
+            central.query_facade.get_generic_data_point(channel_address="VCU3609622:1", parameter="LEVEL"),
+        )
+        # Establish a known, refreshed value.
+        level.write_value(value=0.5, write_at=datetime.now())
+        known_value = level.value
+        assert level.is_refreshed is True
+
+        # Simulate the init load: value comes back as the default 0, status as UNKNOWN.
+        with patch.object(type(level._device.value_cache), "get_value", new=AsyncMock(side_effect=[0.0, "UNKNOWN"])):
+            await level.load_data_point_value(call_source=CallSource.HM_INIT, direct_call=True)
+
+        assert level.status == ParameterStatus.UNKNOWN
+        assert level.value == known_value
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
     async def test_load_custom_data_point(
         self,
         central_client_factory_with_homegear_client,
@@ -240,6 +280,52 @@ class TestDataPointLoading:
             parameter="STATE",
             call_source="hm_init",
         )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_load_generic_data_point_also_loads_status(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """
+        Loading a data point with a paired ``*_STATUS`` must also load that status (#3228).
+
+        After a CCU restart the ``getValue`` fallback returns the default ``0`` for a
+        not-yet-measured value, while the paired ``*_STATUS`` is never queried. The
+        status must be loaded on init so the value's validity can be judged.
+        """
+        central, mock_client, _ = central_client_factory_with_homegear_client
+        level: DpSensor = cast(
+            DpSensor,
+            central.query_facade.get_generic_data_point(channel_address="VCU3609622:1", parameter="LEVEL"),
+        )
+        assert level.has_status_parameter is True
+        assert level.status_parameter == "LEVEL_STATUS"
+
+        await level.load_data_point_value(call_source=CallSource.MANUAL_OR_SCHEDULED)
+
+        status_calls = [
+            c
+            for c in mock_client.method_calls
+            if c
+            == call.get_value(
+                channel_address="VCU3609622:1",
+                paramset_key=ParamsetKey.VALUES,
+                parameter="LEVEL_STATUS",
+                call_source="hm_init",
+            )
+        ]
+        assert len(status_calls) == 1
 
 
 class TestWrappedDataPoint:

--- a/tests/test_model_data_point_validity.py
+++ b/tests/test_model_data_point_validity.py
@@ -130,3 +130,18 @@ class TestDataPointValidity:
 
         result = BaseParameterDataPoint.is_status_valid.__get__(mock)
         assert result is False
+
+    def test_status_unknown_valid(self) -> None:
+        """
+        Test that UNKNOWN status keeps DP valid (#2630).
+
+        UNKNOWN means "not yet confirmed" after a restart; the entity must stay
+        valid so cover/dimmer restore their last value instead of going
+        unavailable. The placeholder-overwrite guard for #3228 lives in the load
+        path, not here, so this invariant must hold.
+        """
+        mock = Mock()
+        mock._status_value = ParameterStatus.UNKNOWN
+
+        result = BaseParameterDataPoint.is_status_valid.__get__(mock)
+        assert result is True


### PR DESCRIPTION
## Summary

Fixes the remaining part of #3228: sensors (notably **virtual heating groups**, `HmIP-HEATING`) showing an implausible `0` after a CCU restart.

The debug log from the issue showed the placeholder does **not** come through the ReGa bulk-load script (fixed in 2026.6.3) but through the per-parameter **`getValue` fallback**: for a not-yet-measured value the CCU returns the parameter default (`0`) together with `*_STATUS = UNKNOWN`. The status was never consulted on init, so the `0` was treated as a confirmed reading.

## Changes

- **`model/data_point.py`** — `load_data_point_value` now:
  - loads the paired `*_STATUS` on init (`_load_status_value`); previously it was only updated via later events;
  - judges the status **before** writing: a freshly loaded default with status `UNKNOWN` no longer overwrites an already known value (`is_refreshed`) — the last value is kept until a confirmed reading arrives.
- `is_status_valid` is left untouched, so restoring a real value after restart (cover/dimmer `LEVEL`, #2630) keeps working: `UNKNOWN` stays valid.

## Relation to 2026.6.3 / #3229

Complementary, not redundant. The ReGa-script fix guards the **bulk-fetch/cache** path; this guards the **`getValue`/write** path. Both kept (defense in depth).

## Tests

- `test_load_generic_data_point_also_loads_status` — status is loaded on init
- `test_init_keeps_known_value_when_status_unknown` — known value retained on `UNKNOWN`
- `test_status_unknown_valid` — pins #2630 (UNKNOWN stays valid)
- `test_central_services` call count adjusted (+8: each status data point now loads its status)
- Full suite: 4082 passed, 1 skipped; ruff/mypy/pylint clean.

## ⚠️ Verification still open

The fix relies on the CCU actually returning `ACTUAL_TEMPERATURE_STATUS = UNKNOWN` for the heating groups after a restart. This was never observed directly (the status was never queried before). The change now makes it visible in the debug log — a beta test should confirm before closing #3228. If the CCU returns `NORMAL` despite the default `0`, a plausibility rule would be needed instead.

Changelog: appended under 2026.6.4.