### PR TITLE
fix(model): roll back optimistic values immediately on collector send error (#3238)

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.6.6"
+VERSION: Final = "2026.6.7"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/model/data_point.py
+++ b/aiohomematic/model/data_point.py
@@ -1199,6 +1199,59 @@ class BaseParameterDataPoint[
         if self.is_readable and self._paramset_key == ParamsetKey.MASTER:
             await self.load_data_point_value(call_source=CallSource.MANUAL_OR_SCHEDULED, direct_call=True)
 
+    def rollback_optimistic_value(self, *, reason: str, error: str | None = None) -> None:
+        """
+        Rollback optimistic value to previous confirmed value.
+
+        Args:
+            reason: Reason for rollback (e.g., "timeout", "send_error", "mismatch")
+            error: Error message (if reason is send_error)
+
+        This method:
+        1. Logs the rollback with details
+        2. Clears optimistic state
+        3. Restores previous confirmed value
+        4. Publishes data_point_updated event (UI reverts)
+        5. Publishes rollback event for user notification (Step 1.7)
+
+        """
+        if not self._optimistic.is_active:
+            return  # Already rolled back or confirmed
+
+        # Log rollback with age
+        age = self._optimistic.age or 0.0
+        _LOGGER.warning(
+            i18n.tr(
+                key="log.model.data_point.optimistic_rollback",
+                full_name=self.full_name,
+                optimistic_value=self._optimistic.value,
+                previous_value=self._optimistic.previous_value,
+                reason=reason,
+                age=age,
+            )
+        )
+
+        # Rollback optimistic state
+        rolled_back_value, restored_value = self._optimistic.rollback()
+
+        # Clear unconfirmed value so it cannot override the restored value
+        self._reset_unconfirmed_value()
+
+        # Restore previous value
+        self._current_value = restored_value
+
+        # Publish event (Home Assistant UI reverts)
+        self.publish_data_point_updated_event()
+
+        # Publish rollback event for user notification
+        self._publish_rollback_event(
+            reason=reason,
+            rolled_back_value=rolled_back_value,
+            restored_value=restored_value,
+            error=error,
+            age_seconds=age,
+        )
+
     def set_last_non_default_value(self, *, value: ParameterT | None) -> None:
         """Set the last non default value."""
         self._last_non_default_value = value
@@ -1539,59 +1592,6 @@ class BaseParameterDataPoint[
         self._unconfirmed_value = None
         self._reset_unconfirmed_timestamps()
 
-    def _rollback_optimistic_value(self, *, reason: str, error: str | None = None) -> None:
-        """
-        Rollback optimistic value to previous confirmed value.
-
-        Args:
-            reason: Reason for rollback (e.g., "timeout", "send_error", "mismatch")
-            error: Error message (if reason is send_error)
-
-        This method:
-        1. Logs the rollback with details
-        2. Clears optimistic state
-        3. Restores previous confirmed value
-        4. Publishes data_point_updated event (UI reverts)
-        5. Publishes rollback event for user notification (Step 1.7)
-
-        """
-        if not self._optimistic.is_active:
-            return  # Already rolled back or confirmed
-
-        # Log rollback with age
-        age = self._optimistic.age or 0.0
-        _LOGGER.warning(
-            i18n.tr(
-                key="log.model.data_point.optimistic_rollback",
-                full_name=self.full_name,
-                optimistic_value=self._optimistic.value,
-                previous_value=self._optimistic.previous_value,
-                reason=reason,
-                age=age,
-            )
-        )
-
-        # Rollback optimistic state
-        rolled_back_value, restored_value = self._optimistic.rollback()
-
-        # Clear unconfirmed value so it cannot override the restored value
-        self._reset_unconfirmed_value()
-
-        # Restore previous value
-        self._current_value = restored_value
-
-        # Publish event (Home Assistant UI reverts)
-        self.publish_data_point_updated_event()
-
-        # Publish rollback event for user notification
-        self._publish_rollback_event(
-            reason=reason,
-            rolled_back_value=rolled_back_value,
-            restored_value=restored_value,
-            error=error,
-            age_seconds=age,
-        )
-
     def _schedule_optimistic_rollback(self, *, timeout: float) -> None:
         """
         Schedule rollback if CCU confirmation doesn't arrive.
@@ -1607,7 +1607,7 @@ class BaseParameterDataPoint[
         """
         self._optimistic.schedule_rollback(
             timeout=timeout,
-            callback=partial(self._rollback_optimistic_value, reason="timeout", error=None),
+            callback=partial(self.rollback_optimistic_value, reason="timeout", error=None),
         )
 
     def _set_value(self, value: ParameterT) -> None:  # kwonly: disable
@@ -1720,6 +1720,19 @@ class CallParameterCollector:
                     )
         return dpk_values
 
+    def _rollback_optimistic_for_paramset(
+        self,
+        *,
+        channel_address: str,
+        paramset_key: ParamsetKey,
+        paramset: dict[str, Any],
+        error: str,
+    ) -> None:
+        """Roll back optimistic values for the data points contained in a failed paramset send."""
+        for dp, _value, _retry in self._collected_data_points:
+            if dp.channel.address == channel_address and dp.paramset_key == paramset_key and dp.parameter in paramset:
+                dp.rollback_optimistic_value(reason="send_error", error=error)
+
     async def _send_paramset(
         self,
         *,
@@ -1732,9 +1745,20 @@ class CallParameterCollector:
         retry: bool = True,
     ) -> set[DP_KEY_VALUE]:
         """Send a single paramset via set_value or put_paramset."""
-        if len(paramset) == 1:
-            parameter, value = next(iter(paramset.items()))
-            if purge_addresses:
+        try:
+            if len(paramset) == 1:
+                parameter, value = next(iter(paramset.items()))
+                if purge_addresses:
+                    return await self._client.set_value(
+                        channel_address=channel_address,
+                        paramset_key=paramset_key,
+                        parameter=parameter,
+                        value=value,
+                        wait_for_callback=wait_for_callback,
+                        priority=priority,
+                        purge_addresses=purge_addresses,
+                        retry=retry,
+                    )
                 return await self._client.set_value(
                     channel_address=channel_address,
                     paramset_key=paramset_key,
@@ -1742,36 +1766,37 @@ class CallParameterCollector:
                     value=value,
                     wait_for_callback=wait_for_callback,
                     priority=priority,
+                    retry=retry,
+                )
+            if purge_addresses:
+                return await self._client.put_paramset(
+                    channel_address=channel_address,
+                    paramset_key_or_link_address=paramset_key,
+                    values=paramset,
+                    wait_for_callback=wait_for_callback,
+                    priority=priority,
                     purge_addresses=purge_addresses,
                     retry=retry,
                 )
-            return await self._client.set_value(
-                channel_address=channel_address,
-                paramset_key=paramset_key,
-                parameter=parameter,
-                value=value,
-                wait_for_callback=wait_for_callback,
-                priority=priority,
-                retry=retry,
-            )
-        if purge_addresses:
             return await self._client.put_paramset(
                 channel_address=channel_address,
                 paramset_key_or_link_address=paramset_key,
                 values=paramset,
                 wait_for_callback=wait_for_callback,
                 priority=priority,
-                purge_addresses=purge_addresses,
                 retry=retry,
             )
-        return await self._client.put_paramset(
-            channel_address=channel_address,
-            paramset_key_or_link_address=paramset_key,
-            values=paramset,
-            wait_for_callback=wait_for_callback,
-            priority=priority,
-            retry=retry,
-        )
+        except Exception as err:
+            # Roll back optimistic values immediately on send error (after all retries
+            # are exhausted). Mirrors the direct-send path in GenericDataPoint.send_value;
+            # without this the optimistic value would linger until the 30s timeout (#3238).
+            self._rollback_optimistic_for_paramset(
+                channel_address=channel_address,
+                paramset_key=paramset_key,
+                paramset=paramset,
+                error=str(err),
+            )
+            raise
 
 
 @overload

--- a/aiohomematic/model/generic/data_point.py
+++ b/aiohomematic/model/generic/data_point.py
@@ -222,7 +222,7 @@ class GenericDataPoint[ParameterT: ParamType, InputParameterT: ParamType](
             )
         except Exception as err:
             # Immediate rollback on send error (after ALL retries exhausted)
-            self._rollback_optimistic_value(reason="send_error", error=str(err))
+            self.rollback_optimistic_value(reason="send_error", error=str(err))
             raise
 
     def _get_data_point_name(self) -> DataPointNameData:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,22 @@
+# Version 2026.6.7 (2026-06-23)
+
+## What's Changed
+
+### Fixed
+
+- **A failed collector send now rolls back optimistic values immediately instead of
+  after the 30 s timeout (#3238).** The direct-send path in
+  `GenericDataPoint.send_value()` already rolled back the optimistic value when the
+  backend `set_value` raised (e.g. an XML-RPC `RESPONSE_NAK` after all retries were
+  exhausted), but the collector path (`CallParameterCollector.send_data()`) did not.
+  As a result, a write the CCU rejected left the optimistic value active for the full
+  `optimistic_update_timeout` (30 s), so the entity kept displaying the value that
+  never reached the device until the timeout rollback fired. `_send_paramset` now
+  mirrors the direct-send path: on a send error it immediately rolls back the
+  optimistic values of the data points contained in the failed paramset
+  (`reason=send_error`). The rollback entry point `_rollback_optimistic_value` was
+  promoted to the public `rollback_optimistic_value` so the collector can invoke it.
+
 # Version 2026.6.6 (2026-06-23)
 
 ## What's Changed

--- a/tests/contract/test_optimistic_updates_contract.py
+++ b/tests/contract/test_optimistic_updates_contract.py
@@ -165,8 +165,8 @@ class TestDataPointOptimisticAPIContract:
 
         Used to clear optimistic state.
         """
-        assert hasattr(BaseParameterDataPoint, "_rollback_optimistic_value"), (
-            "BaseParameterDataPoint must have _rollback_optimistic_value method"
+        assert hasattr(BaseParameterDataPoint, "rollback_optimistic_value"), (
+            "BaseParameterDataPoint must have rollback_optimistic_value method"
         )
 
     def test_data_point_has_schedule_rollback_method(self) -> None:

--- a/tests/test_optimistic_updates.py
+++ b/tests/test_optimistic_updates.py
@@ -1,14 +1,17 @@
 """Tests for optimistic update system."""
 
+import asyncio
 from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from aiohomematic.central.events import OptimisticRollbackEvent
 from aiohomematic.client import CommandPriority
 from aiohomematic.client.backends.capabilities import BackendCapabilities
 from aiohomematic.const import RollbackReason
-from aiohomematic.model.data_point import BaseParameterDataPoint
+from aiohomematic.exceptions import ClientException
+from aiohomematic.model.data_point import BaseParameterDataPoint, CallParameterCollector
 from aiohomematic.model.generic import DpSwitch
 
 TEST_DEVICES: set[str] = {"VCU2128127", "VCU3609622"}
@@ -94,7 +97,7 @@ class TestOptimisticRollback:
 
     def test_rollback_method_exists(self) -> None:
         """Test that rollback method exists."""
-        assert hasattr(BaseParameterDataPoint, "_rollback_optimistic_value")
+        assert hasattr(BaseParameterDataPoint, "rollback_optimistic_value")
 
     def test_schedule_rollback_method_exists(self) -> None:
         """Test that schedule rollback method exists."""
@@ -321,6 +324,68 @@ class TestNoRpcCallbackSkipsOptimistic:
 
         # Optimistic state should be active
         assert switch.is_optimistic is True
+
+
+class TestCollectorSendErrorRollback:
+    """Test that a failed collector send rolls back optimistic values immediately (issue #3238)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_collector_send_error_rolls_back_optimistic_immediately(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """
+        A failing set_value during collector.send_data() must roll back immediately.
+
+        The direct-send path in send_value() already rolls back on send error, but the
+        collector path (CallParameterCollector.send_data) did not. Without rollback the
+        optimistic value stayed active until the 30s timeout fired (issue #3238).
+        """
+        central, mock_client, _ = central_client_factory_with_homegear_client
+        switch: DpSwitch = cast(
+            DpSwitch,
+            central.query_facade.get_generic_data_point(channel_address="VCU2128127:4", parameter="STATE"),
+        )
+
+        rollback_events: list[OptimisticRollbackEvent] = []
+
+        def _on_rollback(*, event: OptimisticRollbackEvent) -> None:
+            rollback_events.append(event)
+
+        unsub = central.event_bus.subscribe(event_type=OptimisticRollbackEvent, event_key=None, handler=_on_rollback)
+
+        # Make the backend set_value fail (simulates RESPONSE_NAK after retries).
+        mock_client.set_value.side_effect = ClientException("RESPONSE_NAK")
+
+        collector = CallParameterCollector(client=switch.channel.device.client)
+        collector.add_data_point(data_point=switch, value=True, collector_order=50)
+
+        try:
+            with pytest.raises(ClientException):
+                await collector.send_data(wait_for_callback=None)
+
+            # Optimistic value must be rolled back immediately (not waiting for the 30s timeout).
+            assert switch.is_optimistic is False
+
+            # Allow the fire-and-forget OptimisticRollbackEvent publish task to run.
+            await asyncio.sleep(0.05)
+            assert any(str(event.reason) == str(RollbackReason.SEND_ERROR) for event in rollback_events), (
+                f"expected a send_error rollback event, got {[str(e.reason) for e in rollback_events]}"
+            )
+        finally:
+            unsub()
+            mock_client.set_value.side_effect = None
 
 
 class TestPriorityAndOptimisticIntegration:


### PR DESCRIPTION
## Summary

Fixes the log-confirmed defect behind #3238: a write the CCU rejects leaves the entity displaying a value that never reached the device for the full 30s `optimistic_update_timeout`, instead of reverting immediately.

The direct-send path in `GenericDataPoint.send_value()` already rolled back the optimistic value when the backend `set_value` raised (e.g. an XML-RPC `RESPONSE_NAK` after all retries were exhausted), but the **collector path** (`CallParameterCollector.send_data`) did not. So a failed `setValue` lingered until the timeout rollback (`reason=timeout`) fired ~30s later.

## Changes

- `model/data_point.py`: `_send_paramset` now wraps the wire call in `try/except`; on a send error it immediately rolls back the optimistic values of the data points contained in the **failed paramset** (`reason=send_error`), mirroring the direct-send path. The rollback entry point `_rollback_optimistic_value` was promoted to the public `rollback_optimistic_value` so the collector can invoke it.
- `model/generic/data_point.py`: direct-send path updated to the new method name.
- `tests/test_optimistic_updates.py`: new test-first reproducer `TestCollectorSendErrorRollback` (failed before the fix, passes now); contract name updated.
- `tests/contract/test_optimistic_updates_contract.py`: contract name updated.
- `changelog.md` (`2026.6.7`) + `aiohomematic/const.py:VERSION` kept in sync.

## Scope / notes

- Per-paramset rollback (not a blanket rollback of all staged DPs), so a multi-channel batch does not over-roll already-successful paramsets. The reported single-paramset case (HmIP-FWI `CODE_ID`) is fully covered.
- The later user-reported "31 never reaches HA" symptom is **not** addressed here — it could not be verified with the available logs (in the only HA log, the idle event reached HA correctly; the HA integration ignores `old/new` and always re-renders). That would need a DEBUG log of the specific episode.

## Verification

- `pytest tests/test_optimistic_updates.py tests/contract/` + custom-device suites green (1265+ tests).
- `prek run` clean.