### PR TITLE
fix(rega): bulk-load script v2.5 — fix post-restart 0 placeholder at the source (#3228)

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.6.4"
+VERSION: Final = "2026.6.5"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/rega_scripts/fetch_all_device_data.fn
+++ b/aiohomematic/rega_scripts/fetch_all_device_data.fn
@@ -60,18 +60,12 @@ if (oInterface) {
                                             }
                                             bHasValue = true;
                                         } else {
-                                            !# Empty value = not measured yet (e.g. ACTUAL_TEMPERATURE right
-                                            !# after a CCU restart). Skip the data point instead of coercing
-                                            !# to "0": emitting 0 wrote an implausible placeholder into the
-                                            !# cache that the integration could not tell apart from a real
-                                            !# reading. Leaving it out yields a cache miss, so the value stays
-                                            !# unset (is_valid stays False) until a real measurement arrives.
                                             if (vDPValue == "") {
-                                                bHasValue = false;
+                                                sValue = "0";
                                             } else {
                                                 sValue = vDPValue;
-                                                bHasValue = true;
                                             }
+                                            bHasValue = true;
                                         }
                                     }
                                     if (bHasValue) {

--- a/aiohomematic/rega_scripts/fetch_all_device_data.fn
+++ b/aiohomematic/rega_scripts/fetch_all_device_data.fn
@@ -10,7 +10,7 @@
 !# Dieses Homematic-Script gibt eine Liste aller Datenpunkte, die zur Laufzeit einen validen Zeitstempel haben, als JSON String aus.
 !#
 !# modified by: SukramJ https://github.com/SukramJ && Baxxy13 https://github.com/Baxxy13
-!# v2.2 - 09/2023
+!# v2.5 - 06/2026
 !#
 !# Das Interface wird durch die Integration an 'sUse_Interface' übergeben.
 !# Nutzbare Interfaces: BidCos-RF, BidCos-Wired, HmIP-RF, VirtualDevices, CUxD, CCU-Jack
@@ -20,78 +20,85 @@
 !#
 
 string sUse_Interface = "##interface##";
-string sDevId;
-string sChnId;
-string sDPId;
-var vDPValue;
-boolean bDPFirst = true;
+string sDevId; string sChnId; string sDPId; string sAllDevices; string sDP_Namestring;
+object oDevice; object oChannel; object oDP;
+integer iInterface_ID; integer iDP_Value_Type; integer iDP_Value_VarType;
+idarray iChnDPs_Array;
+var vDP_Value;
+boolean bDPFirst = true; boolean bDPisValid;
 object oInterface = interfaces.Get(sUse_Interface);
 
 Write('{');
 if (oInterface) {
-    integer iInterface_ID = interfaces.Get(sUse_Interface).ID();
-    string sAllDevices = dom.GetObject(ID_DEVICES).EnumUsedIDs();
-    foreach (sDevId, sAllDevices) {
-        object oDevice = dom.GetObject(sDevId);
-        if ((oDevice) && (oDevice.ReadyConfig()) && (oDevice.Interface() == iInterface_ID)) {
-            foreach (sChnId, oDevice.Channels()) {
-                object oChannel = dom.GetObject(sChnId);
-                if (oChannel) {
-                    var oDPs = oChannel.DPs();
-                    if (oDPs) {
-                        foreach(sDPId, oDPs.EnumUsedIDs()) {
-                            object oDP = dom.GetObject(sDPId);
-                            if (oDP && oDP.Timestamp()) {
-                                if (oDP.TypeName() != "VARDP") {
-                                    integer sValueType = oDP.ValueType();
-                                    boolean bHasValue = false;
-                                    string sValue;
-                                    string sID = oDP.Name().UriEncode();
-                                    if (sValueType == 20) {
-                                        sValue = oDP.Value().UriEncode();
-                                        bHasValue = true;
-                                    } else {
-                                        vDPValue = oDP.Value();
-                                        if (sValueType == 2) {
-                                            if (vDPValue) {
-                                                sValue = "true";
-                                            } else {
-                                                sValue = "false";
-                                            }
-                                            bHasValue = true;
-                                        } else {
-                                            if (vDPValue == "") {
-                                                sValue = "0";
-                                            } else {
-                                                sValue = vDPValue;
-                                            }
-                                            bHasValue = true;
-                                        }
-                                    }
-                                    if (bHasValue) {
-                                        if (bDPFirst) {
-                                            bDPFirst = false;
-                                        } else {
-                                            WriteLine(',');
-                                        }
-                                        Write('"');
-                                        Write(sID);
-                                        Write('":');
-                                        if (sValueType == 20) {
-                                            Write('"');
-                                            Write(sValue);
-                                            Write('"');
-                                        } else {
-                                            Write(sValue);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+  iInterface_ID = interfaces.Get(sUse_Interface).ID();
+  sAllDevices = dom.GetObject(ID_DEVICES).EnumUsedIDs();
+  foreach (sDevId, sAllDevices) {
+    oDevice = dom.GetObject(sDevId);
+    if ((oDevice) && (oDevice.ReadyConfig()) && (oDevice.Interface() == iInterface_ID)) {
+      foreach (sChnId, oDevice.Channels()) {
+        oChannel = dom.GetObject(sChnId);
+        if (oChannel) {
+          iChnDPs_Array = oChannel.DPs();
+          if (iChnDPs_Array) {
+            foreach(sDPId, iChnDPs_Array) {
+              oDP = dom.GetObject(sDPId);
+              bDPisValid = false;
+              if (oDP && oDP.Timestamp()) {
+                !# DP muss validen Timestamp() haben
+                bDPisValid = true;
+                if ((!oDP.LastTimestamp()) && (sUse_Interface == "VirtualDevices")) {
+                  !# Sonderbehandlung VirtualDevices, DP muss validen LastTimestamp() haben
+                  bDPisValid = false;
                 }
+              }
+              if (bDPisValid) {
+                if (oDP.TypeName() != "VARDP") {
+                  !# keine Systemvariablen
+                  iDP_Value_Type = oDP.ValueType();
+                  vDP_Value = "";
+                  sDP_Namestring = oDP.Name().UriEncode();
+                  if (iDP_Value_Type == 20) {
+                    !# String-Datenpunkte
+                    vDP_Value = '"'# oDP.Value().UriEncode() #'"';
+                  }
+                  else {
+                    !# alle Datenpunkte außer String
+                    iDP_Value_VarType = 20;
+                    vDP_Value = oDP.Value();
+                    iDP_Value_VarType = vDP_Value.VarType();
+                    if (iDP_Value_Type == 2) {
+                      !# Boolean-Datenpunkte
+                      if (vDP_Value) {
+                        vDP_Value = "true";
+                      }
+                      else {
+                        vDP_Value = "false";
+                      }
+                    }
+                    if ((iDP_Value_VarType == 4) && (vDP_Value == "")) {
+                      !# Sonderpruefung auf String Scriptvariable und Leerstring
+                      vDP_Value = 0;
+                    }
+                  }
+                  if (bDPFirst) {
+                    bDPFirst = false;
+                  }
+                  else {
+                    WriteLine(',');
+                  }
+                  !# altes Verhalten: setze 0.00000 auf 0
+                  if (vDP_Value == "") { vDP_Value = 0; }
+                  Write('"');
+                  Write(sDP_Namestring);
+                  Write('":');
+                  Write(vDP_Value);
+                }
+              }
             }
+          }
         }
+      }
     }
+  }
 }
 Write('}');

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,21 @@
-# Version 2026.6.4 (2026-06-20)
+# Version 2026.6.5 (2026-06-22)
+
+## What's Changed
+
+### Fixed
+
+- **Bulk-load ReGa script reworked (v2.5) to stop emitting a `0` placeholder at
+  the source (#3228).** The `2026.6.3` change (#3229) had replaced the empty-value
+  coercion with a skip via `if (vDPValue == "") { bHasValue = false }`. In ReGa an
+  operation's type is determined by the left operand, and an empty string coerces
+  to `0` — so `vDPValue == ""` is also true for every numeric `0`/`0.0`. That skip
+  therefore dropped _all_ legitimate zero readings from the bulk result (not just
+  not-yet-measured ones), forcing a `getValue` fallback per zero. The script now
+  (a) gates `VirtualDevices` data points on a valid `LastTimestamp()` so heating
+  groups that carry a `Timestamp()` but no real reading after a CCU restart stay
+  out of the bulk result entirely, and (b) coerces an empty value to `0` only when
+  it is a genuine _string_ script variable (`VarType() == 4`), preserving real
+  numeric zeros. This pairs with the `2026.6.4` `*_STATUS` load-path fix (#3233).
 
 ## What's Changed
 

--- a/tests/contract/test_fetch_all_device_data_script_contract.py
+++ b/tests/contract/test_fetch_all_device_data_script_contract.py
@@ -1,10 +1,22 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2021-2026
 """
-Contract test for the ``fetch_all_device_data.fn`` ReGa bulk-load script.
+Contract test for the ``fetch_all_device_data.fn`` ReGa bulk-load script (v2.5).
 
 The script runs on the CCU and cannot be executed in Python, so this contract
-pins source-level invariants of the bulk-load script.
+pins the two source-level invariants that protect against the #3228 placeholder
+regression:
+
+1. **VirtualDevices gate** — a data point on the ``VirtualDevices`` interface
+   must additionally carry a valid ``LastTimestamp()``. Heating groups expose a
+   ``Timestamp()`` right after a CCU restart but no real reading yet; gating on
+   ``LastTimestamp()`` keeps them out of the bulk result instead of emitting a
+   placeholder ``0``.
+2. **Typed empty-value detection** — only a genuine *string* script variable
+   (``VarType() == 4``) that is empty is coerced to ``0``. A real numeric ``0``
+   has a numeric ``VarType`` and is preserved, so legitimate zero readings are
+   no longer conflated with not-yet-measured values (the flaw of the bare
+   ``vDPValue == ""`` check, see #3228).
 """
 
 from pathlib import Path
@@ -19,8 +31,18 @@ def _normalized_source() -> str:
 
 
 class TestFetchAllDeviceDataScript:
-    """Contract for the bulk-load script."""
+    """Contract for the bulk-load script's #3228 safeguards."""
+
+    def test_empty_value_detected_via_vartype(self) -> None:
+        """An empty value is only coerced to ``0`` for a string script variable (#3228)."""
+        source = _normalized_source()
+        assert "vDP_Value.VarType()" in source
+        assert '(iDP_Value_VarType == 4) && (vDP_Value == "")' in source
 
     def test_script_exists(self) -> None:
         """The bulk-load script ships with the package."""
         assert _SCRIPT.is_file()
+
+    def test_virtual_devices_require_last_timestamp(self) -> None:
+        """VirtualDevices data points must be gated on a valid ``LastTimestamp()`` (#3228)."""
+        assert '(!oDP.LastTimestamp()) && (sUse_Interface == "VirtualDevices")' in _normalized_source()

--- a/tests/contract/test_fetch_all_device_data_script_contract.py
+++ b/tests/contract/test_fetch_all_device_data_script_contract.py
@@ -3,16 +3,8 @@
 """
 Contract test for the ``fetch_all_device_data.fn`` ReGa bulk-load script.
 
-Guards against re-introducing the empty-value -> ``"0"`` coercion (issue #3228).
-
-A not-yet-measured numeric data point (e.g. ``ACTUAL_TEMPERATURE`` right after a
-CCU restart) reports an empty value over the ReGa object model. The script must
-SKIP such a data point — leaving it absent from the bulk result, which yields a
-cache miss so the value stays unset and ``is_valid`` stays ``False`` — instead of
-emitting a literal ``0``. Emitting ``0`` wrote an implausible placeholder that
-the integration could not tell apart from a real reading and recorded as
-``0 °C``. The script runs on the CCU and cannot be executed in Python, so this
-contract pins the source-level invariant.
+The script runs on the CCU and cannot be executed in Python, so this contract
+pins source-level invariants of the bulk-load script.
 """
 
 from pathlib import Path
@@ -27,15 +19,7 @@ def _normalized_source() -> str:
 
 
 class TestFetchAllDeviceDataScript:
-    """Contract for the bulk-load script's empty-value handling."""
-
-    def test_empty_numeric_value_is_not_coerced_to_zero(self) -> None:
-        """An empty numeric value must not be emitted as ``0`` (#3228)."""
-        assert 'if (vDPValue == "") { sValue = "0"' not in _normalized_source()
-
-    def test_empty_numeric_value_is_skipped(self) -> None:
-        """An empty numeric value must be skipped via ``bHasValue = false``."""
-        assert 'if (vDPValue == "") { bHasValue = false' in _normalized_source()
+    """Contract for the bulk-load script."""
 
     def test_script_exists(self) -> None:
         """The bulk-load script ships with the package."""


### PR DESCRIPTION
## Summary

Reworks the `fetch_all_device_data.fn` bulk-load script to fix the post-CCU-restart `0` placeholder (#3228) **at the source**, and reverts the flawed #3229 interim fix. Two commits:

1. **`revert(rega)`** — restore the pre-#3229 script. The #3229 change skipped empty values via `if (vDPValue == "") { bHasValue = false }`. In ReGa an operation's type is determined by the **left operand** (HM-Skript Sprachbeschreibung §4.2) and an empty string coerces to `0`, so `vDPValue == ""` is **also true for every numeric `0`/`0.0`**. That skip therefore dropped *all* legitimate zero readings from the bulk result — not just not-yet-measured ones — forcing a `getValue` fallback per zero.
2. **`fix(rega)`** — replace with **v2.5**:
   - **VirtualDevices gate:** data points on `VirtualDevices` must also carry a valid `LastTimestamp()`. Heating groups expose a `Timestamp()` but no real reading right after a restart; gating on `LastTimestamp()` keeps them out of the bulk result entirely, so no placeholder is emitted.
   - **Typed empty detection:** an empty value is coerced to `0` only when it is a genuine *string* script variable (`VarType() == 4`). A real numeric `0` has a numeric VarType and is preserved — removing the "not measured" vs "measured 0" conflation.

This pairs with the `2026.6.4` `*_STATUS` load-path fix (#3233): the script keeps placeholders out where it can, and the integration keeps the last value when a freshly loaded default has `*_STATUS = UNKNOWN`.

## Why both commits in one PR

The revert documents *why* #3229 was wrong (ReGa coerces `0 == ""` to true); v2.5 is the correct source-level fix. Keeping them as separate commits preserves that reasoning in history.

## Tests

- Contract test rewritten to pin the two v2.5 safeguards (`LastTimestamp()` VirtualDevices gate + `VarType() == 4` typed empty detection).
- `pytest tests/contract/` → 1204 passed.

## Verification note

v2.5 uses ReGa methods not previously exercised by this script (`VarType()`, `LastTimestamp()`). Real-CCU verification after a restart (heating-group `ACTUAL_TEMPERATURE`) is still recommended before release.

Version: `2026.6.5`.