### PR TITLE
fix(model): widen HmIP-FWI CODE_ID MAX to 31 so idle value reaches HA (#3238)

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.6.7"
+VERSION: Final = "2026.6.8"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (
@@ -1268,6 +1268,7 @@ class Parameter(StrEnum):
     CHANNEL_COLOR = "CHANNEL_COLOR"
     CHANNEL_LOCK = "CHANNEL_LOCK"
     CHANNEL_OPERATION_MODE = "CHANNEL_OPERATION_MODE"
+    CODE_ID = "CODE_ID"
     COLOR = "COLOR"
     COLOR_BEHAVIOUR = "COLOR_BEHAVIOUR"
     COLOR_TEMPERATURE = "COLOR_TEMPERATURE"

--- a/aiohomematic/store/patches/paramset_patches.py
+++ b/aiohomematic/store/patches/paramset_patches.py
@@ -84,6 +84,22 @@ PARAMSET_PATCHES: Final[tuple[ParamsetPatch, ...]] = (
         ticket=None,
     ),
     # -------------------------------------------------------------------------
+    # HmIP-FWI: Fingerprint reader
+    # -------------------------------------------------------------------------
+    # The CCU declares MAX=21 for CODE_ID, but the device reports CODE_ID=31 in
+    # idle/standby (5-bit field, 31 = no active code). The too-low MAX dropped
+    # the idle value at the HA number entity, so number.*_code_id never returned
+    # to 31 after a recognized code. Widen MAX to 31; MIN stays at 1.
+    ParamsetPatch(
+        device_type="HmIP-FWI",
+        channel_no=0,
+        paramset_key=ParamsetKey.VALUES,
+        parameter=Parameter.CODE_ID,
+        patches={"MAX": 31},
+        reason="CCU declares MAX=21 but device reports idle CODE_ID=31",
+        ticket="#3238",
+    ),
+    # -------------------------------------------------------------------------
     # Add more patches below as needed
     # -------------------------------------------------------------------------
 )

--- a/aiohomematic/store/persistent/paramset.py
+++ b/aiohomematic/store/persistent/paramset.py
@@ -53,7 +53,8 @@ class ParamsetDescriptionRegistry(
     #   1: Initial schema
     #   2: Normalized OPERATIONS and FLAGS to integers
     #   3: Added paramset patching system for device-specific corrections
-    SCHEMA_VERSION: int = 3
+    #   4: Added HmIP-FWI CODE_ID MAX patch (#3238)
+    SCHEMA_VERSION: int = 4
 
     __slots__ = ("_address_parameter_cache",)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,19 @@
+# Version 2026.6.8 (2026-06-24)
+
+## What's Changed
+
+### Fixed
+
+- **`HmIP-FWI` `CODE_ID` no longer drops the idle value 31 (#3238).** The CCU declares
+  `MAX=21` for the fingerprint reader's `CODE_ID`, but the device reports `CODE_ID=31`
+  in idle/standby. The too-low maximum dropped the idle value at the Home Assistant
+  `number` entity, so `number.*_code_id` kept the last recognized code (e.g. 21) and
+  never returned to 31, while the sibling `sensor.*_code_state` updated correctly.
+  A paramset patch now widens `CODE_ID` `MAX` to 31 for `HmIP-FWI`. This fixes the
+  event-driven flow (device-reported codes); it is unrelated to the optimistic
+  send/rollback path addressed in 2026.6.7. The paramset cache schema version was
+  bumped to 4 so the corrected bounds are rebuilt from the CCU.
+
 # Version 2026.6.7 (2026-06-23)
 
 ## What's Changed

--- a/tests/test_paramset_patches.py
+++ b/tests/test_paramset_patches.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""Tests for the paramset description patching system."""
+
+from __future__ import annotations
+
+from aiohomematic.const import Parameter, ParameterData, ParameterType, ParamsetKey
+from aiohomematic.store import PARAMSET_PATCHES, ParamsetPatchMatcher
+
+
+def test_hm_cc_vg_1_set_temperature_bounds_patched() -> None:
+    """The HM-CC-VG-1 SET_TEMPERATURE MIN/MAX bounds are corrected."""
+    matcher = ParamsetPatchMatcher(device_type="HM-CC-VG-1")
+    assert matcher.has_patches is True
+
+    paramset: dict[str, ParameterData] = {
+        Parameter.SET_TEMPERATURE: ParameterData(TYPE=ParameterType.FLOAT, MIN=0.0, MAX=0.0, DEFAULT=0.0)
+    }
+    patched = matcher.apply_patches(
+        channel_address="VCU0000001:1",
+        paramset_key=ParamsetKey.VALUES,
+        paramset_description=paramset,
+    )
+    assert patched[Parameter.SET_TEMPERATURE]["MIN"] == 4.5
+    assert patched[Parameter.SET_TEMPERATURE]["MAX"] == 30.5
+
+
+def test_hmip_fwi_code_id_max_patched() -> None:
+    """
+    The HmIP-FWI CODE_ID MAX is widened to the device idle value 31 (#3238).
+
+    The CCU declares MAX=21, but the fingerprint reader reports CODE_ID=31 in
+    idle/standby. The too-low MAX dropped the idle value at the HA number
+    entity, so number.*_code_id never returned to 31.
+    """
+    matcher = ParamsetPatchMatcher(device_type="HmIP-FWI")
+    assert matcher.has_patches is True
+
+    paramset: dict[str, ParameterData] = {
+        Parameter.CODE_ID: ParameterData(TYPE=ParameterType.INTEGER, MIN=1, MAX=21, DEFAULT=1)
+    }
+    patched = matcher.apply_patches(
+        channel_address="VCU4820995:0",
+        paramset_key=ParamsetKey.VALUES,
+        paramset_description=paramset,
+    )
+    assert patched[Parameter.CODE_ID]["MAX"] == 31
+    # MIN stays untouched.
+    assert patched[Parameter.CODE_ID]["MIN"] == 1
+
+
+def test_hmip_fwi_code_id_patch_is_registered() -> None:
+    """The HmIP-FWI CODE_ID patch is present in the central registry."""
+    assert any(
+        p.device_type == "HmIP-FWI"
+        and p.parameter == Parameter.CODE_ID
+        and p.channel_no == 0
+        and p.paramset_key == ParamsetKey.VALUES
+        and p.patches.get("MAX") == 31
+        for p in PARAMSET_PATCHES
+    )


### PR DESCRIPTION
## Problem

`number.*_code_id` for the `HmIP-FWI` fingerprint reader keeps the last recognized code (e.g. 21) and never returns to the idle value 31, while `sensor.*_code_state` updates correctly (#3238).

## Root cause

The fresh debug log for #3238 (2.8.0b7) shows the `CODE_ID` 21→31 values arriving **purely as XML-RPC device events** — there is no `setValue`, no optimistic write, no rollback. So this is **unrelated** to the optimistic send/rollback path fixed in 2026.6.7 (#3245).

The CCU declares `MIN=1, MAX=21` for `CODE_ID`, but the device reports `CODE_ID=31` in idle/standby (5-bit field, 31 = no active code). The model writes 31 correctly, but `MAX=21` is propagated to Home Assistant as `native_max_value`, so the `number` entity drops the out-of-range idle value. The sibling `sensor` (no bounds) updates fine.

Evidence from the log:
```
08:03:44.104  EVENT ... parameter = CODE_ID, value = 31
08:03:44.107  WRITE_VALUE: Value 31 above maximum 21 for .../002BDD89B07897:0/CODE_ID
```

## Fix

Use the paramset-patch mechanism (`aiohomematic/store/patches/`) — built exactly for "CCU returns wrong MIN/MAX":

- Add a `ParamsetPatch` for `HmIP-FWI` / channel 0 / `VALUES` / `CODE_ID` widening `MAX` to 31 (MIN stays 1).
- Add `Parameter.CODE_ID` to the enum.
- Bump `ParamsetDescriptionRegistry.SCHEMA_VERSION` 3 → 4 so corrected bounds are rebuilt from the CCU.
- Add `tests/test_paramset_patches.py` (registry + matcher tests, test-first).
- Bump `VERSION` 2026.6.7 → 2026.6.8 + changelog.

## Verification

- `tests/test_paramset_patches.py` ✓
- `tests/contract/` (1207) ✓
- `tests/test_central_full_session.py` (9 min) ✓
- mypy / pylint / ruff / all prek hooks ✓

Closes #3238