### PR TITLE
chore(ci): harden CI supply chain and refresh dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,9 +39,10 @@ updates:
       prod-dependencies:
         patterns:
           - "aiohttp"
+          - "openccu-data"
           - "orjson"
+          - "pydantic"
           - "python-slugify"
-          - "voluptuous"
 
   # Update GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository_owner == 'SukramJ'
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v6.0.2
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c  # v6.0.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: "3"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -93,7 +93,7 @@ jobs:
           name: release-dists
           path: dist/
       - name: Publish to PyPI (Trusted Publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           packages-dir: dist/
 
@@ -184,7 +184,7 @@ jobs:
           fi
 
       - name: Create/Update Support Release and upload assets
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3
         with:
           tag_name: support-${{ env.TAG_NAME }}
           name: "AioHomematic Support ${{ env.TAG_NAME }}"
@@ -199,7 +199,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish support package to PyPI (OIDC Trusted Publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           packages-dir: aiohomematic_test_support/dist/
           skip-existing: true

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -81,7 +81,7 @@ jobs:
           sed -n '1,40p' RELEASE_NOTES.md >&2
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3
         with:
           tag_name: ${{ env.TAG_NAME }}
           name: ${{ env.TAG_NAME }}

--- a/.github/workflows/test-run.yaml
+++ b/.github/workflows/test-run.yaml
@@ -40,7 +40,7 @@ jobs:
           pytest tests/ -n auto --dist loadscope --asyncio-mode=legacy --cov=aiohomematic --cov-report=xml --cov-report=term-missing
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.14'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
         with:
           files: ./coverage.xml
           flags: unittests


### PR DESCRIPTION
## Summary

Supply-chain hardening and dependabot cleanup, following the repository-settings review.

## Changes

- **Pin third-party GitHub Actions to full commit SHA** (with version comment). Most important: `pypa/gh-action-pypi-publish` was using the **mutable** `@release/v1` branch ref in the publish workflow.
  - `pypa/gh-action-pypi-publish` → `cef2210` (release/v1)
  - `softprops/action-gh-release` → `718ea10` (v3)
  - `codecov/codecov-action` → `fb8b358` (v7)
  - `dessant/lock-threads` → `89ae32b` (v6.0.2)
- **Dependabot `prod-dependencies` group** now matches the actual runtime deps: dropped `voluptuous` (no longer a dependency), added `openccu-data` and `pydantic`; kept `orjson` (optional fast extra).

First-party `actions/*` and `github/codeql-action` remain on version tags; Dependabot keeps the pinned SHAs up to date.

## Applied separately (repo settings, not in this PR)

- Default workflow token permissions → read-only
- Secret scanning + push protection → enabled
- Auto-delete merged branches → enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)