### PR TITLE
fix(model): disable getValue fallback for BidCos-RF (#3260)

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.6.9"
+VERSION: Final = "2026.7.1"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/model/device.py
+++ b/aiohomematic/model/device.py
@@ -2012,14 +2012,19 @@ class _ValueCache:
             )
             return {}
         if dpk.paramset_key == ParamsetKey.VALUES:
-            # VirtualDevices (e.g. heating groups) have no physical device behind them;
-            # their VALUES are aggregated by the CCU. A getValue therefore cannot return
-            # device-fresh data, only the CCU-internal default (e.g. 0 for a not-yet-measured
-            # ACTUAL_TEMPERATURE right after a CCU restart). The bulk ReGa fetch already
-            # filters such placeholders via LastTimestamp and is the only trustworthy source
-            # for this interface, so skip the per-parameter getValue fallback. The data point
-            # keeps its (unset) state until a real value arrives via event (#3228).
-            if self._device.interface == Interface.VIRTUAL_DEVICES:
+            # For some interfaces a per-parameter getValue during init cannot return
+            # device-fresh data, only a CCU-internal placeholder that would be marked as
+            # valid and thereby mask an actually uncertain state:
+            #   - VirtualDevices (e.g. heating groups) have no physical device behind them;
+            #     their VALUES are aggregated by the CCU (e.g. 0 for a not-yet-measured
+            #     ACTUAL_TEMPERATURE right after a CCU restart).
+            #   - BidCos-RF hosts passive/battery devices that cannot be actively queried;
+            #     getValue then returns the paramset default instead of a real reading.
+            # The bulk ReGa fetch already filters such placeholders via LastTimestamp and is
+            # the only trustworthy source for these interfaces, so skip the per-parameter
+            # getValue fallback. The data point keeps its (unset) state until a real value
+            # arrives via event (#3228, #3260).
+            if self._device.interface in (Interface.VIRTUAL_DEVICES, Interface.BIDCOS_RF):
                 return {dpk.parameter: self._NO_VALUE_CACHE_ENTRY}
             return {
                 dpk.parameter: await self._device.client.get_value(

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+# Version 2026.7.1 (2026-07-03)
+
+## What's Changed
+
+### Fixed
+
+- **BidCos-RF no longer fills not-yet-refreshed VALUES with getValue defaults
+  (#3260).** Passive/battery BidCos-RF devices cannot be actively queried, so the
+  per-parameter `getValue` fallback during init returned the paramset default (marked
+  as valid) instead of a real reading — masking an actually uncertain state for devices
+  that had not reported yet. As already done for VirtualDevices (#3228), the `getValue`
+  fallback is now skipped for the BidCos-RF interface: readable VALUES keep their
+  (unset) `NO_VALUE` state until a real value arrives via event. The bulk ReGa fetch
+  (which filters placeholders via `LastTimestamp`) remains the trustworthy init source.
+
 # Version 2026.6.9 (2026-06-30)
 
 ## What's Changed

--- a/tests/test_central.py
+++ b/tests/test_central.py
@@ -835,19 +835,20 @@ class TestCentralCallbacksAndServices:
         await central.load_and_refresh_data_point_data(interface=Interface.BIDCOS_RF, paramset_key=ParamsetKey.MASTER)
         assert len(mock_client.method_calls) == init_len_method_calls
         await central.load_and_refresh_data_point_data(interface=Interface.BIDCOS_RF, paramset_key=ParamsetKey.VALUES)
-        # +8 over the plain value loads: each readable data point with a paired
-        # *_STATUS parameter now also loads that status on init (#3228).
-        assert len(mock_client.method_calls) == init_len_method_calls + 27
+        # +1: BidCos-RF skips the per-parameter getValue fallback (incl. the paired
+        # *_STATUS loads), so only the bulk fetch_all_device_data from data_cache.load
+        # remains (#3260).
+        assert len(mock_client.method_calls) == init_len_method_calls + 1
 
         await central.hub_coordinator.get_system_variable(legacy_name="SysVar_Name")
         assert mock_client.method_calls[-1] == call.get_system_variable(name="SysVar_Name")
 
-        assert len(mock_client.method_calls) == init_len_method_calls + 28
+        assert len(mock_client.method_calls) == init_len_method_calls + 2
         await central.hub_coordinator.set_system_variable(legacy_name="alarm", value=True)
         assert mock_client.method_calls[-1] == call.set_system_variable(legacy_name="alarm", value=True)
-        assert len(mock_client.method_calls) == init_len_method_calls + 29
+        assert len(mock_client.method_calls) == init_len_method_calls + 3
         await central.hub_coordinator.set_system_variable(legacy_name="SysVar_Name", value=True)
-        assert len(mock_client.method_calls) == init_len_method_calls + 29
+        assert len(mock_client.method_calls) == init_len_method_calls + 3
 
         await central.client_coordinator.get_client(interface_id=const.INTERFACE_ID).set_value(
             channel_address="123",
@@ -861,7 +862,7 @@ class TestCentralCallbacksAndServices:
             parameter="LEVEL",
             value=1.0,
         )
-        assert len(mock_client.method_calls) == init_len_method_calls + 30
+        assert len(mock_client.method_calls) == init_len_method_calls + 4
 
         with pytest.raises(AioHomematicException):
             await central.client_coordinator.get_client(interface_id="NOT_A_VALID_INTERFACE_ID").set_value(
@@ -870,7 +871,7 @@ class TestCentralCallbacksAndServices:
                 parameter="LEVEL",
                 value=1.0,
             )
-        assert len(mock_client.method_calls) == init_len_method_calls + 30
+        assert len(mock_client.method_calls) == init_len_method_calls + 4
 
         await central.client_coordinator.get_client(interface_id=const.INTERFACE_ID).put_paramset(
             channel_address="123",
@@ -880,14 +881,14 @@ class TestCentralCallbacksAndServices:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="123", paramset_key_or_link_address=ParamsetKey.VALUES, values={"LEVEL": 1.0}
         )
-        assert len(mock_client.method_calls) == init_len_method_calls + 31
+        assert len(mock_client.method_calls) == init_len_method_calls + 5
         with pytest.raises(AioHomematicException):
             await central.client_coordinator.get_client(interface_id="NOT_A_VALID_INTERFACE_ID").put_paramset(
                 channel_address="123",
                 paramset_key_or_link_address=ParamsetKey.VALUES,
                 values={"LEVEL": 1.0},
             )
-        assert len(mock_client.method_calls) == init_len_method_calls + 31
+        assert len(mock_client.method_calls) == init_len_method_calls + 5
 
         assert (
             central.query_facade.get_generic_data_point(

--- a/tests/test_model_data_point.py
+++ b/tests/test_model_data_point.py
@@ -225,9 +225,14 @@ class TestDataPointLoading:
     async def test_load_custom_data_point(
         self,
         central_client_factory_with_homegear_client,
+        monkeypatch,
     ) -> None:
         """Test custom data point value loading."""
         central, mock_client, _ = central_client_factory_with_homegear_client
+        # VCU2128127 is a HmIP-BSM; pin it to HMIP_RF so the per-parameter getValue
+        # fallback runs. BidCos-RF (the test factory default) skips it (#3260).
+        device = central.device_coordinator.get_device(address="VCU2128127")
+        monkeypatch.setattr(device, "_interface", Interface.HMIP_RF)
         switch: DpSwitch = cast(DpSwitch, get_prepared_custom_data_point(central, "VCU2128127", 4))
         await switch.load_data_point_value(call_source=CallSource.MANUAL_OR_SCHEDULED)
         # Find the two STATE get_value calls (order: ch4 STATE, ch3 STATE)
@@ -267,9 +272,14 @@ class TestDataPointLoading:
     async def test_load_generic_data_point(
         self,
         central_client_factory_with_homegear_client,
+        monkeypatch,
     ) -> None:
         """Test generic data point value loading."""
         central, mock_client, _ = central_client_factory_with_homegear_client
+        # VCU2128127 is a HmIP-BSM; pin it to HMIP_RF so the per-parameter getValue
+        # fallback runs. BidCos-RF (the test factory default) skips it (#3260).
+        device = central.device_coordinator.get_device(address="VCU2128127")
+        monkeypatch.setattr(device, "_interface", Interface.HMIP_RF)
         switch: DpSwitch = cast(
             DpSwitch, central.query_facade.get_generic_data_point(channel_address="VCU2128127:4", parameter="STATE")
         )
@@ -296,6 +306,7 @@ class TestDataPointLoading:
     async def test_load_generic_data_point_also_loads_status(
         self,
         central_client_factory_with_homegear_client,
+        monkeypatch,
     ) -> None:
         """
         Loading a data point with a paired ``*_STATUS`` must also load that status (#3228).
@@ -305,6 +316,10 @@ class TestDataPointLoading:
         status must be loaded on init so the value's validity can be judged.
         """
         central, mock_client, _ = central_client_factory_with_homegear_client
+        # VCU3609622 is a HmIP-eTRV-E; pin it to HMIP_RF so the per-parameter getValue
+        # fallback runs. BidCos-RF (the test factory default) skips it (#3260).
+        device = central.device_coordinator.get_device(address="VCU3609622")
+        monkeypatch.setattr(device, "_interface", Interface.HMIP_RF)
         level: DpSensor = cast(
             DpSensor,
             central.query_facade.get_generic_data_point(channel_address="VCU3609622:1", parameter="LEVEL"),

--- a/tests/test_model_device.py
+++ b/tests/test_model_device.py
@@ -17,6 +17,7 @@ from aiohomematic.const import (
     VIRTUAL_REMOTE_MODELS,
     DeviceTriggerEventType,
     ForcedDeviceAvailability,
+    Interface,
     ParamsetKey,
 )
 from aiohomematic.exceptions import AioHomematicException, BaseHomematicException
@@ -1317,25 +1318,28 @@ class TestValueCachePaths:
         ),
         [({"VCU2128127"}, True, None, None)],
     )
-    async def test_get_values_for_cache_skips_getvalue_for_virtual_devices(
-        self, central_client_factory_with_homegear_client, monkeypatch
+    @pytest.mark.parametrize(
+        "skip_interface",
+        [Interface.VIRTUAL_DEVICES, Interface.BIDCOS_RF],
+    )
+    async def test_get_values_for_cache_skips_getvalue_for_interface(
+        self, central_client_factory_with_homegear_client, monkeypatch, skip_interface
     ) -> None:
         """
-        Skip the VALUES getValue fallback for VirtualDevices (#3228).
+        Skip the VALUES getValue fallback for VirtualDevices and BidCos-RF (#3228, #3260).
 
-        VirtualDevices (e.g. heating groups) have no physical device behind them, so a
-        getValue can only return the CCU-internal default (e.g. 0 for a not-yet-measured
-        ACTUAL_TEMPERATURE after a CCU restart) instead of a real reading. The bulk ReGa
-        fetch already filters such placeholders via LastTimestamp, so the getValue
-        fallback must not run for this interface.
+        VirtualDevices (e.g. heating groups) have no physical device behind them, and
+        BidCos-RF hosts passive/battery devices that cannot be actively queried. In both
+        cases a getValue can only return the CCU-internal default (e.g. 0 for a
+        not-yet-measured ACTUAL_TEMPERATURE after a CCU restart) instead of a real reading.
+        The bulk ReGa fetch already filters such placeholders via LastTimestamp, so the
+        getValue fallback must not run for these interfaces.
         """
         central, _, _ = central_client_factory_with_homegear_client
         device = central.device_coordinator.get_device(address="VCU2128127")
 
-        from aiohomematic.const import Interface, ParamsetKey
-
-        # Pretend this device lives on the VirtualDevices interface.
-        monkeypatch.setattr(device, "_interface", Interface.VIRTUAL_DEVICES)
+        # Pretend this device lives on the interface under test.
+        monkeypatch.setattr(device, "_interface", skip_interface)
 
         values_dps = [dp for dp in device.generic_data_points if dp.paramset_key == ParamsetKey.VALUES]
         assert values_dps
@@ -1352,7 +1356,7 @@ class TestValueCachePaths:
 
         result = await device.value_cache._get_values_for_cache(dpk=dpk)  # type: ignore[attr-defined]
 
-        # No getValue fallback for VirtualDevices VALUES ...
+        # No getValue fallback for these interfaces' VALUES ...
         assert backend_calls == []
         # ... and a NO_VALUE marker is returned so the data point stays unavailable.
         assert result == {dpk.parameter: device.value_cache._NO_VALUE_CACHE_ENTRY}  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Following [discussion #3260](https://github.com/SukramJ/aiohomematic/discussions/3260), the per-parameter `getValue` fallback during init is now also disabled for the **BidCos-RF** interface.

Passive/battery BidCos-RF devices cannot be actively queried, so the `getValue` fallback returned the paramset default (marked as *valid*) instead of a real reading — masking an actually uncertain state for devices that had not reported yet.

As already done for VirtualDevices (#3228), the fallback is now skipped for BidCos-RF: readable `VALUES` keep their (unset) `NO_VALUE` state until a real value arrives via event. The bulk ReGa fetch (which filters placeholders via `LastTimestamp`) remains the trustworthy init source.

## Changes

- **`aiohomematic/model/device.py`** — `_ValueCache._get_values_for_cache` now skips the `getValue` fallback for `Interface.BIDCOS_RF` in addition to `Interface.VIRTUAL_DEVICES`; comment updated to cover both rationales.
- **`tests/test_model_device.py`** — generalized the existing skip test to `test_get_values_for_cache_skips_getvalue_for_interface`, parametrized over both interfaces (`VIRTUAL_DEVICES`, `BIDCOS_RF`).
- **`changelog.md`** + **`aiohomematic/const.py`** — new entry `2026.7.1`, `VERSION` in sync.

## Scope note

The fallback is intentionally disabled for the **whole** BidCos-RF interface (not just passive devices), as agreed by the maintainer in the discussion. Active BidCos-RF devices still receive their real values via the bulk ReGa fetch and events; only the secondary per-parameter `getValue` fallback is dropped. **BidCos-Wired** is unchanged (mains-powered, actively queryable).

## Verification

- Targeted tests green (3 passed for the getValue fallback; 48 passed in the broader run incl. `test_model_data_point_validity` and the ReGa fetch contract test).
- `prek run` clean (mypy / pylint / ruff / codespell / bandit).
- Version sync confirmed (`changelog.md` head == `const.py:VERSION` == `2026.7.1`).

Refs #3260, #3228, #3255