### PR TITLE
chore(repo): switch default branch from devel to main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -68,16 +68,16 @@ def fetch_data(self) -> dict[str, Any]:
 
 ### Branch Strategy
 
-1. Create your feature branch from `devel`:
+1. Create your feature branch from `main`:
    ```bash
-   git checkout devel
-   git pull origin devel
+   git checkout main
+   git pull origin main
    git checkout -b feature/your-feature-name
    ```
 
 2. Make your changes
 
-3. Submit your PR against the `devel` branch (not `master`)
+3. Submit your PR against the `main` branch
 
 ### Quality Checks
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,8 +120,8 @@ raise ClientException(f"Failed to connect to {host}:{port}")
 
 ### Branch Target
 
-- Create feature branches from `devel`
-- Submit PRs to the `devel` branch (NOT `master`)
+- Create feature branches from `main`
+- Submit PRs to the `main` branch
 
 ### Quality Checks
 
@@ -199,4 +199,4 @@ unsubscribe = data_point.subscribe_to_data_point_updated(
 - Don't perform I/O in model classes
 - Don't use bare `except:` clauses
 - Don't skip prek hooks
-- Don't commit directly to `master` or `devel`
+- Don't commit directly to `main`

--- a/.github/workflows/ISSUE_ANALYZER_README.md
+++ b/.github/workflows/ISSUE_ANALYZER_README.md
@@ -103,7 +103,7 @@ _This analysis was generated automatically. For questions or problems, please us
 
 The available documentation links are defined in `.github/scripts/analyze_issue.py`.
 
-> **Note:** These links point to the deployed documentation site at `sukramj.github.io/aiohomematic/` which is built from the `devel` branch.
+> **Note:** These links point to the deployed documentation site at `sukramj.github.io/aiohomematic/` which is built from the `main` branch.
 
 ```python
 DOCS_LINKS = {

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,9 +3,9 @@ name: "CodeQL"
 # yamllint disable-line rule:truthy
 on:
   push:
-    branches: [devel, master]
+    branches: [main]
   pull_request:
-    branches: [devel, master]
+    branches: [main]
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,15 +4,14 @@ name: Deploy Documentation
 on:
   push:
     branches:
-      - devel
-      - master
+      - main
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
   pull_request:
     branches:
-      - devel
+      - main
     paths:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,11 +4,10 @@ name: Pre-commit checks
 on:
   pull_request:
     branches:
-      - devel
+      - main
   push:
     branches-ignore:
-      - master
-      - devel
+      - main
     tags-ignore:
       - "**"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,8 +81,7 @@ repos:
         exclude: (.vscode|.devcontainer)
       - id: no-commit-to-branch
         args:
-          - --branch=devel
-          - --branch=master
+          - --branch=main
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.37.1
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@
 
 ## Commit & Pull Request Guidelines
 
-- Branch from `devel` using `feature/<slug>` or `fix/<slug>`; AI sessions use `claude/claude-md-<session-id>`.
+- Branch from `main` using `feature/<slug>` or `fix/<slug>`; AI sessions use `claude/claude-md-<session-id>`.
 - Adopt the conventional commit format `type(scope): subject`; supported types are `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`.
 - Describe intent in the body and reference issues when applicable (e.g., `Closes #123`).
-- Target PRs at `devel`, include a brief summary plus test/type results, and supply evidence for behavioral changes.
+- Target PRs at `main`, include a brief summary plus test/type results, and supply evidence for behavioral changes.
 - Update `changelog.md` for user-visible impact and call out configuration or migration notes in the PR description.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,7 +506,7 @@ Release process (tagging, changelog rules): **`docs/contributor/release_process.
 
 ### Essentials
 
-- Main branch: `master` (protected). Development branch: `devel` (protected).
+- Default branch: `main` (protected). All PRs target `main`.
 - Feature branches: `feature/<desc>`; fixes: `fix/<desc>`; AI sessions: `claude/claude-md-<session>`.
 - Conventional-commit style: `<type>(<scope>): <subject>`.
 - Pre-commit hooks (prek): sort-class-members, check-i18n, lint-package-imports,
@@ -676,7 +676,7 @@ Non-negotiable rules for how the assistant works with the user:
 ### Don'ts
 
 - ❌ No untyped code or skipped hooks.
-- ❌ No direct commits to `master` or `devel`.
+- ❌ No direct commits to `main`.
 - ❌ No `Any` without justification.
 - ❌ No I/O in the model layer.
 - ❌ No bare `except:`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,4 +95,4 @@ docs/
 3. Test locally with `mkdocs serve`
 4. Submit a pull request
 
-Documentation is automatically deployed when changes are pushed to `devel` or `master`.
+Documentation is automatically deployed when changes are pushed to `main`.

--- a/docs/adr/0019-derived-binary-sensors.md
+++ b/docs/adr/0019-derived-binary-sensors.md
@@ -451,10 +451,10 @@ To add support for a new device/parameter combination:
 
 ## References
 
-- [CalculatedDataPoint Implementation](https://github.com/sukramj/aiohomematic/blob/devel/aiohomematic/model/calculated/data_point.py) - Base class for calculated data points
-- [OperatingVoltageLevel](https://github.com/sukramj/aiohomematic/blob/devel/aiohomematic/model/calculated/operating_voltage_level.py) - Example calculated data point
-- [DeviceProfileRegistry](https://github.com/sukramj/aiohomematic/blob/devel/aiohomematic/model/custom/registry.py) - Similar registry pattern
-- [CustomDpIpSirenSmoke](https://github.com/sukramj/aiohomematic/blob/devel/aiohomematic/model/custom/siren.py) - Current workaround with `is_on` property
+- [CalculatedDataPoint Implementation](https://github.com/sukramj/aiohomematic/blob/main/aiohomematic/model/calculated/data_point.py) - Base class for calculated data points
+- [OperatingVoltageLevel](https://github.com/sukramj/aiohomematic/blob/main/aiohomematic/model/calculated/operating_voltage_level.py) - Example calculated data point
+- [DeviceProfileRegistry](https://github.com/sukramj/aiohomematic/blob/main/aiohomematic/model/custom/registry.py) - Similar registry pattern
+- [CustomDpIpSirenSmoke](https://github.com/sukramj/aiohomematic/blob/main/aiohomematic/model/custom/siren.py) - Current workaround with `is_on` property
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ aiohomematic uses **protocol-based dependency injection** to reduce coupling and
 
 ### Source of truth for protocols
 
-All protocol interfaces — with full categorisation, member signatures, and sub-protocol composition — live in the module docstring of [`aiohomematic/interfaces/__init__.py`](https://github.com/SukramJ/aiohomematic/blob/devel/aiohomematic/interfaces/__init__.py). That module is the authoritative reference; this page deliberately does not duplicate the list so the two cannot drift.
+All protocol interfaces — with full categorisation, member signatures, and sub-protocol composition — live in the module docstring of [`aiohomematic/interfaces/__init__.py`](https://github.com/SukramJ/aiohomematic/blob/main/aiohomematic/interfaces/__init__.py). That module is the authoritative reference; this page deliberately does not duplicate the list so the two cannot drift.
 
 Further reading:
 

--- a/docs/contributor/coding/docstring_standards.md
+++ b/docs/contributor/coding/docstring_standards.md
@@ -687,4 +687,4 @@ Commits that fail these checks will be rejected.
 - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
 - [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
 - [NumPy Docstring Guide](https://numpydoc.readthedocs.io/en/latest/format.html)
-- [aiohomematic CLAUDE.md](https://github.com/sukramj/aiohomematic/blob/devel/CLAUDE.md)
+- [aiohomematic CLAUDE.md](https://github.com/sukramj/aiohomematic/blob/main/CLAUDE.md)

--- a/docs/contributor/git-workflow.md
+++ b/docs/contributor/git-workflow.md
@@ -4,31 +4,30 @@ This guide covers the git workflow for contributing to aiohomematic.
 
 ## Branch Structure
 
-| Branch      | Purpose                 | Protection |
-| ----------- | ----------------------- | ---------- |
-| `master`    | Stable releases         | Protected  |
-| `devel`     | Development integration | Protected  |
-| `feature/*` | New features            | -          |
-| `fix/*`     | Bug fixes               | -          |
+| Branch      | Purpose              | Protection |
+| ----------- | -------------------- | ---------- |
+| `main`      | Stable / integration | Protected  |
+| `feature/*` | New features         | -          |
+| `fix/*`     | Bug fixes            | -          |
 
 ## Workflow Overview
 
 ```
 1. Fork repository
-2. Create feature branch from devel
+2. Create feature branch from main
 3. Make changes with tests
 4. Run pre-commit hooks
 5. Commit with descriptive message
 6. Push to your fork
-7. Create Pull Request to devel
+7. Create Pull Request to main
 ```
 
 ## Creating a Feature Branch
 
 ```bash
-# Ensure you're on devel and up to date
-git checkout devel
-git pull origin devel
+# Ensure you're on main and up to date
+git checkout main
+git pull origin main
 
 # Create feature branch
 git checkout -b feature/my-feature
@@ -103,7 +102,7 @@ git push -u origin feature/my-feature
 
 ### 2. Create PR on GitHub
 
-- **Target branch**: `devel`
+- **Target branch**: `main`
 - **Title**: Clear, concise description
 - **Description**: Explain what and why
 
@@ -150,7 +149,7 @@ git push
 
 ### Never Do
 
-- Push directly to `master` or `devel`
+- Push directly to `main`
 - Force push to shared branches
 - Use `git reset --hard` on shared branches
 - Skip hooks with `--no-verify` without good reason
@@ -170,10 +169,10 @@ git push
 
 ```bash
 git fetch origin
-git checkout devel
-git merge origin/devel
+git checkout main
+git merge origin/main
 git checkout feature/my-feature
-git rebase devel
+git rebase main
 ```
 
 ### Fix Last Commit Message

--- a/docs/contributor/release_process.md
+++ b/docs/contributor/release_process.md
@@ -103,7 +103,7 @@ git commit -m "Release version 2025.12.43"
 git tag -a "2025.12.43" -m "Release 2025.12.43"
 
 # Push with tags
-git push origin devel --tags
+git push origin main --tags
 ```
 
 ## Changelog Format

--- a/docs/contributor/testing/coverage.md
+++ b/docs/contributor/testing/coverage.md
@@ -165,7 +165,7 @@ def test_device_found():
 Coverage is automatically checked on:
 
 - Pull requests
-- Pushes to `master` and `devel`
+- Pushes to `main`
 
 Codecov comments on PRs with:
 
@@ -270,4 +270,4 @@ Coverage data is automatically combined.
 
 - [pytest-cov documentation](https://pytest-cov.readthedocs.io/)
 - [Codecov documentation](https://docs.codecov.com/)
-- [CLAUDE.md](https://github.com/sukramj/aiohomematic/blob/devel/CLAUDE.md#testing-guidelines) - Testing guidelines
+- [CLAUDE.md](https://github.com/sukramj/aiohomematic/blob/main/CLAUDE.md#testing-guidelines) - Testing guidelines

--- a/docs/developer/homematicip_local_api_usage.md
+++ b/docs/developer/homematicip_local_api_usage.md
@@ -631,7 +631,7 @@ This analysis is based on:
 
 For breaking changes and migration guides, see:
 
-- [aiohomematic changelog](https://github.com/sukramj/aiohomematic/blob/devel/changelog.md)
+- [aiohomematic changelog](https://github.com/sukramj/aiohomematic/blob/main/changelog.md)
 - [Homematic(IP) Local releases](https://github.com/sukramj/homematicip_local/releases)
 
 ---

--- a/docs/developer/incident_system.md
+++ b/docs/developer/incident_system.md
@@ -427,4 +427,4 @@ Add the context schema to this document in the "Context Data Requirements" secti
 ## Related Documentation
 
 - [Architecture Overview](../architecture.md)
-- [Circuit Breaker Implementation](https://github.com/sukramj/aiohomematic/blob/devel/aiohomematic/client/circuit_breaker.py)
+- [Circuit Breaker Implementation](https://github.com/sukramj/aiohomematic/blob/main/aiohomematic/client/circuit_breaker.py)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -11,7 +11,7 @@ explicit interface configuration.
 > the [Glossary](reference/glossary.md).
 >
 > **Verified code:** a known-good, end-to-end working script lives at
-> [`example.py`](https://github.com/SukramJ/aiohomematic/blob/devel/example.py) in the repository
+> [`example.py`](https://github.com/SukramJ/aiohomematic/blob/main/example.py) in the repository
 > root. When the snippets below conflict with `example.py`, treat `example.py` as the source of
 > truth.
 

--- a/docs/user/troubleshooting/homeassistant_troubleshooting.de.md
+++ b/docs/user/troubleshooting/homeassistant_troubleshooting.de.md
@@ -523,7 +523,7 @@ Die Integration verwendet optimierte REGA-Skripte, um Gerätedaten gebündelt ab
 
 **Diagnoseschritte:**
 
-1. Das [REGA-Skript](https://github.com/sukramj/aiohomematic/blob/devel/aiohomematic/rega_scripts/fetch_all_device_data.fn) herunterladen
+1. Das [REGA-Skript](https://github.com/sukramj/aiohomematic/blob/main/aiohomematic/rega_scripts/fetch_all_device_data.fn) herunterladen
 2. `##interface##` (Zeile 17) durch die Schnittstelle aus der Fehlermeldung ersetzen (z.B. `HmIP-RF`)
 3. Das Skript in der CCU-Weboberfläche ausführen: **Settings** → **Control panel** → **Execute script**
 4. Prüfen, ob die Ausgabe gültiges JSON ist

--- a/docs/user/troubleshooting/homeassistant_troubleshooting.md
+++ b/docs/user/troubleshooting/homeassistant_troubleshooting.md
@@ -517,7 +517,7 @@ The integration uses optimized REGA scripts to fetch device data in bulk. If thi
 
 **Diagnostic steps:**
 
-1. Get the [REGA script](https://github.com/sukramj/aiohomematic/blob/devel/aiohomematic/rega_scripts/fetch_all_device_data.fn)
+1. Get the [REGA script](https://github.com/sukramj/aiohomematic/blob/main/aiohomematic/rega_scripts/fetch_all_device_data.fn)
 2. Replace `##interface##` (line 17) with the interface from the error message (e.g., `HmIP-RF`)
 3. Run the script in CCU web interface: **Settings** → **Control panel** → **Execute script**
 4. Check if the output is valid JSON

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: Modern async Python library for Homematic and HomematicIP devi
 site_url: https://sukramj.github.io/aiohomematic/
 repo_url: https://github.com/sukramj/aiohomematic
 repo_name: sukramj/aiohomematic
-edit_uri: edit/devel/docs/
+edit_uri: edit/main/docs/
 
 copyright: Copyright &copy; 2021-2026 aiohomematic contributors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ fast = ["orjson>=3.11.0"]
 "Homepage" = "https://github.com/sukramj/aiohomematic"
 "Source Code" = "https://github.com/sukramj/aiohomematic"
 "Bug Reports" = "https://github.com/sukramj/aiohomematic/issues"
-"Changelog" = "https://github.com/sukramj/aiohomematic/blob/devel/changelog.md"
+"Changelog" = "https://github.com/sukramj/aiohomematic/blob/main/changelog.md"
 "Documentation" = "https://sukramj.github.io/aiohomematic"
 "Forum" = "https://github.com/sukramj/aiohomematic/discussions"
 


### PR DESCRIPTION
## Summary

Retire the `devel` branch in favour of a single `main` branch and point all CI, tooling, and documentation at `main`.

## Changes

- **Workflows**: `codeql.yml`, `docs.yml`, `pre-commit.yml` now trigger on `main` (removed `devel`/`master` triggers)
- **Branch protection**: `.pre-commit-config.yaml` `no-commit-to-branch` now protects `main`
- **Tooling URLs**: `mkdocs.yml` `edit_uri` and `pyproject.toml` changelog link point to `main`
- **Docs**: contributor/agent guides (CLAUDE.md, AGENTS.md, CONTRIBUTING.md, copilot-instructions.md, git-workflow.md, release_process.md) updated; all `blob/devel/*` GitHub permalinks rewritten to `blob/main/*`

## Notes

- Historical `changelog.md` entries and Homematic `master`-paramset terminology were intentionally left untouched.
- The `devel` branch deletion is performed separately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)