### PR TITLE
fix(model): keep valve-only HmIP heating group climate valid (#3279)

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.7.3"
+VERSION: Final = "2026.7.4"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/model/custom/climate.py
+++ b/aiohomematic/model/custom/climate.py
@@ -722,8 +722,18 @@ class CustomDpIpThermostat(BaseCustomDpClimate):
     @property
     @override
     def _validity_irrelevant_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
-        """Exclude the LEVEL/STATE actuator values from validity checks (#3255)."""
-        return (self._dp_level, self._dp_state)
+        """
+        Exclude data points a valve-only heating group never refreshes from validity checks.
+
+        ``LEVEL``/``STATE`` are actuator values the CCU does not report for heating groups
+        (#3255). ``HUMIDITY``/``HEATING_COOLING`` are only fed by a wall thermostat
+        (``HmIP-WTH``/``STHD``): a group built from valves alone (``HmIP-eTRV``) never receives
+        events for them, and since #3228 ``VirtualDevices`` get no ``getValue`` fallback. Left in
+        the validity set they keep ``is_refreshed``/``is_valid`` false forever, freezing
+        ``current_temperature`` (``value_state=restored``) even though ``ACTUAL_TEMPERATURE``
+        arrives via event (#3279).
+        """
+        return (self._dp_level, self._dp_state, self._dp_humidity, self._dp_heating_mode)
 
     @config_property
     def schedule_profile_nos(self) -> int:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,23 @@
+# Version 2026.7.4 (2026-07-09)
+
+## What's Changed
+
+### Fixed
+
+- **Valve-only HmIP heating groups no longer freeze `current_temperature`/`current_humidity`
+  (#3279).** Follow-up to #3255. `HmIP-HEATING` groups always expose `HUMIDITY` and
+  `HEATING_COOLING` on the group channel, but only a group containing a wall thermostat
+  (`HmIP-WTH`/`STHD`) ever receives events for them. In a group built from valves alone
+  (`HmIP-eTRV`) those readable data points never refresh — and since #3228 `VirtualDevices`
+  get no `getValue` fallback — so they dragged the whole custom climate data point to
+  `is_valid=False`, leaving Home Assistant in `value_state=restored` and freezing
+  `current_temperature` at the last (re)start value even though `ACTUAL_TEMPERATURE` kept
+  arriving via events. #3255 only excluded the actuator values `LEVEL`/`STATE` from the climate
+  validity check; `CustomDpIpThermostat._validity_irrelevant_data_points` now also excludes
+  `HUMIDITY` and `HEATING_COOLING`, so a group's climate validity follows its aggregated
+  `ACTUAL_TEMPERATURE` regardless of whether a wall thermostat is present. A regression test
+  covers a valve-only group whose `HUMIDITY`/`HEATING_COOLING` never refresh.
+
 # Version 2026.7.3 (2026-07-08)
 
 ## What's Changed

--- a/tests/test_model_climate.py
+++ b/tests/test_model_climate.py
@@ -2634,6 +2634,43 @@ class TestClimateValidityIrrelevantDataPoints:
             (TEST_DEVICES, True, None, None),
         ],
     )
+    async def test_ip_heating_group_humidity_heating_cooling_excluded_from_validity(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """HUMIDITY/HEATING_COOLING must not block is_valid for a valve-only heating group (#3279)."""
+        central, _mock_client, _ = central_client_factory_with_homegear_client
+        climate = cast(CustomDpIpThermostat, get_prepared_custom_data_point(central, "VCU5778428", 1))
+        # Preconditions: HUMIDITY and HEATING_COOLING are real, readable data points on the group.
+        assert climate._dp_humidity.is_readable
+        assert climate._dp_heating_mode.is_readable
+        # They must be excluded from the validity-relevant data points (#3279).
+        assert climate._dp_humidity not in climate._relevant_data_points
+        assert climate._dp_heating_mode not in climate._relevant_data_points
+        # Simulate a valve-only group: every value arrives via event EXCEPT the actuator values
+        # (LEVEL/STATE) and the wall-thermostat-only values (HUMIDITY/HEATING_COOLING), which such
+        # a group never reports.
+        excluded = (climate._dp_level, climate._dp_state, climate._dp_humidity, climate._dp_heating_mode)
+        for dp in climate._readable_data_points:
+            if dp not in excluded:
+                dp._set_refreshed_at(refreshed_at=datetime.now())
+        assert climate._dp_humidity.is_refreshed is False
+        assert climate._dp_heating_mode.is_refreshed is False
+        # The climate must be valid even though HUMIDITY/HEATING_COOLING never refreshed.
+        assert climate.is_valid is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
     async def test_ip_thermostat_level_excluded_from_validity(
         self,
         central_client_factory_with_homegear_client,


### PR DESCRIPTION
## Summary

Fixes #3279 — a follow-up to #3255. `HmIP-HEATING` heating groups that contain **no** wall thermostat (built from valves like `HmIP-eTRV`) freeze `current_temperature`/`current_humidity` at the last-restart value since the 2.8.0 integration (aiohomematic #3228), while groups **with** a wall thermostat keep updating.

## Root cause (verified: reporter's log + pydevccu + code)

- `HmIP-HEATING` always exposes `HUMIDITY` and `HEATING_COOLING` on the group channel (verified in pydevccu: `:1` = `ACTUAL_TEMPERATURE, HEATING_COOLING, HUMIDITY, LEVEL, SET_POINT_TEMPERATURE, VALVE_STATE`).
- Only a group containing a wall thermostat (`HmIP-WTH`/`STHD`) receives events for `HUMIDITY`/`HEATING_COOLING`. In the reporter's log the broken group `INT0000006` receives `ACTUAL_TEMPERATURE=21.0` but **no** `HUMIDITY` event; the working group `INT0000002` receives `HUMIDITY=56`.
- Since #3228, `VirtualDevices` get no `getValue` fallback, so those never-refreshing readable data points stay `is_refreshed=False` and drag the aggregate custom-climate `is_valid` to `False` → Home Assistant keeps the entity in `value_state=restored`, freezing `current_temperature` even though `ACTUAL_TEMPERATURE` keeps arriving.
- #3255 (`d02167af`) only excluded the actuator values `LEVEL`/`STATE` from the climate validity check — it did **not** exclude `HUMIDITY`/`HEATING_COOLING`, and its regression test masked the gap by artificially refreshing every data point except `LEVEL`/`STATE`.

## Fix

`CustomDpIpThermostat._validity_irrelevant_data_points` now also excludes `HUMIDITY` and `HEATING_COOLING`, so a group's climate validity follows its aggregated `ACTUAL_TEMPERATURE` regardless of whether a wall thermostat is present — exactly the behaviour the reporter expects. `current_humidity` cleanly reports `None` for valve-only groups instead of a frozen value. BidCos groups (`HM-CC-VG-1`) are unaffected (no `HUMIDITY`/`HEATING_COOLING` on the group channel).

## Test

- New regression test on the real `HmIP-HEATING` group fixture `VCU5778428`: asserts `HUMIDITY`/`HEATING_COOLING` are readable, excluded from `_relevant_data_points`, and that `is_valid` stays `True` when they never refresh. **Verified it fails without the fix.**
- Full suite: 4098 passed, 1 skipped; prek all hooks green.