### PR TITLE
fix(model): skip VALUES getValue fallback for VirtualDevices (#3228)

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.6.5"
+VERSION: Final = "2026.6.6"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/model/device.py
+++ b/aiohomematic/model/device.py
@@ -2012,6 +2012,15 @@ class _ValueCache:
             )
             return {}
         if dpk.paramset_key == ParamsetKey.VALUES:
+            # VirtualDevices (e.g. heating groups) have no physical device behind them;
+            # their VALUES are aggregated by the CCU. A getValue therefore cannot return
+            # device-fresh data, only the CCU-internal default (e.g. 0 for a not-yet-measured
+            # ACTUAL_TEMPERATURE right after a CCU restart). The bulk ReGa fetch already
+            # filters such placeholders via LastTimestamp and is the only trustworthy source
+            # for this interface, so skip the per-parameter getValue fallback. The data point
+            # keeps its (unset) state until a real value arrives via event (#3228).
+            if self._device.interface == Interface.VIRTUAL_DEVICES:
+                return {dpk.parameter: self._NO_VALUE_CACHE_ENTRY}
             return {
                 dpk.parameter: await self._device.client.get_value(
                     channel_address=dpk.channel_address,

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,23 @@
-# Version 2026.6.5 (2026-06-22)
+# Version 2026.6.6 (2026-06-23)
+
+## What's Changed
+
+### Fixed
+
+- **`VirtualDevices` no longer report an implausible `0` after a CCU restart via
+  the `getValue` fallback (#3228).** The previous attempts (`*_STATUS` load-path,
+  ReGa script v2.5) could not fix this case: a virtual heating group's
+  `ACTUAL_TEMPERATURE` is aggregated by the CCU and has **no physical device**
+  behind it, so the per-parameter `getValue` fallback can only ever return the
+  CCU-internal default (`0`) — and the CCU reports it with `*_STATUS = NORMAL`
+  (the status default), not `UNKNOWN`, so the status check never rejected it.
+  Because `getValue` cannot deliver a device-fresh value for an interface without
+  a backing device, the `VALUES` `getValue` fallback is now **skipped entirely for
+  `VirtualDevices`**. The bulk ReGa fetch — which already gates these data points
+  on a valid `LastTimestamp()` (v2.5) — becomes the single source of truth, and the
+  data point stays unavailable until a real reading arrives via event. Physical
+  interfaces are unaffected: there `getValue` can read the device, so the fallback
+  is retained.
 
 ## What's Changed
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,7 +8,7 @@ mypy==2.1.0
 pip==26.1.2
 prek==0.4.5
 pur==7.4.0
-pydevccu==0.2.4
+pydevccu==0.2.5
 pylint-per-file-ignores==3.2.1
 pylint-strict-informational==0.1
 pylint==4.0.6

--- a/tests/test_model_device.py
+++ b/tests/test_model_device.py
@@ -1307,6 +1307,56 @@ class TestValueCachePaths:
         # Restore availability.
         device.set_forced_availability(forced_availability=ForcedDeviceAvailability.NOT_SET)
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [({"VCU2128127"}, True, None, None)],
+    )
+    async def test_get_values_for_cache_skips_getvalue_for_virtual_devices(
+        self, central_client_factory_with_homegear_client, monkeypatch
+    ) -> None:
+        """
+        Skip the VALUES getValue fallback for VirtualDevices (#3228).
+
+        VirtualDevices (e.g. heating groups) have no physical device behind them, so a
+        getValue can only return the CCU-internal default (e.g. 0 for a not-yet-measured
+        ACTUAL_TEMPERATURE after a CCU restart) instead of a real reading. The bulk ReGa
+        fetch already filters such placeholders via LastTimestamp, so the getValue
+        fallback must not run for this interface.
+        """
+        central, _, _ = central_client_factory_with_homegear_client
+        device = central.device_coordinator.get_device(address="VCU2128127")
+
+        from aiohomematic.const import Interface, ParamsetKey
+
+        # Pretend this device lives on the VirtualDevices interface.
+        monkeypatch.setattr(device, "_interface", Interface.VIRTUAL_DEVICES)
+
+        values_dps = [dp for dp in device.generic_data_points if dp.paramset_key == ParamsetKey.VALUES]
+        assert values_dps
+        dpk = values_dps[0].dpk
+
+        backend_calls: list[int] = []
+        original_get_value = device.client.get_value
+
+        async def counting_get_value(**kw: Any) -> Any:
+            backend_calls.append(1)
+            return await original_get_value(**kw)
+
+        monkeypatch.setattr(device.client, "get_value", counting_get_value)
+
+        result = await device.value_cache._get_values_for_cache(dpk=dpk)  # type: ignore[attr-defined]
+
+        # No getValue fallback for VirtualDevices VALUES ...
+        assert backend_calls == []
+        # ... and a NO_VALUE marker is returned so the data point stays unavailable.
+        assert result == {dpk.parameter: device.value_cache._NO_VALUE_CACHE_ENTRY}  # type: ignore[attr-defined]
+
 
 class TestChannelRemoveAndLifecycle:
     """Tests for Channel.remove, _has_central_link exception, and on_config_changed notifications."""


### PR DESCRIPTION
## Problem

After a CCU restart, virtual heating groups (`VirtualDevices`, e.g. `INT0000001:1`) report `ACTUAL_TEMPERATURE = 0` instead of staying `unavailable`, corrupting HA long-term statistics. Closes the remaining part of #3228.

## Root cause

The v2.5 ReGa bulk script (#3236) already excludes data points without a valid `LastTimestamp()`. But on the resulting cache-miss, the per-parameter `getValue` fallback in `_ValueCache._get_values_for_cache` re-introduced the placeholder:

- **Physical device:** `getValue` faults (`-5 Unknown Parameter value`) → nothing written → stays unavailable. ✅
- **VirtualDevice (heating group):** `getValue` returns the CCU-internal default `0` (no fault) → `0` written. ❌

A heating group has **no physical device** behind it — `ACTUAL_TEMPERATURE` is aggregated by the CCU — so `getValue` can never deliver a device-fresh reading there, only the default. The CCU reports it with `*_STATUS = NORMAL` (the status default, not `UNKNOWN`), so the earlier `*_STATUS`-based guard (2026.6.4/.5) never triggered. Confirmed in two users' debug logs.

## Fix

Skip the `VALUES` `getValue` fallback entirely for `Interface.VIRTUAL_DEVICES` and return the `NO_VALUE` marker, so the data point stays unavailable until a real value arrives via event. The bulk ReGa fetch (gated on `LastTimestamp()`) is the single source of truth for this interface. Physical interfaces are unaffected — there `getValue` can read the device, so the fallback is retained.

## Tests

- New reproducer `TestValueCachePaths::test_get_values_for_cache_skips_getvalue_for_virtual_devices` — red before the fix (getValue called), green after.
- `tests/test_model_device.py`, `tests/test_model_data_point.py`, `tests/contract/` green (1246 passed). ruff + mypy clean.

> Note: `test_central_pydevccu.py::test_central_full` fails with `397 == 399` in my environment, but it fails identically on a clean checkout (verified by stashing this change) — a pre-existing pydevccu-version/device-count issue, unrelated to this PR.