### PR TITLE
fix(model): exclude actuator data points from climate validity (#3255)

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.6.8"
+VERSION: Final = "2026.6.9"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/model/custom/climate.py
+++ b/aiohomematic/model/custom/climate.py
@@ -25,7 +25,7 @@ from aiohomematic.const import (
 )
 from aiohomematic.decorators import inspector
 from aiohomematic.exceptions import ValidationException
-from aiohomematic.interfaces import ChannelProtocol
+from aiohomematic.interfaces import ChannelProtocol, GenericDataPointProtocolAny
 from aiohomematic.model.custom.capabilities.climate import (
     BASIC_CLIMATE_CAPABILITIES,
     IP_THERMOSTAT_CAPABILITIES,
@@ -207,6 +207,28 @@ class BaseCustomDpClimate(CustomDataPoint):
     current_humidity: Final = DelegatedProperty[int | None](path="_dp_humidity.value", kind=Kind.STATE)
     current_temperature: Final = DelegatedProperty[float | None](path="_dp_temperature.value", kind=Kind.STATE)
     target_temperature: Final = DelegatedProperty[float | None](path="_dp_setpoint.value", kind=Kind.STATE)
+
+    @property
+    def _validity_irrelevant_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
+        """
+        Return readable data points that must not affect climate validity (#3255).
+
+        Actuator/activity values (``LEVEL``, ``STATE``, ``VALVE_STATE``) are not reported by
+        the CCU for heating groups (``HmIP-HEATING`` on the VirtualDevices interface), and since
+        the #3228 fixes the ``getValue`` fallback no longer fills them with a placeholder. Left
+        in the validity set they would keep ``is_refreshed``/``is_valid`` false forever, freezing
+        ``current_temperature``/``current_humidity`` (``value_state=restored``) while the sibling
+        sensors keep updating. Subclasses list their actuator data points here.
+        """
+        return ()
+
+    @property
+    @override
+    def _relevant_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
+        """Return readable data points relevant for validity, excluding actuator values (#3255)."""
+        if not (irrelevant := self._validity_irrelevant_data_points):
+            return self._readable_data_points
+        return tuple(dp for dp in self._readable_data_points if dp not in irrelevant)
 
     @property
     def _temperature_for_heat_mode(self) -> float:
@@ -483,6 +505,12 @@ class CustomDpRfThermostat(BaseCustomDpClimate):
 
         return profiles
 
+    @property
+    @override
+    def _validity_irrelevant_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
+        """Exclude the VALVE_STATE actuator readback from validity checks (#3255)."""
+        return (self._dp_valve_state,)
+
     @config_property
     def schedule_profile_nos(self) -> int:
         """Return the number of supported profiles."""
@@ -690,6 +718,12 @@ class CustomDpIpThermostat(BaseCustomDpClimate):
                 profiles[ClimateProfile(f"{PROFILE_PREFIX}{i}")] = i
 
         return profiles
+
+    @property
+    @override
+    def _validity_irrelevant_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
+        """Exclude the LEVEL/STATE actuator values from validity checks (#3255)."""
+        return (self._dp_level, self._dp_state)
 
     @config_property
     def schedule_profile_nos(self) -> int:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,23 @@
+# Version 2026.6.9 (2026-06-30)
+
+## What's Changed
+
+### Fixed
+
+- **Heating-group `climate` no longer freezes `current_temperature`/`current_humidity`
+  (#3255).** For `HmIP-HEATING` groups (VirtualDevices interface) the CCU never sends
+  events for the actuator values `LEVEL`/`STATE`/`VALVE_STATE`, and since the #3228
+  fixes the `getValue` fallback returns `NO_VALUE` for VirtualDevices. Those readable
+  data points therefore stayed unrefreshed forever and dragged the whole custom climate
+  data point to `is_valid=False`, so Home Assistant kept the climate entity in
+  `value_state=restored` and froze `current_temperature`/`current_humidity` at the value
+  loaded on the last (re)start — while the sibling `sensor.*` entities (gated on their own
+  data point) kept updating. The climate validity check now ignores these actuator/activity
+  data points: `BaseCustomDpClimate` exposes a `_validity_irrelevant_data_points` hook,
+  with `CustomDpIpThermostat` excluding `LEVEL`/`STATE` and `CustomDpRfThermostat`
+  excluding `VALVE_STATE`. The values themselves are unaffected (they still arrive via
+  events when the CCU sends them); only the validity/`value_state` gating changes.
+
 # Version 2026.6.8 (2026-06-24)
 
 ## What's Changed

--- a/tests/test_model_climate.py
+++ b/tests/test_model_climate.py
@@ -2608,3 +2608,79 @@ class TestClimateSimpleScheduleMethods:
             )
             assert isinstance(checked_values["P1_TEMPERATURE_MONDAY_2"], float)
             assert checked_values["P1_TEMPERATURE_MONDAY_2"] == 21.0
+
+
+class TestClimateValidityIrrelevantDataPoints:
+    """
+    #3255: actuator/activity data points must not block climate validity.
+
+    Heating groups (``HmIP-HEATING`` on the VirtualDevices interface) never receive
+    events for actuator values like ``LEVEL``/``STATE``/``VALVE_STATE``, and since the
+    #3228 fixes the ``getValue`` fallback returns ``NO_VALUE`` for VirtualDevices. Those
+    data points would otherwise stay unrefreshed forever and invalidate the whole climate
+    (frozen ``current_temperature``, ``value_state=restored``), while the sibling sensors
+    keep updating. They are therefore excluded from the validity-relevant data points.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_ip_thermostat_level_excluded_from_validity(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """LEVEL/STATE must not block is_valid for an IP thermostat (#3255)."""
+        central, _mock_client, _ = central_client_factory_with_homegear_client
+        climate = cast(CustomDpIpThermostat, get_prepared_custom_data_point(central, "VCU3609622", 1))
+        # Precondition: LEVEL is a real, readable data point on this device.
+        assert climate._dp_level.is_readable
+        # LEVEL/STATE must be excluded from the validity-relevant data points.
+        assert climate._dp_level not in climate._relevant_data_points
+        assert climate._dp_state not in climate._relevant_data_points
+        # Simulate a heating group: every value arrives via event EXCEPT the actuator
+        # values LEVEL/STATE, which the CCU never reports for groups.
+        excluded = (climate._dp_level, climate._dp_state)
+        for dp in climate._readable_data_points:
+            if dp not in excluded:
+                dp._set_refreshed_at(refreshed_at=datetime.now())
+        assert climate._dp_level.is_refreshed is False
+        # The climate must be valid even though LEVEL/STATE never refreshed.
+        assert climate.is_valid is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_rf_thermostat_valve_state_excluded_from_validity(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """VALVE_STATE must not block is_valid for an RF thermostat (#3255)."""
+        central, _mock_client, _ = central_client_factory_with_homegear_client
+        climate = cast(CustomDpRfThermostat, get_prepared_custom_data_point(central, "VCU0000050", 4))
+        # Precondition: VALVE_STATE is a real, readable data point on this device.
+        assert climate._dp_valve_state.is_readable
+        assert climate._dp_valve_state not in climate._relevant_data_points
+        excluded = (climate._dp_valve_state,)
+        for dp in climate._readable_data_points:
+            if dp not in excluded:
+                dp._set_refreshed_at(refreshed_at=datetime.now())
+        assert climate._dp_valve_state.is_refreshed is False
+        assert climate.is_valid is True


### PR DESCRIPTION
## Problem (#3255)

For `HmIP-HEATING` heating groups (VirtualDevices interface) the `climate` entity froze
`current_temperature`/`current_humidity` (HA `value_state: restored`) at the value loaded on
the last (re)start, while the sibling `sensor.*` entities kept updating live.

Verified from a 7.5 h DEBUG log: the CCU **does** send regular `ACTUAL_TEMPERATURE`/`HUMIDITY`
events for the group, and they are written correctly (sensor = `valid`/27.5 °C). The climate,
however, was `restored`/29.6 °C.

## Root cause

`CustomDataPoint.is_valid` is an AND over **all** readable child data points
(`_relevant_data_points`). Heating groups never receive events for the actuator values
`LEVEL`/`STATE`/`VALVE_STATE`, and since #3228 the `getValue` fallback returns `NO_VALUE`
for VirtualDevices — so those DPs stay `is_refreshed=False` forever and force
`custom.is_valid=False`. The HA `climate` platform gates `current_temperature`/`current_humidity`
on `custom.is_valid`, hence the frozen `value_state: restored`. The generic sensor gates on its
own DP only, so it keeps updating.

## Fix

`BaseCustomDpClimate` exposes a `_validity_irrelevant_data_points` hook and overrides
`_relevant_data_points` to exclude it:
- `CustomDpIpThermostat` excludes `LEVEL`/`STATE`
- `CustomDpRfThermostat` excludes `VALVE_STATE`

Same established pattern as the `_relevant_data_points` overrides in `cover.py`/`light.py`.
The values themselves are unaffected (they still arrive via events when the CCU sends them);
only the validity / `value_state` gating changes.

## Tests

`tests/test_model_climate.py::TestClimateValidityIrrelevantDataPoints` — two reproducers
(IP thermostat `LEVEL`/`STATE`, RF thermostat `VALVE_STATE`): red before the fix, green after.

- climate suite: 30 passed · contract: 1204 passed · cover/light: 19 passed
- ruff / ruff format / mypy / pylint: clean
- Changelog `2026.6.9` + `const.py:VERSION` in sync

Fixes #3255.