### PR TITLE
fix(model): don't let CUxD/CCU-Jack init drown in the JSON-RPC session storm

### DIFF
--- a/aiohomematic/client/json_rpc.py
+++ b/aiohomematic/client/json_rpc.py
@@ -413,6 +413,7 @@ class AioJsonRpcAioHttpClient(LogContextMixin):
         self._session_recorder: Final = session_recorder
         self._supported_methods: tuple[str, ...] | None = None
         self._http_session_semaphore: Final = Semaphore(value=MAX_CONCURRENT_HTTP_SESSIONS)
+        self._session_lock: Final = asyncio.Lock()
 
         # Login rate limiting state
         self._failed_login_attempts: int = 0
@@ -2194,13 +2195,24 @@ class AioJsonRpcAioHttpClient(LogContextMixin):
 
     async def _login_or_renew(self) -> bool:
         """Renew JSON-RPC session or perform login."""
-        if not self.is_activated:
-            self._session_id = await self._do_login()
-            self._last_session_id_refresh = datetime.now()
+        # Fast path: a valid, recently refreshed session needs neither network nor lock.
+        if self.is_activated and self._has_session_recently_refreshed:
+            return True
+        # Serialize login/renew so a burst of concurrent callers at cold start does not
+        # race into multiple parallel Session.login calls, which would create several CCU
+        # sessions at once and trip the CCU's "too many sessions" limit.
+        async with self._session_lock:
+            # Re-check under the lock: another coroutine may have logged in or renewed
+            # the session while we were waiting for it.
+            if self.is_activated and self._has_session_recently_refreshed:
+                return True
+            if not self.is_activated:
+                self._session_id = await self._do_login()
+                self._last_session_id_refresh = datetime.now()
+                return self._session_id is not None
+            if self._session_id:
+                self._session_id = await self._do_renew_login(session_id=self._session_id)
             return self._session_id is not None
-        if self._session_id:
-            self._session_id = await self._do_renew_login(session_id=self._session_id)
-        return self._session_id is not None
 
     async def _post(
         self,

--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.7.1"
+VERSION: Final = "2026.7.2"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (
@@ -1831,6 +1831,28 @@ INTERFACES_REQUIRING_JSON_RPC_CLIENT: Final[frozenset[Interface]] = frozenset(
 
 DEFAULT_INTERFACES_REQUIRING_PERIODIC_REFRESH: Final[frozenset[Interface]] = frozenset(
     INTERFACES_REQUIRING_JSON_RPC_CLIENT - INTERFACES_REQUIRING_XML_RPC
+)
+
+# Interfaces for which the per-parameter getValue fallback during init is skipped.
+# For these interfaces a getValue on init cannot return trustworthy device-fresh data,
+# so the bulk fetch (ReGa / JSON get_all_device_data) plus later events are the only
+# reliable sources and the fallback is skipped (the data point stays unset until a real
+# value arrives):
+#   - VirtualDevices (e.g. heating groups) have no physical device; VALUES are CCU
+#     aggregates that read as a valid placeholder (e.g. 0) after a restart (#3228).
+#   - BidCos-RF hosts passive/battery devices that cannot be actively queried; getValue
+#     returns the paramset default instead of a real reading (#3260).
+#   - CUxD / CCU-Jack are JSON-RPC interfaces that perform a Session.login per getValue;
+#     running the fallback for every readable data point (and its paired *_STATUS, #3228)
+#     floods the CCU's JSON-RPC session pool ("too many sessions") and marks the devices
+#     unavailable. Their values arrive via bulk get_all_device_data and MQTT events.
+INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK: Final[frozenset[Interface]] = frozenset(
+    {
+        Interface.VIRTUAL_DEVICES,
+        Interface.BIDCOS_RF,
+        Interface.CUXD,
+        Interface.CCU_JACK,
+    }
 )
 
 INTERFACE_RPC_SERVER_TYPE: Final[Mapping[Interface, RpcServerType]] = MappingProxyType(

--- a/aiohomematic/model/device.py
+++ b/aiohomematic/model/device.py
@@ -66,6 +66,7 @@ from aiohomematic.const import (
     DEVICE_DESCRIPTIONS_ZIP_DIR,
     IDENTIFIER_SEPARATOR,
     INIT_DATETIME,
+    INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK,
     NO_CACHE_ENTRY,
     PARAMSET_DESCRIPTIONS_ZIP_DIR,
     RELEVANT_INIT_PARAMETERS,
@@ -2013,18 +2014,15 @@ class _ValueCache:
             return {}
         if dpk.paramset_key == ParamsetKey.VALUES:
             # For some interfaces a per-parameter getValue during init cannot return
-            # device-fresh data, only a CCU-internal placeholder that would be marked as
-            # valid and thereby mask an actually uncertain state:
-            #   - VirtualDevices (e.g. heating groups) have no physical device behind them;
-            #     their VALUES are aggregated by the CCU (e.g. 0 for a not-yet-measured
-            #     ACTUAL_TEMPERATURE right after a CCU restart).
-            #   - BidCos-RF hosts passive/battery devices that cannot be actively queried;
-            #     getValue then returns the paramset default instead of a real reading.
-            # The bulk ReGa fetch already filters such placeholders via LastTimestamp and is
-            # the only trustworthy source for these interfaces, so skip the per-parameter
-            # getValue fallback. The data point keeps its (unset) state until a real value
-            # arrives via event (#3228, #3260).
-            if self._device.interface in (Interface.VIRTUAL_DEVICES, Interface.BIDCOS_RF):
+            # trustworthy device-fresh data (only a CCU-internal placeholder that would be
+            # marked valid), or is actively harmful. The bulk fetch (ReGa /
+            # get_all_device_data) plus later events are the reliable sources, so the
+            # per-parameter getValue fallback is skipped and the data point keeps its (unset)
+            # state until a real value arrives via event. See
+            # INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK for the per-interface rationale
+            # (VirtualDevices/BidCos-RF placeholders #3228/#3260; CUxD/CCU-Jack JSON-RPC
+            # session flood).
+            if self._device.interface in INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK:
                 return {dpk.parameter: self._NO_VALUE_CACHE_ENTRY}
             return {
                 dpk.parameter: await self._device.client.get_value(

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,28 @@
+# Version 2026.7.2 (2026-07-08)
+
+## What's Changed
+
+### Fixed
+
+- **CUxD/CCU-Jack devices no longer go unavailable after init.** The
+  per-parameter `getValue` fallback that runs on init when a value is missing from the
+  bulk cache was still active for the JSON-RPC interfaces CUxD and CCU-Jack. Since
+  #3228 the bulk fetch skips not-yet-measured values (cache miss) and additionally loads
+  each data point's paired `*_STATUS`, roughly doubling the fallback traffic. For CUxD/
+  CCU-Jack every `getValue` performs a `Session.login`, so this flooded the CCU's
+  JSON-RPC session pool (`too many sessions` / `invalid credentials`), and the affected
+  devices were marked unavailable in Home Assistant. CUxD/CCU-Jack are now added to the
+  new `INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK` set (alongside VirtualDevices and
+  BidCos-RF): the fallback is skipped and values arrive via the bulk
+  `get_all_device_data` fetch and MQTT events, as intended. Added a contract test
+  pinning CUxD/CCU-Jack to this behavior.
+- **JSON-RPC session login is no longer raced on cold start.** `_login_or_renew`
+  was unguarded, so a burst of concurrent callers at init (all seeing `session_id is
+None`) each performed a `Session.login`, creating several CCU sessions at once and
+  contributing to the `too many sessions` limit. Login/renew is now serialized with an
+  `asyncio.Lock` (with a lock-free fast path for a recently refreshed session), so a
+  cold-start burst results in exactly one login that the other callers reuse.
+
 # Version 2026.7.1 (2026-07-03)
 
 ## What's Changed

--- a/tests/contract/test_cuxd_ccu_jack_contract.py
+++ b/tests/contract/test_cuxd_ccu_jack_contract.py
@@ -39,6 +39,7 @@ from aiohomematic.client.backends.json_ccu import JsonCcuBackend
 from aiohomematic.const import (
     INTERFACES_REQUIRING_JSON_RPC_CLIENT,
     INTERFACES_REQUIRING_XML_RPC,
+    INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK,
     INTERFACES_SUPPORTING_RPC_CALLBACK,
     Interface,
     get_json_rpc_default_port,
@@ -88,6 +89,26 @@ class TestCuxdCcuJackInterfaceClassification:
         )
         assert Interface.CCU_JACK not in INTERFACES_REQUIRING_XML_RPC, (
             "CCU-Jack MUST NOT be in INTERFACES_REQUIRING_XML_RPC"
+        )
+
+    def test_cuxd_and_ccu_jack_skip_init_getvalue_fallback(self) -> None:
+        """
+        CONTRACT: CUxD and CCU-Jack MUST skip the per-parameter getValue fallback on init.
+
+        REGRESSION: These JSON-RPC interfaces perform a Session.login per getValue.
+        Running the fallback for every readable data point (and its paired *_STATUS, #3228)
+        floods the CCU's JSON-RPC session pool ("too many sessions") and marks CUxD/CCU-Jack
+        devices unavailable. Their values arrive via bulk get_all_device_data and MQTT events.
+        """
+        assert Interface.CUXD in INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK, (
+            "CUxD MUST be in INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK"
+        )
+        assert Interface.CCU_JACK in INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK, (
+            "CCU-Jack MUST be in INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK"
+        )
+        # Every JSON-RPC-only interface must skip the fallback (none may hammer getValue).
+        assert INTERFACES_REQUIRING_JSON_RPC_CLIENT <= INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK, (
+            "All JSON-RPC-only interfaces MUST skip the init getValue fallback"
         )
 
     def test_cuxd_does_not_support_rpc_callback(self) -> None:

--- a/tests/test_client_json_rpc_client.py
+++ b/tests/test_client_json_rpc_client.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2021-2026
 """Integration and unit tests for the JSON-RPC client using the local mock server."""
 
+import asyncio
 from collections.abc import Mapping
 from datetime import datetime
 from typing import Any, Self
@@ -234,6 +235,44 @@ class TestJsonRpcClientAuthentication:
 
         with pytest.raises(ClientException):
             await client._post(method=_JsonRpcMethod.CCU_GET_AUTH_ENABLED)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_login_creates_single_session(
+        self, aiohttp_session: ClientSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        A burst of concurrent cold-start logins must create only one CCU session.
+
+        Without a lock around ``_login_or_renew`` a burst of concurrent calls at init (all
+        seeing ``session_id is None``) each perform a ``Session.login``, creating several CCU
+        sessions at once and tripping the CCU's "too many sessions" limit.
+        """
+        conn_state = hmcu.CentralConnectionState()
+        client = AioJsonRpcAioHttpClient(
+            username="user",
+            password="pass",
+            device_url="http://example",
+            connection_state=conn_state,
+            client_session=aiohttp_session,
+            tls=False,
+        )
+
+        login_calls = {"count": 0}
+
+        async def counting_login() -> str:
+            login_calls["count"] += 1
+            await asyncio.sleep(0.01)  # yield so concurrent callers interleave before the session is set
+            return "sid-123"
+
+        monkeypatch.setattr(client, "_do_login", counting_login)  # type: ignore[attr-defined]
+
+        results = await asyncio.gather(*[client._login_or_renew() for _ in range(10)])
+
+        assert all(results)
+        assert client._session_id == "sid-123"  # type: ignore[attr-defined]
+        assert login_calls["count"] == 1
+
+        await client.stop()
 
     @pytest.mark.asyncio
     async def test_login_and_recent_renew_short_circuit(

--- a/tests/test_model_data_point.py
+++ b/tests/test_model_data_point.py
@@ -342,6 +342,53 @@ class TestDataPointLoading:
         ]
         assert len(status_calls) == 1
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_load_generic_data_point_skips_getvalue_for_cuxd(
+        self,
+        central_client_factory_with_homegear_client,
+        monkeypatch,
+    ) -> None:
+        """
+        CUxD (and CCU-Jack) must NOT run the per-parameter ``getValue`` fallback on init.
+
+        These JSON-RPC interfaces perform a ``Session.login`` per ``getValue`` call; running the
+        fallback for every readable data point (and its paired ``*_STATUS``, #3228) floods the CCU's
+        JSON-RPC session pool ("too many sessions") and marks CUxD devices unavailable. Their values
+        arrive via the bulk ``get_all_device_data`` fetch and MQTT events, so the fallback is skipped.
+        """
+        central, mock_client, _ = central_client_factory_with_homegear_client
+        # VCU2128127 is a HmIP-BSM; pin it to CUxD so the getValue fallback would run were it not
+        # skipped for JSON-RPC interfaces.
+        device = central.device_coordinator.get_device(address="VCU2128127")
+        monkeypatch.setattr(device, "_interface", Interface.CUXD)
+        switch: DpSwitch = cast(
+            DpSwitch, central.query_facade.get_generic_data_point(channel_address="VCU2128127:4", parameter="STATE")
+        )
+        await switch.load_data_point_value(call_source=CallSource.MANUAL_OR_SCHEDULED)
+        state_calls = [
+            c
+            for c in mock_client.method_calls
+            if c
+            == call.get_value(
+                channel_address="VCU2128127:4",
+                paramset_key=ParamsetKey.VALUES,
+                parameter="STATE",
+                call_source="hm_init",
+            )
+        ]
+        assert len(state_calls) == 0
+
 
 class TestWrappedDataPoint:
     """Tests for wrapped data point functionality."""


### PR DESCRIPTION
## Problem

After updating to `homematicip_local` 2.8.0/2.8.1 (aiohomematic **2026.7.1**) all
**CUxD** devices stay unavailable in Home Assistant, while 2.7.3 (aiohomematic
**2026.5.11**) worked. Diagnostics/log confirm the interface connects and receives
events, devices are created (`ADD_NEW_DEVICES: Homematic-CUxD, device_descriptions = 204`),
but the log is full of `invalid credentials or too many sessions` on the JSON-RPC
endpoint — **only for CUxD devices** — after which they are marked `is not available`
and never recover. Rollback to 2.7.3 fixes it.

The startup "too many sessions" storm itself is **pre-existing** (present in 2.7.3 too,
affecting all protocols for ~5 min after a HA restart). What regressed is that **CUxD no
longer survives it**.

## Changes

1. **Regression fix.** Add CUxD/CCU-Jack to the new
   `INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK` set (alongside VirtualDevices/BidCos-RF).
   Their values come from the single bulk `get_all_device_data` fetch and MQTT events, so
   the per-parameter `getValue` fallback is skipped.
2. **Hardening.** Serialize JSON-RPC login/renew with an `asyncio.Lock` (lock-free fast
   path for a recently refreshed session). `_login_or_renew` was unguarded, so a
   cold-start burst raced into multiple parallel `Session.login` calls, creating several
   CCU sessions at once. A cold-start burst now results in exactly one login the other
   callers reuse.

## Tests

- Reproducer: a CUxD-pinned generic data point does **not** call `get_value` on init.
- Contract test: CUxD/CCU-Jack are in `INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK`, and
  all JSON-RPC-only interfaces skip the fallback.
- Concurrency test: a burst of 10 concurrent cold-start `_login_or_renew()` calls results
  in exactly one `Session.login`.

`prek run` (ruff/mypy/pylint/sort-class-members/…) and the affected suites pass;
`VERSION`/changelog bumped to **2026.7.2**.

Fixes #3273 