### PR TITLE
feat(model): add user access permission switches for HmIP-DLD and HmIP-FWI (#3262)

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -1015,6 +1015,7 @@ class DeviceFirmwareState(StrEnum):
 class DeviceProfile(StrEnum):
     """Enum for device profiles."""
 
+    IP_ACCESS_PERMISSION = "IPAccessPermission"
     IP_BUTTON_LOCK = "IPButtonLock"
     IP_COVER = "IPCover"
     IP_DIMMER = "IPDimmer"
@@ -1080,6 +1081,7 @@ class EventData:
 class Field(Enum):
     """Enum for fields."""
 
+    ACCESS_AUTHORIZATION = "access_authorization"
     ACOUSTIC_ALARM_ACTIVE = "acoustic_alarm_active"
     ACOUSTIC_ALARM_SELECTION = "acoustic_alarm_selection"
     ACOUSTIC_NOTIFICATION_SELECTION = "acoustic_notification_selection"
@@ -1252,6 +1254,7 @@ class OptionalSettings(StrEnum):
 class Parameter(StrEnum):
     """Enum with Homematic parameters."""
 
+    ACCESS_AUTHORIZATION = "ACCESS_AUTHORIZATION"
     ACOUSTIC_ALARM_ACTIVE = "ACOUSTIC_ALARM_ACTIVE"
     ACOUSTIC_ALARM_SELECTION = "ACOUSTIC_ALARM_SELECTION"
     ACOUSTIC_NOTIFICATION_SELECTION = "ACOUSTIC_NOTIFICATION_SELECTION"

--- a/aiohomematic/model/custom/__init__.py
+++ b/aiohomematic/model/custom/__init__.py
@@ -42,6 +42,7 @@ from typing import Final
 from aiohomematic.const import ServiceScope
 from aiohomematic.decorators import inspector
 from aiohomematic.interfaces.model import DeviceProtocol
+from aiohomematic.model.custom.access_permission import CustomDpIpAccessPermission
 from aiohomematic.model.custom.climate import (
     PROFILE_PREFIX,
     BaseCustomDpClimate,
@@ -153,6 +154,7 @@ __all__ = [
     # Lock
     "BaseCustomDpLock",
     "CustomDpButtonLock",
+    "CustomDpIpAccessPermission",
     "CustomDpIpLock",
     "CustomDpRfLock",
     "LockState",

--- a/aiohomematic/model/custom/access_permission.py
+++ b/aiohomematic/model/custom/access_permission.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""
+Custom access permission data points for door lock user channels.
+
+Public API of this module is defined by __all__.
+"""
+
+from enum import StrEnum, unique
+from typing import Final, Unpack, override
+
+from aiohomematic import ccu_translations
+from aiohomematic.const import DataPointCategory, Field, Parameter
+from aiohomematic.model.custom.data_point import CustomDataPoint
+from aiohomematic.model.custom.field import DataPointField
+from aiohomematic.model.custom.mixins import StateChangeArg, StateChangeArgs
+from aiohomematic.model.data_point import CallParameterCollector, bind_collector
+from aiohomematic.model.generic import DpActionSelect, DpBinarySensor
+from aiohomematic.model.support import DataPointNameData, get_data_point_name_data
+from aiohomematic.property_decorators import DelegatedProperty, Kind
+
+__all__ = ["CustomDpIpAccessPermission"]
+
+
+@unique
+class _AccessAuthorization(StrEnum):
+    """Enum with user access authorization values."""
+
+    DISABLE = "DISABLE"
+    ENABLE = "ENABLE"
+
+
+class CustomDpIpAccessPermission(CustomDataPoint):
+    """
+    Class for a HomematicIP user access permission switch.
+
+    Combines the read-only ``STATE`` (current permission) with the write-only
+    ``ACCESS_AUTHORIZATION`` control (enable/disable) of a single ACCESS_RECEIVER
+    channel into one switch, mirroring the ``PERMISSION_STATE`` switch of newer
+    door locks (e.g. HmIP-DLP). Used for the per-user channels of the HmIP-DLD.
+    """
+
+    __slots__ = ()  # Required to prevent __dict__ creation (descriptors are class-level)
+
+    _category = DataPointCategory.SWITCH
+
+    # Declarative data point field definitions
+    _dp_authorization: Final = DataPointField(field=Field.ACCESS_AUTHORIZATION, dpt=DpActionSelect)
+    _dp_state: Final = DataPointField(field=Field.STATE, dpt=DpBinarySensor)
+
+    value: Final = DelegatedProperty[bool | None](path="_dp_state.value", kind=Kind.STATE)
+
+    @override
+    def is_state_change(self, **kwargs: Unpack[StateChangeArgs]) -> bool:
+        """Check if the state changes due to kwargs."""
+        if kwargs.get(StateChangeArg.ON) is not None and self.value is not True:
+            return True
+        if kwargs.get(StateChangeArg.OFF) is not None and self.value is not False:
+            return True
+        return super().is_state_change(**kwargs)
+
+    @bind_collector
+    async def turn_off(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Revoke the user access permission."""
+        if not self.is_state_change(off=True):
+            return
+        await self._dp_authorization.send_value(value=_AccessAuthorization.DISABLE, collector=collector)
+
+    @bind_collector
+    async def turn_on(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Grant the user access permission."""
+        if not self.is_state_change(on=True):
+            return
+        await self._dp_authorization.send_value(value=_AccessAuthorization.ENABLE, collector=collector)
+
+    @override
+    def _get_data_point_name(self) -> DataPointNameData:
+        """
+        Create a per-channel name so each user channel is distinguishable.
+
+        The ACCESS_RECEIVER channels usually carry only the device name (no channel
+        suffix), so the default custom naming would produce identical names for all
+        user channels. Use the generic parameter naming instead, which appends a
+        ``chN`` marker for parameters present on multiple channels — mirroring the
+        per-channel ``PERMISSION_STATE`` switches of the HmIP-DLP.
+        """
+        return get_data_point_name_data(
+            channel=self._channel,
+            parameter=Parameter.ACCESS_AUTHORIZATION,
+            parameter_translation=ccu_translations.get_parameter_translation(
+                parameter=Parameter.ACCESS_AUTHORIZATION,
+                channel_type=self._channel.type_name,
+                locale=self._channel.device.config_provider.config.locale,
+            ),
+        )
+
+    @override
+    def _post_init(self) -> None:
+        """
+        Resolve the write-only ACCESS_AUTHORIZATION control after field init.
+
+        ACCESS_AUTHORIZATION is globally ignored; declaring it as a profile field
+        would make it a globally-required parameter and expose a bare control data
+        point on every unrelated device that has it (HmIP-WKP, HmIP-FWI). It is
+        instead un-ignored only for HmIP-DLD and resolved here from the generic data
+        point, consumed (NO_CREATE) into this switch so it is not shown separately.
+        """
+        super()._post_init()
+        self._add_data_point(
+            field=Field.ACCESS_AUTHORIZATION,
+            data_point=self._device.get_generic_data_point(
+                channel_address=self._channel.address, parameter=Parameter.ACCESS_AUTHORIZATION
+            ),
+            is_visible=False,
+        )
+
+
+# NOTE: The DeviceProfileRegistry registration for this SWITCH-category data point
+# lives in switch.py (next to the other SWITCH registrations), not here. Registering
+# it from this module would make it the first SWITCH-category insertion in the
+# registry, which reorders category processing and changes channel-conflict
+# resolution for unrelated multi-profile devices (e.g. HmIP-WGTC).

--- a/aiohomematic/model/custom/profile.py
+++ b/aiohomematic/model/custom/profile.py
@@ -644,6 +644,33 @@ RF_LOCK_CONFIG: Final = ProfileConfig(
 )
 
 
+# --- Access Permission Profiles ---
+
+# User access permission on a single ACCESS_RECEIVER channel (e.g. HmIP-DLD user
+# channels 2-9). STATE is the read-only current permission (mapped here). The
+# write-only ACCESS_AUTHORIZATION control is deliberately NOT a profile field: it
+# is globally ignored, and mapping it here would make it a globally-required
+# parameter that gets exposed on unrelated devices (HmIP-WKP, HmIP-FWI). Instead it
+# is un-ignored only for HmIP-DLD and resolved inside CustomDpIpAccessPermission.
+IP_ACCESS_PERMISSION_CONFIG: Final = ProfileConfig(
+    profile_type=DeviceProfile.IP_ACCESS_PERMISSION,
+    channel_group=ChannelGroupConfig(
+        # Keep all other generic data points of the device. Devices whose ONLY custom
+        # data points are these permission switches (e.g. HmIP-FWI) would otherwise
+        # have their unrelated generic data points (access codes, output switches,
+        # week program) suppressed. On devices that also have other custom profiles
+        # (e.g. HmIP-DLD lock/button-lock) the device-level flag stays False via
+        # all(...), so their behaviour is unchanged.
+        allow_undefined_generic_data_points=True,
+        fields={
+            # Hidden: consumed by the switch as its read value; allow_undefined above
+            # would otherwise keep STATE visible as a separate generic sensor.
+            Field.STATE: _hidden(parameter=Parameter.STATE),
+        },
+    ),
+)
+
+
 # --- Siren Profiles ---
 
 IP_SIREN_CONFIG: Final = ProfileConfig(
@@ -933,6 +960,8 @@ PROFILE_CONFIGS: Final[ProfileRegistry] = {
     # Lock
     DeviceProfile.IP_LOCK: IP_LOCK_CONFIG,
     DeviceProfile.RF_LOCK: RF_LOCK_CONFIG,
+    # Access Permission
+    DeviceProfile.IP_ACCESS_PERMISSION: IP_ACCESS_PERMISSION_CONFIG,
     # Siren
     DeviceProfile.IP_SIREN: IP_SIREN_CONFIG,
     DeviceProfile.IP_SIREN_SMOKE: IP_SIREN_SMOKE_CONFIG,

--- a/aiohomematic/model/custom/switch.py
+++ b/aiohomematic/model/custom/switch.py
@@ -11,6 +11,7 @@ from typing import Final, Unpack, override
 
 from aiohomematic.const import DataPointCategory, DeviceProfile, Field, Parameter
 from aiohomematic.model.combined.field import CombinedTimerField
+from aiohomematic.model.custom.access_permission import CustomDpIpAccessPermission
 from aiohomematic.model.custom.data_point import CustomDataPoint
 from aiohomematic.model.custom.field import DataPointField
 from aiohomematic.model.custom.mixins import GroupStateMixin, StateChangeArgs, StateChangeTimerMixin
@@ -128,3 +129,23 @@ DeviceProfileRegistry.register(
         }
     ),
 )
+
+# User access permission switches for access-control devices that split the per-user
+# permission into read-only STATE + write-only ACCESS_AUTHORIZATION (e.g. HmIP-DLD
+# channels 2-9, HmIP-FWI channels 1-8). Registered here (not in access_permission.py)
+# so the SWITCH category keeps its usual insertion order in the registry; registering
+# from access_permission.py would make SWITCH the first category and reorder
+# channel-conflict resolution for unrelated devices.
+_IP_ACCESS_PERMISSION_REGISTRATIONS: Final[tuple[tuple[str, tuple[int, ...]], ...]] = (
+    ("HmIP-DLD", (2, 3, 4, 5, 6, 7, 8, 9)),
+    ("HmIP-FWI", (1, 2, 3, 4, 5, 6, 7, 8)),
+)
+
+for _model, _channels in _IP_ACCESS_PERMISSION_REGISTRATIONS:
+    DeviceProfileRegistry.register(
+        category=DataPointCategory.SWITCH,
+        models=_model,
+        data_point_class=CustomDpIpAccessPermission,
+        profile_type=DeviceProfile.IP_ACCESS_PERMISSION,
+        channels=_channels,
+    )

--- a/aiohomematic/store/visibility/rules.py
+++ b/aiohomematic/store/visibility/rules.py
@@ -221,8 +221,9 @@ def parameter_is_wildcard_ignored(*, parameter: ParameterName) -> bool:
 # Parameters that are normally ignored but should be created for specific devices.
 
 UN_IGNORE_PARAMETERS_BY_DEVICE: Final[Mapping[ModelName, frozenset[Parameter]]] = {
-    "HmIP-DLD": frozenset({Parameter.ERROR_JAMMED}),
+    "HmIP-DLD": frozenset({Parameter.ERROR_JAMMED, Parameter.ACCESS_AUTHORIZATION}),
     "HmIP-DLP": frozenset({Parameter.ERROR_JAMMED}),
+    "HmIP-FWI": frozenset({Parameter.ACCESS_AUTHORIZATION}),
     "HmIP-SWSD": frozenset({Parameter.DIRT_LEVEL, Parameter.SMOKE_LEVEL, Parameter.SMOKE_DETECTOR_ALARM_STATUS}),
     # Text display parameters for HmIP-WRCD
     "HmIP-WRCD": frozenset(

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,21 @@
 
 ## What's Changed
 
+### Added
+
+- **User access permission switches for HmIP-DLD and HmIP-FWI (#3262).** These
+  access-control devices now expose their per-user access channels (HmIP-DLD
+  `:2`–`:9`, HmIP-FWI `:1`–`:8`) as switch data points, mirroring the
+  `PERMISSION_STATE` switches added for the newer HmIP-DLP. Unlike the DLP — which
+  has a single read/write `PERMISSION_STATE` parameter — these devices split the
+  permission into a read-only `STATE` and a write-only `ACCESS_AUTHORIZATION` (ENUM
+  `DISABLE`/`ENABLE`). The new `CustomDpIpAccessPermission` custom data point
+  combines both into one switch: `value` reflects `STATE`, `turn_on`/`turn_off`
+  write `ACCESS_AUTHORIZATION`. Added the `IP_ACCESS_PERMISSION` device profile and
+  the `ACCESS_AUTHORIZATION` `Parameter`/`Field`. The profile keeps the devices'
+  unrelated data points (HmIP-FWI access codes, output switches, week program) via
+  `allow_undefined_generic_data_points`.
+
 ### Fixed
 
 - **BidCos-RF no longer fills not-yet-refreshed VALUES with getValue defaults

--- a/tests/test_central_full_session.py
+++ b/tests/test_central_full_session.py
@@ -174,15 +174,15 @@ class TestCentralFullSession:
             if dev.model == "HM-CC-VG-1":
                 pass
 
-        assert usage_types[DataPointUsage.CDP_PRIMARY] == 277
+        assert usage_types[DataPointUsage.CDP_PRIMARY] == 293
         assert usage_types[DataPointUsage.CDP_SECONDARY] == 162
         assert usage_types[DataPointUsage.CDP_VISIBLE] == 215
-        assert usage_types[DataPointUsage.DATA_POINT] == 4339
-        assert usage_types[DataPointUsage.NO_CREATE] == 4495
+        assert usage_types[DataPointUsage.DATA_POINT] == 4340
+        assert usage_types[DataPointUsage.NO_CREATE] == 4519
 
-        assert len(ce_channels) == 133
+        assert len(ce_channels) == 134
         assert len(data_point_types) == 6
-        assert len(parameters) == 257
+        assert len(parameters) == 258
 
         assert len(central.device_registry.devices) == 395
         virtual_remotes = ["VCU4264293", "VCU0000057", "VCU0000001"]

--- a/tests/test_central_pydev_openccu.py
+++ b/tests/test_central_pydev_openccu.py
@@ -167,15 +167,15 @@ class TestCentralPyDevOpenCCU:
         for sv in central.hub_coordinator.sysvar_data_points:
             assert hasattr(sv, "__dict__") is False
 
-        assert usage_types[DataPointUsage.CDP_PRIMARY] == 282
+        assert usage_types[DataPointUsage.CDP_PRIMARY] == 298
         assert usage_types[DataPointUsage.CDP_SECONDARY] == 166
         assert usage_types[DataPointUsage.CDP_VISIBLE] == 218
-        assert usage_types[DataPointUsage.DATA_POINT] == 4400
-        assert usage_types[DataPointUsage.NO_CREATE] == 4569
+        assert usage_types[DataPointUsage.DATA_POINT] == 4401
+        assert usage_types[DataPointUsage.NO_CREATE] == 4593
 
-        assert len(ce_channels) == 137
+        assert len(ce_channels) == 138
         assert len(data_point_types) == 6
-        assert len(parameters) == 270
+        assert len(parameters) == 271
 
         assert len(central.device_registry.devices) == 399
         virtual_remotes = ["VCU4264293", "VCU0000057", "VCU0000001"]

--- a/tests/test_central_pydevccu.py
+++ b/tests/test_central_pydevccu.py
@@ -156,15 +156,15 @@ class TestCentralPyDevCCU:
         for sv in central.hub_coordinator.sysvar_data_points:
             assert hasattr(sv, "__dict__") is False
 
-        assert usage_types[DataPointUsage.CDP_PRIMARY] == 282
+        assert usage_types[DataPointUsage.CDP_PRIMARY] == 298
         assert usage_types[DataPointUsage.CDP_SECONDARY] == 166
         assert usage_types[DataPointUsage.CDP_VISIBLE] == 218
-        assert usage_types[DataPointUsage.DATA_POINT] == 4400
-        assert usage_types[DataPointUsage.NO_CREATE] == 4569
+        assert usage_types[DataPointUsage.DATA_POINT] == 4401
+        assert usage_types[DataPointUsage.NO_CREATE] == 4593
 
-        assert len(ce_channels) == 137
+        assert len(ce_channels) == 138
         assert len(data_point_types) == 6
-        assert len(parameters) == 270
+        assert len(parameters) == 271
 
         assert len(central.device_registry.devices) == 399
         virtual_remotes = ["VCU4264293", "VCU0000057", "VCU0000001"]

--- a/tests/test_model_access_permission.py
+++ b/tests/test_model_access_permission.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""Tests for access permission data points of aiohomematic."""
+
+from typing import cast
+from unittest.mock import call
+
+import pytest
+
+from aiohomematic.client import CommandPriority
+from aiohomematic.const import DataPointCategory, DataPointUsage, ParamsetKey
+from aiohomematic.model.custom import CustomDpIpAccessPermission
+from aiohomematic_test_support import const
+from aiohomematic_test_support.helper import get_prepared_custom_data_point
+
+TEST_DEVICES: set[str] = {"VCU9724704"}
+
+# pylint: disable=protected-access
+
+
+class TestIpAccessPermission:
+    """Tests for CustomDpIpAccessPermission data points (HmIP-DLD / HmIP-FWI user access channels)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_ip_access_permission(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """Test that the HmIP-DLD exposes a permission switch per user channel 2-9."""
+        central, mock_client, _ = central_client_factory_with_homegear_client
+
+        # One permission switch per user channel 2..9.
+        full_names: set[str] = set()
+        for channel_no in range(2, 10):
+            perm = cast(
+                CustomDpIpAccessPermission,
+                get_prepared_custom_data_point(central, "VCU9724704", channel_no),
+            )
+            assert perm is not None
+            assert perm.category == DataPointCategory.SWITCH
+            assert perm.usage == DataPointUsage.CDP_PRIMARY
+            # Each user channel must be individually named (mirrors HmIP-DLP `chN`).
+            assert perm.full_name.endswith(f"ch{channel_no}")
+            full_names.add(perm.full_name)
+        assert len(full_names) == 8
+
+        perm = cast(
+            CustomDpIpAccessPermission,
+            get_prepared_custom_data_point(central, "VCU9724704", 2),
+        )
+
+        # value mirrors the read-only STATE parameter.
+        await central.event_coordinator.data_point_event(
+            interface_id=const.INTERFACE_ID, channel_address="VCU9724704:2", parameter="STATE", value=True
+        )
+        assert perm.value is True
+
+        # turn_off writes ACCESS_AUTHORIZATION=DISABLE.
+        await perm.turn_off()
+        assert mock_client.method_calls[-1] == call.set_value(
+            channel_address="VCU9724704:2",
+            paramset_key=ParamsetKey.VALUES,
+            parameter="ACCESS_AUTHORIZATION",
+            value="DISABLE",
+            wait_for_callback=None,
+            priority=CommandPriority.HIGH,
+            retry=True,
+        )
+
+        await central.event_coordinator.data_point_event(
+            interface_id=const.INTERFACE_ID, channel_address="VCU9724704:2", parameter="STATE", value=False
+        )
+        assert perm.value is False
+
+        # turn_on writes ACCESS_AUTHORIZATION=ENABLE.
+        await perm.turn_on()
+        assert mock_client.method_calls[-1] == call.set_value(
+            channel_address="VCU9724704:2",
+            paramset_key=ParamsetKey.VALUES,
+            parameter="ACCESS_AUTHORIZATION",
+            value="ENABLE",
+            wait_for_callback=None,
+            priority=CommandPriority.HIGH,
+            retry=True,
+        )
+
+    @pytest.mark.enable_socket
+    @pytest.mark.asyncio
+    @pytest.mark.xdist_group("pydevccu")
+    async def test_ip_access_permission_fwi(self, central_unit_pydevccu_full) -> None:
+        """
+        Test that the HmIP-FWI exposes permission switches (ch 1-8) without losing its other data points.
+
+        The HmIP-FWI is not part of the recorded homegear session, so the virtual
+        PyDevCCU instance is used here (turn_on/turn_off/value are already covered by
+        the shared CustomDpIpAccessPermission logic in the HmIP-DLD test above).
+        """
+        central = central_unit_pydevccu_full
+
+        # One permission switch per user channel 1..8, each individually named.
+        full_names: set[str] = set()
+        for channel_no in range(1, 9):
+            perm = cast(
+                CustomDpIpAccessPermission,
+                get_prepared_custom_data_point(central, "VCU4820995", channel_no),
+            )
+            assert perm is not None
+            assert perm.category == DataPointCategory.SWITCH
+            assert perm.usage == DataPointUsage.CDP_PRIMARY
+            assert perm.full_name.endswith(f"ch{channel_no}")
+            full_names.add(perm.full_name)
+        assert len(full_names) == 8
+
+        # Regression guard: the FWI keeps its unrelated generic data points (the custom
+        # profile must not suppress them). Channel-0 access-code sensor and a channel-9
+        # output switch remain present.
+        assert central.query_facade.get_generic_data_point(channel_address="VCU4820995:0", parameter="CODE_STATE")
+        assert central.query_facade.get_generic_data_point(channel_address="VCU4820995:9", parameter="STATE")


### PR DESCRIPTION
Closes the request in discussion #3262.

## What

Adds user access permission switches for the **HmIP-DLD** and **HmIP-FWI**, mirroring the `PERMISSION_STATE` switches that the newer HmIP-DLP already has.

- **HmIP-DLD**: 8 switches on user channels `:2`–`:9`
- **HmIP-FWI**: 8 switches on user channels `:1`–`:8`

Unlike the DLP — which has a single read/write `PERMISSION_STATE` parameter — these devices split the permission into a read-only `STATE` and a write-only `ACCESS_AUTHORIZATION` (ENUM `DISABLE`/`ENABLE`). The new `CustomDpIpAccessPermission` combines both into one switch: `value` reflects `STATE`, `turn_on`/`turn_off` write `ACCESS_AUTHORIZATION`. Each channel is individually named (`… Access Authorization chN`), like the DLP.

## Implementation notes

`ACCESS_AUTHORIZATION` is a globally-ignored parameter, which made this trickier than the DLP change. Three subtle pitfalls were found and handled (all verified via pydevccu data-point-count diffs against `main`):

1. **No global exposure** — using `ACCESS_AUTHORIZATION` as a normal profile field would make it globally *required* and expose a bare control on every unrelated device that has it (e.g. HmIP-WKP). It is instead un-ignored per model and resolved in `_post_init`, consumed into the switch (`NO_CREATE`).
2. **Stable registry order** — the registration lives in `switch.py` (not the new `access_permission.py`) so the `SWITCH` category keeps its usual insertion order; otherwise channel-conflict resolution for unrelated multi-profile devices (e.g. HmIP-WGTC) silently changes.
3. **No suppression of the FWI's other data points** — the FWI was previously a purely generic device; gaining a custom profile would suppress its access-code sensors, output switches and week program. `allow_undefined_generic_data_points=True` keeps them (the DLD is unaffected, its lock/button-lock keep the device flag `False` via `all(...)`).

### Side effect worth noting
Because the FWI becomes a custom device, it also gains its week-program data points (it has `WEEK_PROGRAM_*` parameters). This is an addition, not a regression — no existing data point is lost.

## Tests

- New `tests/test_model_access_permission.py` (DLD via homegear mock; FWI via pydevccu incl. a regression guard that its code/output data points survive).
- Updated data-point-count assertions in `test_central_pydevccu` / `test_central_pydev_openccu` / `test_central_full_session`.
- Full suite green: `4093 passed, 1 skipped`. Version unchanged (2026.7.1).
