### PR TITLE
fix(model): gate custom data point validity by state-carrying fields only

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.7.5"
+VERSION: Final = "2026.7.6"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/model/custom/access_permission.py
+++ b/aiohomematic/model/custom/access_permission.py
@@ -7,7 +7,7 @@ Public API of this module is defined by __all__.
 """
 
 from enum import StrEnum, unique
-from typing import Final, Unpack, override
+from typing import ClassVar, Final, Unpack, override
 
 from aiohomematic import ccu_translations
 from aiohomematic.const import DataPointCategory, Field, Parameter
@@ -47,6 +47,7 @@ class CustomDpIpAccessPermission(CustomDataPoint):
     # Declarative data point field definitions
     _dp_authorization: Final = DataPointField(field=Field.ACCESS_AUTHORIZATION, dpt=DpActionSelect)
     _dp_state: Final = DataPointField(field=Field.STATE, dpt=DpBinarySensor)
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.STATE})
 
     value: Final = DelegatedProperty[bool | None](path="_dp_state.value")
 

--- a/aiohomematic/model/custom/climate.py
+++ b/aiohomematic/model/custom/climate.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta
 from enum import IntEnum, StrEnum, unique
 import logging
-from typing import Final, Unpack, cast, override
+from typing import ClassVar, Final, Unpack, cast, override
 
 from aiohomematic import i18n
 from aiohomematic.central.events import DataPointStateChangedEvent
@@ -25,7 +25,7 @@ from aiohomematic.const import (
 )
 from aiohomematic.decorators import inspector
 from aiohomematic.exceptions import ValidationException
-from aiohomematic.interfaces import ChannelProtocol, GenericDataPointProtocolAny
+from aiohomematic.interfaces import ChannelProtocol
 from aiohomematic.model.custom.capabilities.climate import (
     BASIC_CLIMATE_CAPABILITIES,
     IP_THERMOSTAT_CAPABILITIES,
@@ -182,6 +182,7 @@ class BaseCustomDpClimate(CustomDataPoint):
     _dp_temperature: Final = DataPointField(field=Field.TEMPERATURE, dpt=DpSensor[float | None])
     _dp_temperature_maximum: Final = DataPointField(field=Field.TEMPERATURE_MAXIMUM, dpt=DpFloat)
     _dp_temperature_minimum: Final = DataPointField(field=Field.TEMPERATURE_MINIMUM, dpt=DpFloat)
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.TEMPERATURE, Field.SETPOINT})
 
     def __init__(
         self,
@@ -212,28 +213,6 @@ class BaseCustomDpClimate(CustomDataPoint):
     current_humidity: Final = DelegatedProperty[int | None](path="_dp_humidity.value")
     current_temperature: Final = DelegatedProperty[float | None](path="_dp_temperature.value")
     target_temperature: Final = DelegatedProperty[float | None](path="_dp_setpoint.value")
-
-    @property
-    def _validity_irrelevant_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
-        """
-        Return readable data points that must not affect climate validity (#3255).
-
-        Actuator/activity values (``LEVEL``, ``STATE``, ``VALVE_STATE``) are not reported by
-        the CCU for heating groups (``HmIP-HEATING`` on the VirtualDevices interface), and since
-        the #3228 fixes the ``getValue`` fallback no longer fills them with a placeholder. Left
-        in the validity set they would keep ``is_refreshed``/``is_valid`` false forever, freezing
-        ``current_temperature``/``current_humidity`` (``value_state=restored``) while the sibling
-        sensors keep updating. Subclasses list their actuator data points here.
-        """
-        return ()
-
-    @property
-    @override
-    def _relevant_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
-        """Return readable data points relevant for validity, excluding actuator values (#3255)."""
-        if not (irrelevant := self._validity_irrelevant_data_points):
-            return self._readable_data_points
-        return tuple(dp for dp in self._readable_data_points if dp not in irrelevant)
 
     @property
     def _temperature_for_heat_mode(self) -> float:
@@ -488,6 +467,9 @@ class CustomDpRfThermostat(BaseCustomDpClimate):
     _dp_temperature_offset: Final = DataPointField(field=Field.TEMPERATURE_OFFSET, dpt=DpSelect)
     _dp_valve_state: Final = DataPointField(field=Field.VALVE_STATE, dpt=DpSensor[int | None])
     _dp_week_program_pointer: Final = DataPointField(field=Field.WEEK_PROGRAM_POINTER, dpt=DpSelect)
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset(
+        {Field.TEMPERATURE, Field.SETPOINT, Field.CONTROL_MODE}
+    )
 
     @property
     def _current_profile_name(self) -> ClimateProfile | None:
@@ -511,12 +493,6 @@ class CustomDpRfThermostat(BaseCustomDpClimate):
                 profiles[ClimateProfile(f"{PROFILE_PREFIX}{i}")] = i - 1
 
         return profiles
-
-    @property
-    @override
-    def _validity_irrelevant_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
-        """Exclude the VALVE_STATE actuator readback from validity checks (#3255)."""
-        return (self._dp_valve_state,)
 
     @property
     def activity(self) -> ClimateActivity | None:
@@ -693,6 +669,9 @@ class CustomDpIpThermostat(BaseCustomDpClimate):
     _dp_set_point_mode: Final = DataPointField(field=Field.SET_POINT_MODE, dpt=DpInteger)
     _dp_state: Final = DataPointField(field=Field.STATE, dpt=DpBinarySensor)
     _dp_temperature_offset: Final = DataPointField(field=Field.TEMPERATURE_OFFSET, dpt=DpFloat)
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset(
+        {Field.TEMPERATURE, Field.SETPOINT, Field.SET_POINT_MODE}
+    )
 
     optimum_start_stop: Final = DelegatedProperty[bool | None](path="_dp_optimum_start_stop.value")
     temperature_offset: Final = DelegatedProperty[float | None](path="_dp_temperature_offset.value")
@@ -725,22 +704,6 @@ class CustomDpIpThermostat(BaseCustomDpClimate):
                 profiles[ClimateProfile(f"{PROFILE_PREFIX}{i}")] = i
 
         return profiles
-
-    @property
-    @override
-    def _validity_irrelevant_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
-        """
-        Exclude data points a valve-only heating group never refreshes from validity checks.
-
-        ``LEVEL``/``STATE`` are actuator values the CCU does not report for heating groups
-        (#3255). ``HUMIDITY``/``HEATING_COOLING`` are only fed by a wall thermostat
-        (``HmIP-WTH``/``STHD``): a group built from valves alone (``HmIP-eTRV``) never receives
-        events for them, and since #3228 ``VirtualDevices`` get no ``getValue`` fallback. Left in
-        the validity set they keep ``is_refreshed``/``is_valid`` false forever, freezing
-        ``current_temperature`` (``value_state=restored``) even though ``ACTUAL_TEMPERATURE``
-        arrives via event (#3279).
-        """
-        return (self._dp_level, self._dp_state, self._dp_humidity, self._dp_heating_mode)
 
     @property
     def activity(self) -> ClimateActivity | None:

--- a/aiohomematic/model/custom/cover.py
+++ b/aiohomematic/model/custom/cover.py
@@ -9,12 +9,11 @@ Public API of this module is defined by __all__.
 import asyncio
 from enum import IntEnum, StrEnum, unique
 import logging
-from typing import Final, Unpack, override
+from typing import ClassVar, Final, Unpack, override
 
 from aiohomematic.client import CommandPriority
 from aiohomematic.const import DataPointCategory, DataPointUsage, DeviceProfile, Field, Parameter
 from aiohomematic.converter import convert_hm_level_to_cpv
-from aiohomematic.interfaces import GenericDataPointProtocolAny
 from aiohomematic.model.custom.capabilities.cover import (
     BLIND_CAPABILITIES,
     COVER_CAPABILITIES,
@@ -124,6 +123,7 @@ class CustomDpCover(PositionMixin, CustomDataPoint):
     _dp_group_level: Final = DataPointField(field=Field.GROUP_LEVEL, dpt=DpSensor[float | None])
     _dp_level: Final = DataPointField(field=Field.LEVEL, dpt=DpFloat)
     _dp_stop: Final = DataPointField(field=Field.STOP, dpt=DpAction)
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.LEVEL})
 
     @property
     def _group_level(self) -> float:
@@ -303,13 +303,6 @@ class CustomDpBlind(CustomDpCover):
         ):
             return float(self._dp_group_level_2.value)
         return self._dp_level_2.value if self._dp_level_2.value is not None else self._closed_level
-
-    @property
-    def _relevant_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
-        """Return the list of relevant data points for state validity checks."""
-        if self._dp_level_2.value is not None:
-            return self._readable_data_points
-        return tuple(dp for dp in self._readable_data_points if dp is not self._dp_level_2)
 
     @property
     def _target_level(self) -> float | None:
@@ -591,6 +584,7 @@ class CustomDpGarage(PositionMixin, CustomDataPoint):
     _dp_door_command: Final = DataPointField(field=Field.DOOR_COMMAND, dpt=DpActionSelect)
     _dp_door_state: Final = DataPointField(field=Field.DOOR_STATE, dpt=DpSensor[str | None])
     _dp_section: Final = DataPointField(field=Field.SECTION, dpt=DpSensor[int | None])
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.DOOR_STATE})
 
     @property
     def current_position(self) -> int | None:

--- a/aiohomematic/model/custom/data_point.py
+++ b/aiohomematic/model/custom/data_point.py
@@ -9,7 +9,7 @@ Public API of this module is defined by __all__.
 from collections.abc import Mapping
 from datetime import datetime
 import logging
-from typing import Any, Final, Unpack, override
+from typing import Any, ClassVar, Final, Unpack, override
 import weakref
 
 from aiohomematic import ccu_translations
@@ -107,10 +107,19 @@ class CustomDataPoint(BaseDataPoint, CustomDataPointProtocol):
         """Returns the list of readable data points."""
         return tuple(dp for dp in self._data_points.values() if dp.is_readable)
 
+    # Fields whose readable data points gate validity (is_refreshed / is_valid /
+    # state_uncertain). Assigned by subclasses; enforced for every concrete class by
+    # tests/contract/test_cdp_validity_contract.py. An empty set means "always valid"
+    # (write-only devices). See ADR-0025.
+    # pylint false positive: a value-less ClassVar annotation is not a slot declaration.
+    _validity_relevant_fields: ClassVar[frozenset[Field]]  # pylint: disable=declare-non-slot
+
     @property
     def _relevant_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
-        """Returns the list of relevant data points. To be overridden by subclasses."""
-        return self._readable_data_points
+        """Return the readable data points whose fields gate validity."""
+        return tuple(
+            dp for field, dp in self._data_points.items() if field in self._validity_relevant_fields and dp.is_readable
+        )
 
     @property
     def data_point_name_postfix(self) -> str:

--- a/aiohomematic/model/custom/light.py
+++ b/aiohomematic/model/custom/light.py
@@ -9,7 +9,7 @@ Public API of this module is defined by __all__.
 from collections.abc import Mapping
 from enum import StrEnum, unique
 import math
-from typing import Final, TypedDict, Unpack, override
+from typing import ClassVar, Final, TypedDict, Unpack, override
 
 from aiohomematic.const import DataPointCategory, DataPointUsage, DeviceProfile, Field, Parameter
 from aiohomematic.model.combined.field import CombinedHsColorField, CombinedTimerField
@@ -19,7 +19,7 @@ from aiohomematic.model.custom.field import DataPointField
 from aiohomematic.model.custom.mixins import BrightnessMixin, StateChangeArgs, StateChangeTimerMixin
 from aiohomematic.model.custom.registry import DeviceConfig, DeviceProfileRegistry, ExtendedDeviceConfig
 from aiohomematic.model.data_point import CallParameterCollector, bind_collector
-from aiohomematic.model.generic import DpActionSelect, DpFloat, DpInteger, DpSelect, DpSensor, GenericDataPointAny
+from aiohomematic.model.generic import DpActionSelect, DpFloat, DpInteger, DpSelect, DpSensor
 from aiohomematic.property_decorators import DelegatedProperty, hm_property
 
 # Activity states indicating LED is active
@@ -235,6 +235,7 @@ class CustomDpDimmer(StateChangeTimerMixin, BrightnessMixin, CustomDataPoint):
     _dp_level: Final = DataPointField(field=Field.LEVEL, dpt=DpFloat)
     _dp_on_time = CombinedTimerField(value_field=Field.ON_TIME_VALUE)
     _dp_ramp_time = CombinedTimerField(value_field=Field.RAMP_TIME_VALUE)
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.LEVEL})
 
     @property
     def _commanded_brightness(self) -> int | None:
@@ -572,22 +573,6 @@ class CustomDpIpRGBWLight(CustomDpDimmer):
             return _DeviceOperationMode.RGBW
 
     @property
-    def _relevant_data_points(self) -> tuple[GenericDataPointAny, ...]:
-        """Returns the list of relevant data points. To be overridden by subclasses."""
-        if self._device_operation_mode == _DeviceOperationMode.RGBW:
-            return (
-                self._dp_hue,
-                self._dp_level,
-                self._dp_saturation,
-                self._dp_color_temperature_kelvin,
-            )
-        if self._device_operation_mode == _DeviceOperationMode.RGB:
-            return self._dp_hue, self._dp_level, self._dp_saturation
-        if self._device_operation_mode == _DeviceOperationMode.TUNABLE_WHITE:
-            return self._dp_level, self._dp_color_temperature_kelvin
-        return (self._dp_level,)
-
-    @property
     def color_temp_kelvin(self) -> int | None:
         """Return the color temperature in kelvin."""
         if not self._dp_color_temperature_kelvin.value:
@@ -708,11 +693,6 @@ class CustomDpIpDrgDaliLight(CustomDpDimmer):
     _dp_on_time = CombinedTimerField(value_field=Field.ON_TIME_VALUE, unit_field=Field.ON_TIME_UNIT)
     _dp_ramp_time = CombinedTimerField(value_field=Field.RAMP_TIME_VALUE, unit_field=Field.RAMP_TIME_UNIT)
     _dp_saturation: Final = DataPointField(field=Field.SATURATION, dpt=DpFloat)
-
-    @property
-    def _relevant_data_points(self) -> tuple[GenericDataPointAny, ...]:
-        """Returns the list of relevant data points. To be overridden by subclasses."""
-        return (self._dp_level,)
 
     @property
     def color_temp_kelvin(self) -> int | None:

--- a/aiohomematic/model/custom/lock.py
+++ b/aiohomematic/model/custom/lock.py
@@ -8,7 +8,7 @@ Public API of this module is defined by __all__.
 
 from abc import abstractmethod
 from enum import StrEnum, unique
-from typing import Final
+from typing import ClassVar, Final
 
 from aiohomematic.client import CommandPriority
 from aiohomematic.const import DataPointCategory, DeviceProfile, Field, Parameter
@@ -118,6 +118,7 @@ class CustomDpIpLock(BaseCustomDpLock):
     _dp_direction: Final = DataPointField(field=Field.DIRECTION, dpt=DpSensor[str | None])
     _dp_lock_state: Final = DataPointField(field=Field.LOCK_STATE, dpt=DpSensor[str | None])
     _dp_lock_target_level: Final = DataPointField(field=Field.LOCK_TARGET_LEVEL, dpt=DpActionSelect)
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.LOCK_STATE})
 
     @property
     def is_locked(self) -> bool:
@@ -165,6 +166,7 @@ class CustomDpButtonLock(BaseCustomDpLock):
 
     # Declarative data point field definitions
     _dp_button_lock: Final = DataPointField(field=Field.BUTTON_LOCK, dpt=DpSwitch)
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.BUTTON_LOCK})
 
     @property
     def data_point_name_postfix(self) -> str:
@@ -206,6 +208,7 @@ class CustomDpRfLock(BaseCustomDpLock):
     _dp_error: Final = DataPointField(field=Field.ERROR, dpt=DpSensor[str | None])
     _dp_open: Final = DataPointField(field=Field.OPEN, dpt=DpAction)
     _dp_state: Final = DataPointField(field=Field.STATE, dpt=DpSwitch)
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.STATE})
 
     @property
     def is_jammed(self) -> bool:

--- a/aiohomematic/model/custom/siren.py
+++ b/aiohomematic/model/custom/siren.py
@@ -8,7 +8,7 @@ Public API of this module is defined by __all__.
 
 from abc import abstractmethod
 from enum import StrEnum, unique
-from typing import Final, TypedDict, Unpack
+from typing import ClassVar, Final, TypedDict, Unpack
 
 from aiohomematic import i18n
 from aiohomematic.client import CommandPriority
@@ -145,6 +145,9 @@ class CustomDpIpSiren(BaseCustomDpSiren):
     _dp_duration: Final = CombinedTimerField(value_field=Field.DURATION, unit_field=Field.DURATION_UNIT, visible=True)
     _dp_optical_alarm_active: Final = DataPointField(field=Field.OPTICAL_ALARM_ACTIVE, dpt=DpBinarySensor)
     _dp_optical_alarm_selection: Final = DataPointField(field=Field.OPTICAL_ALARM_SELECTION, dpt=DpActionSelect)
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset(
+        {Field.ACOUSTIC_ALARM_ACTIVE, Field.OPTICAL_ALARM_ACTIVE}
+    )
 
     available_lights: Final = DelegatedProperty[tuple[str, ...] | None](path="_dp_optical_alarm_selection.values")
     available_tones: Final = DelegatedProperty[tuple[str, ...] | None](path="_dp_acoustic_alarm_selection.values")
@@ -227,6 +230,7 @@ class CustomDpIpSirenSmoke(BaseCustomDpSiren):
         field=Field.SMOKE_DETECTOR_ALARM_STATUS, dpt=DpSensor[str | None]
     )
     _dp_smoke_detector_command: Final = DataPointField(field=Field.SMOKE_DETECTOR_COMMAND, dpt=DpActionSelect)
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.SMOKE_DETECTOR_ALARM_STATUS})
 
     @property
     def available_lights(self) -> tuple[str, ...] | None:
@@ -277,6 +281,8 @@ class CustomDpSoundPlayer(BaseCustomDpSiren):
     _dp_soundfile: Final = DataPointField(field=Field.SOUNDFILE, dpt=DpSelect)
     _dp_repetitions: Final = DataPointField(field=Field.REPETITIONS, dpt=DpActionSelect)
     _dp_direction: Final = DataPointField(field=Field.DIRECTION, dpt=DpSensor[str | None])
+    # ACTIVITY_STATE carries is_on ("is playing") — the state-carrying field here.
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.DIRECTION})
 
     # Expose available options via DelegatedProperty (from ActionSelect VALUE_LISTs)
     @staticmethod

--- a/aiohomematic/model/custom/switch.py
+++ b/aiohomematic/model/custom/switch.py
@@ -7,7 +7,7 @@ Public API of this module is defined by __all__.
 """
 
 import logging
-from typing import Final, Unpack, override
+from typing import ClassVar, Final, Unpack, override
 
 from aiohomematic.const import DataPointCategory, DeviceProfile, Field, Parameter
 from aiohomematic.model.combined.field import CombinedTimerField
@@ -34,6 +34,7 @@ class CustomDpSwitch(StateChangeTimerMixin, GroupStateMixin, CustomDataPoint):
     _dp_group_state = DataPointField(field=Field.GROUP_STATE, dpt=DpBinarySensor)
     _dp_on_time = CombinedTimerField(value_field=Field.ON_TIME_VALUE)
     _dp_state: Final = DataPointField(field=Field.STATE, dpt=DpSwitch)
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.STATE})
 
     value: Final = DelegatedProperty[bool | None](path="_dp_state.value")
 

--- a/aiohomematic/model/custom/text_display.py
+++ b/aiohomematic/model/custom/text_display.py
@@ -10,7 +10,7 @@ Public API of this module is defined by __all__.
 """
 
 import logging
-from typing import Final, TypedDict, Unpack
+from typing import ClassVar, Final, TypedDict, Unpack
 
 from aiohomematic import i18n
 from aiohomematic.const import DataPointCategory, DeviceProfile, Field
@@ -78,6 +78,9 @@ class CustomDpTextDisplay(CustomDataPoint):
     _dp_interval: Final = DataPointField(field=Field.INTERVAL, dpt=DpActionSelect)
     _dp_repetitions: Final = DataPointField(field=Field.REPETITIONS, dpt=DpActionSelect)
     _dp_burst_limit_warning: Final = DataPointField(field=Field.BURST_LIMIT_WARNING, dpt=DpBinarySensor)
+    # Write-only device: no field gates validity, BURST_LIMIT_WARNING is a warning
+    # channel, not a state carrier.
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset()
 
     # Expose available options via DelegatedProperty
     @staticmethod

--- a/aiohomematic/model/custom/valve.py
+++ b/aiohomematic/model/custom/valve.py
@@ -7,7 +7,7 @@ Public API of this module is defined by __all__.
 """
 
 import logging
-from typing import Final, Unpack, override
+from typing import ClassVar, Final, Unpack, override
 
 from aiohomematic.const import DataPointCategory, DeviceProfile, Field
 from aiohomematic.model.combined.field import CombinedTimerField
@@ -33,6 +33,7 @@ class CustomDpIpIrrigationValve(StateChangeTimerMixin, GroupStateMixin, CustomDa
     _dp_group_state = DataPointField(field=Field.GROUP_STATE, dpt=DpBinarySensor)
     _dp_on_time = CombinedTimerField(value_field=Field.ON_TIME_VALUE)
     _dp_state: Final = DataPointField(field=Field.STATE, dpt=DpSwitch)
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.STATE})
 
     value: Final = DelegatedProperty[bool | None](path="_dp_state.value")
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,26 @@
+# Version 2026.7.6 (2026-07-10)
+
+## What's Changed
+
+### Changed
+
+- **Custom data point validity is now gated only by state-carrying fields
+  (ADR-0025).** Secondary values (activity/direction readbacks, group-channel
+  readbacks, colors, extra sensors, MASTER config values) can stay unrefreshed for
+  hours after a CCU restart — nothing re-polls them — and previously dragged the whole
+  custom data point to `is_valid=False`, leaving Home Assistant entities stuck in
+  `value_state=restored` (covers; same class as climate #3255/#3279). Every
+  custom data point class now declares its validity-relevant fields in a single
+  declarative `_validity_relevant_fields` set (cover/blind/dimmer: `LEVEL`;
+  switch/valve/access permission: `STATE`; garage: `DOOR_STATE`; locks:
+  `LOCK_STATE`/`STATE`/`BUTTON_LOCK`; climate: `ACTUAL_TEMPERATURE` + setpoint + mode
+  source; sirens: alarm-active states; sound player: `ACTIVITY_STATE`). The climate
+  blocklist `_validity_irrelevant_data_points` (#3255) and the per-class
+  `_relevant_data_points` overrides (blind `LEVEL_2`, RGBW operation-mode allowlist,
+  DALI) are replaced by the unified mechanism. A new contract test
+  (`tests/contract/test_cdp_validity_contract.py`) pins the field set of all 27
+  classes.
+
 # Version 2026.7.5 (2026-07-10)
 
 ## What's Changed

--- a/docs/adr/0025-cdp-validity-relevant-fields.md
+++ b/docs/adr/0025-cdp-validity-relevant-fields.md
@@ -1,0 +1,151 @@
+# ADR-0025: Custom Data Point Validity Gating via Validity-Relevant Fields
+
+## Status
+
+Accepted (2026-07-10)
+
+## Context
+
+### Three coexisting mechanisms
+
+`CustomDataPoint.is_valid` (and, transitively, `is_refreshed` / `state_uncertain`) is
+derived from `_relevant_data_points`: the set of the custom data point's own readable
+data points that must have refreshed at least once before the custom data point is
+considered valid. Historically this set was produced by three different, coexisting
+mechanisms:
+
+1. **Default "all readable"** — the base `_relevant_data_points` property returned
+   every readable field data point (`self._readable_data_points`).
+2. **Climate blocklist** — `BaseCustomDpClimate` and its subclasses defined
+   `_validity_irrelevant_data_points`, a set of data points to _subtract_ from the
+   default "all readable" set.
+3. **Per-class allowlist overrides** — individual classes (`CustomDpBlind`,
+   `CustomDpIpRGBWLight`, `CustomDpIpDrgDaliLight`) overrode `_relevant_data_points`
+   directly with bespoke, value-dependent logic (e.g. excluding `LEVEL_2` only when the
+   device never reports it, or excluding color fields based on the current operation
+   mode).
+
+### Failure class
+
+Under the default "all readable" mechanism, _every_ readable field data point gates
+validity — including secondary values such as activity/direction readbacks,
+group-channel readbacks, colors, and extra sensors. These secondary data points are
+frequently `NO_CREATE` and are therefore excluded from the periodic refresh
+(`refresh_data_point_data`); nothing re-polls them after a reconnect. If the CCU does
+not spontaneously emit an event for a secondary parameter, its data point never
+refreshes, and the whole custom data point — including its primary, state-carrying
+value — stays `is_valid=False` for hours after a CCU restart.
+
+This was observed and worked around piecemeal:
+
+- Climate (#3255, #3279): mode-independent fields (`ACTIVE_PROFILE`, `PARTY_MODE`,
+  `CONCENTRATION`, `HUMIDITY`, MASTER fields) had to be added to
+  `_validity_irrelevant_data_points` one at a time as they were discovered.
+- Cover/switch/other custom data points: the same class of failure exists for
+  every custom data point that still relies on the default "all readable" mechanism —
+  e.g. a cover's `DIRECTION` or `GROUP_LEVEL` readback blocking `is_valid` even though
+  `LEVEL` — the only value a consumer needs — has already been refreshed.
+
+The blocklist approach does not scale: it requires enumerating every secondary field
+retroactively, per class, after each failure report, and the allowlist overrides
+duplicated similar logic ad hoc per class with no shared contract.
+
+## Decision
+
+Replace all three mechanisms with a single declarative allowlist:
+
+```python
+class CustomDataPoint(...):
+    # Fields whose readable data points gate validity. Assigned by subclasses.
+    _validity_relevant_fields: ClassVar[frozenset[Field]]
+
+    @property
+    def _relevant_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
+        """Return the readable data points whose fields gate validity."""
+        return tuple(
+            dp
+            for field, dp in self._data_points.items()
+            if field in self._validity_relevant_fields and dp.is_readable
+        )
+```
+
+- `CustomDataPoint` declares `_validity_relevant_fields` as an annotation only (no
+  default value) — every concrete subclass must assign it explicitly, either directly
+  or by inheriting an identical set from its parent.
+- The set is filtered by `is_readable`: fields not present on a particular device (or
+  resolved to `DpDummy`, which is never readable) drop out automatically. No special
+  casing is needed for devices that lack an optional field.
+- An empty set is a deliberate, valid declaration: `all(())` is `True`, so a custom
+  data point with no validity-relevant fields is always considered valid. This is used
+  for write-only devices (`CustomDpTextDisplay`), whose only readable field
+  (`BURST_LIMIT_WARNING`) is a warning channel, not a state carrier.
+- No subclass may override `_relevant_data_points` anymore — the frozenset is the only
+  mechanism. This is enforced by a contract test.
+- A new contract test, `tests/contract/test_cdp_validity_contract.py`, pins the
+  effective `_validity_relevant_fields` set for all 27 concrete custom data point
+  classes. Any change to a set is a deliberate, changelog-documented decision, not an
+  incidental side effect of refactoring.
+
+### Field set examples
+
+Fields are chosen to be the minimal set of state carriers, not every readable field:
+
+- Cover/blind/dimmer classes: `{LEVEL}` — `DIRECTION`, `GROUP_LEVEL`, `LEVEL_2`
+  (optional slats level, per D4 in the implementation plan) no longer gate validity.
+- Switch/valve/access permission: `{STATE}`.
+- Garage: `{DOOR_STATE}`.
+- Locks: `{LOCK_STATE}` / `{STATE}` / `{BUTTON_LOCK}` depending on the class.
+- Climate: `{TEMPERATURE, SETPOINT}` plus the field that feeds `mode`
+  (`CONTROL_MODE` for RF, `SET_POINT_MODE` for IP). `ACTIVE_PROFILE`, `PARTY_MODE`,
+  `CONCENTRATION`, `HUMIDITY` and all MASTER fields no longer gate validity.
+- Sirens: the alarm-active state fields (e.g. `ACOUSTIC_ALARM_ACTIVE` /
+  `OPTICAL_ALARM_ACTIVE`, or `SMOKE_DETECTOR_ALARM_STATUS`).
+- Sound player: `{DIRECTION}`, because its `is_on` ("is playing") is derived from
+  `ACTIVITY_STATE`, making that the state carrier for this class.
+- RGBW/DALI lights: `{LEVEL}` only — color values (`HUE`, `SATURATION`,
+  `COLOR_TEMPERATURE`) are exposed as attributes and no longer gate validity. This is a
+  deliberate relaxation versus the previous per-operation-mode allowlist.
+
+The full contract table lives in
+`tests/contract/test_cdp_validity_contract.py::EXPECTED_VALIDITY_RELEVANT_FIELDS`.
+
+## Consequences
+
+### Positive
+
+- Entities become valid as soon as their state-carrying fields refresh, regardless of
+  whether secondary/readback fields have ever received a value. This closes the
+  `value_state=restored` failure class reported in #3255 and #3279.
+- A single, uniform mechanism replaces three overlapping ones — no more blocklist
+  maintenance, no more bespoke per-class override logic.
+- The contract test makes validity gating an explicit, reviewable contract: adding a
+  new custom data point class fails the test until its author consciously declares
+  `_validity_relevant_fields`, and widening an existing set requires a deliberate,
+  changelog-documented change.
+
+### Negative / trade-offs
+
+- Secondary attributes (activity/direction readbacks, colors, group-channel readbacks,
+  extra sensors) may report `None` or a stale value while the owning custom data point
+  is already valid — they are no longer coupled to `is_valid`. Consumers that need
+  freshness guarantees for a specific secondary attribute must check that data point's
+  own `is_refreshed` state directly.
+- RGBW/DALI lights slightly relax existing behavior: color fields no longer gate
+  validity, so a light can report `is_valid=True` with an unrefreshed color. This is
+  accepted as consistent with the general principle (see the implementation plan,
+  `docs/plans/cdp_validity_relevant_fields_2026_07.md`, decision D6).
+- Blinds with a permanently-absent `LEVEL_2` (e.g. operated as plain shutters) are
+  valid based on `LEVEL` alone; `tilt_position` may stay `None` indefinitely. This is
+  intentional (decision D4) — gating on `LEVEL_2` would recreate the same failure
+  class for those devices.
+- No migration guide is required: `_validity_irrelevant_data_points` and the removed
+  per-class `_relevant_data_points` overrides were protected (non-public) members, so
+  this is not a public API change.
+
+## References
+
+- `aiohomematic/model/custom/data_point.py` — `_relevant_data_points` base property
+- `tests/contract/test_cdp_validity_contract.py` — contract test pinning all 27 classes
+- `docs/plans/cdp_validity_relevant_fields_2026_07.md` — implementation plan with the
+  full per-class rationale (design decisions D1–D8)
+- Issues #3255, #3279

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -4,30 +4,31 @@ This directory contains Architecture Decision Records (ADRs) for the aiohomemati
 
 ## Index
 
-| ADR                                                                | Title                                                         | Status                 |
-| ------------------------------------------------------------------ | ------------------------------------------------------------- | ---------------------- |
-| [0001](0001-circuit-breaker-and-connection-state.md)               | CircuitBreaker and CentralConnectionState Coexistence         | Accepted               |
-| [0002](0002-protocol-based-dependency-injection.md)                | Protocol-Based Dependency Injection                           | Accepted               |
-| [0003](0003-explicit-over-composite-protocol-injection.md)         | Explicit over Composite Protocol Injection                    | Accepted               |
-| [0004](0004-thread-based-xml-rpc-server.md)                        | Thread-Based XML-RPC Server                                   | Superseded by ADR 0012 |
-| [0005](0005-unbounded-parameter-visibility-cache.md)               | Unbounded Parameter Visibility Cache                          | Accepted               |
-| [0006](0006-event-system-priorities-and-batching.md)               | Event System Priorities and Batching                          | Accepted               |
-| [0007](0007-device-slots-reduction-rejected.md)                    | Device Slots Reduction via Composition                        | Rejected               |
-| [0008](0008-taskgroup-migration-deferred.md)                       | TaskGroup Migration                                           | Deferred               |
-| [0009](0009-interface-event-consolidation.md)                      | Interface Event Consolidation                                 | Accepted               |
-| [0010](0010-protocol-combination-analysis.md)                      | Protocol Combination Analysis                                 | Accepted               |
-| [0011](0011-storage-abstraction.md)                                | Storage Abstraction Layer                                     | Accepted               |
-| [0012](0012-async-xml-rpc-server-poc.md)                           | Async XML-RPC Server                                          | Accepted               |
-| [0013](0013-interface-client-backend-strategy.md)                  | InterfaceClient with Backend Strategy Pattern                 | Accepted               |
-| [0013a](0013a-implementation-status.md)                            | Implementation Status (tracking document)                     | --                     |
-| [0014](0014-retry-logic-removal.md)                                | Removal of Retry Logic for RPC Operations                     | Accepted               |
-| [0015](0015-description-normalization-concept.md)                  | Description Data Normalization and Validation                 | Accepted               |
-| [0016](0016-paramset-description-patching.md)                      | Paramset Description Patching                                 | Accepted               |
-| [0017](0017-startup-auth-error-handling.md)                        | Defensive Client Initialization with Staged Validation        | Accepted               |
-| [0018](0018-contract-tests.md)                                     | Contract Tests for CUxD/CCU-Jack Stability                    | Accepted               |
-| [0019](0019-derived-binary-sensors.md)                             | Derived Binary Sensors from Enum Data Points                  | Accepted               |
-| [0020](0020-command-throttling-priority-and-optimistic-updates.md) | Command Throttling with Priority Queue and Optimistic Updates | Accepted               |
-| [0021](0021-blind-command-processing-lock.md)                      | Blind Command Processing Lock and Target Preservation         | Accepted               |
-| [0022](0022-week-profile-data-point.md)                            | Unified Schedule Access via WeekProfileDataPoint              | Accepted               |
-| [0023](0023-paramset-consistency-checker.md)                       | Paramset Consistency Checker                                  | Implemented            |
-| [0024](0024-ccu-translation-extraction.md)                         | CCU Translation Extraction                                    | Implemented            |
+| ADR                                                                | Title                                                          | Status                 |
+| ------------------------------------------------------------------ | -------------------------------------------------------------- | ---------------------- |
+| [0001](0001-circuit-breaker-and-connection-state.md)               | CircuitBreaker and CentralConnectionState Coexistence          | Accepted               |
+| [0002](0002-protocol-based-dependency-injection.md)                | Protocol-Based Dependency Injection                            | Accepted               |
+| [0003](0003-explicit-over-composite-protocol-injection.md)         | Explicit over Composite Protocol Injection                     | Accepted               |
+| [0004](0004-thread-based-xml-rpc-server.md)                        | Thread-Based XML-RPC Server                                    | Superseded by ADR 0012 |
+| [0005](0005-unbounded-parameter-visibility-cache.md)               | Unbounded Parameter Visibility Cache                           | Accepted               |
+| [0006](0006-event-system-priorities-and-batching.md)               | Event System Priorities and Batching                           | Accepted               |
+| [0007](0007-device-slots-reduction-rejected.md)                    | Device Slots Reduction via Composition                         | Rejected               |
+| [0008](0008-taskgroup-migration-deferred.md)                       | TaskGroup Migration                                            | Deferred               |
+| [0009](0009-interface-event-consolidation.md)                      | Interface Event Consolidation                                  | Accepted               |
+| [0010](0010-protocol-combination-analysis.md)                      | Protocol Combination Analysis                                  | Accepted               |
+| [0011](0011-storage-abstraction.md)                                | Storage Abstraction Layer                                      | Accepted               |
+| [0012](0012-async-xml-rpc-server-poc.md)                           | Async XML-RPC Server                                           | Accepted               |
+| [0013](0013-interface-client-backend-strategy.md)                  | InterfaceClient with Backend Strategy Pattern                  | Accepted               |
+| [0013a](0013a-implementation-status.md)                            | Implementation Status (tracking document)                      | --                     |
+| [0014](0014-retry-logic-removal.md)                                | Removal of Retry Logic for RPC Operations                      | Accepted               |
+| [0015](0015-description-normalization-concept.md)                  | Description Data Normalization and Validation                  | Accepted               |
+| [0016](0016-paramset-description-patching.md)                      | Paramset Description Patching                                  | Accepted               |
+| [0017](0017-startup-auth-error-handling.md)                        | Defensive Client Initialization with Staged Validation         | Accepted               |
+| [0018](0018-contract-tests.md)                                     | Contract Tests for CUxD/CCU-Jack Stability                     | Accepted               |
+| [0019](0019-derived-binary-sensors.md)                             | Derived Binary Sensors from Enum Data Points                   | Accepted               |
+| [0020](0020-command-throttling-priority-and-optimistic-updates.md) | Command Throttling with Priority Queue and Optimistic Updates  | Accepted               |
+| [0021](0021-blind-command-processing-lock.md)                      | Blind Command Processing Lock and Target Preservation          | Accepted               |
+| [0022](0022-week-profile-data-point.md)                            | Unified Schedule Access via WeekProfileDataPoint               | Accepted               |
+| [0023](0023-paramset-consistency-checker.md)                       | Paramset Consistency Checker                                   | Implemented            |
+| [0024](0024-ccu-translation-extraction.md)                         | CCU Translation Extraction                                     | Implemented            |
+| [0025](0025-cdp-validity-relevant-fields.md)                       | Custom Data Point Validity Gating via Validity-Relevant Fields | Accepted               |

--- a/docs/developer/extension_points.md
+++ b/docs/developer/extension_points.md
@@ -55,7 +55,11 @@ Custom device profiles are used when a specific device (model) requires a bespok
    - If you need special behavior, subclass CustomDataPoint and override:
      - Use `DataPointField` descriptors for declarative field definitions
      - Override `_post_init()` for additional initialization after field resolution
-     - `_readable_data_points` / `_relevant_data_points` (to tune exposure)
+     - Declare `_validity_relevant_fields: ClassVar[frozenset[Field]]` — the fields that
+       gate validity (`is_valid`/`value_state`, see ADR-0025). Every concrete class must
+       resolve it (no base default); do not override `_relevant_data_points`. Add the new
+       class to `EXPECTED_VALIDITY_RELEVANT_FIELDS` in
+       `tests/contract/test_cdp_validity_contract.py`.
      - `@property` getters if you compute an aggregate state
 
 2. **Register the device with DeviceProfileRegistry**

--- a/docs/developer/homematicip_local_api_usage.md
+++ b/docs/developer/homematicip_local_api_usage.md
@@ -269,7 +269,9 @@ BaseDataPoint is the core class for all device parameters and controls.
 
 #### State Information
 
-- **`is_valid`** - Value validity status
+- **`is_valid`** - Value validity status. For custom data points, `is_valid` is gated
+  only by the validity-relevant fields declared for that class (see
+  [ADR-0025](../adr/0025-cdp-validity-relevant-fields.md)), not by every readable field.
 - **`is_readable`** - Whether parameter is readable
 - **`available`** - Data point availability
 - **`state_uncertain`** - State uncertainty flag

--- a/docs/plans/cdp_validity_relevant_fields_2026_07.md
+++ b/docs/plans/cdp_validity_relevant_fields_2026_07.md
@@ -1,0 +1,566 @@
+# Plan: Unified validity gating for custom data points (`_validity_relevant_fields`)
+
+Status: implemented (2026-07-10, released as 2026.7.6)
+Related issues: #3255, #3279
+Target version: 2026.7.6 (verify with `git tag --list '2026.7.*' | sort -V | tail -3` before release; 2026.7.5 is tagged)
+
+## 1. Goal
+
+`CustomDataPoint.is_valid` currently requires **all** readable field data points to be
+refreshed. Secondary values (activity/direction readbacks, group-channel readbacks,
+colors, extra sensors) can stay unrefreshed for hours after a CCU restart — nothing
+re-polls them (the periodic refresh skips `NO_CREATE` data points) — so entities hang in
+`value_state=restored` (covers; same class as climate #3255/#3279).
+
+Replace the three coexisting mechanisms (default "all readable", climate blocklist
+`_validity_irrelevant_data_points`, per-class allowlist overrides of
+`_relevant_data_points`) with **one declarative mechanism**: every custom data point
+class declares the fields that gate validity in a `ClassVar` frozenset. A contract test
+pins the sets for all 27 concrete classes.
+
+## 2. Design decisions (resolved, no TBDs)
+
+- **D1 — Mechanism**: `_validity_relevant_fields: ClassVar[frozenset[Field]]`, annotated
+  (without value) on `CustomDataPoint`, assigned in subclasses, inherited where
+  identical. The base `_relevant_data_points` property filters `_data_points` by this
+  set **and** `is_readable`. No subclass may override `_relevant_data_points` anymore
+  (contract-enforced).
+- **D2 — Non-readable / missing fields**: fields not present on a device (or resolved to
+  `DpDummy`, which is never readable) drop out via the `is_readable` filter. No special
+  handling needed.
+- **D3 — Empty set semantics**: `all(())` is `True`, so an empty set means "always
+  valid". Used deliberately for `CustomDpTextDisplay` (write-only device; its only
+  readable field `BURST_LIMIT_WARNING` is a warning channel, not a state carrier).
+- **D4 — Blind `LEVEL_2` is NOT validity-relevant**: `LEVEL_2` is listed in
+  `_OPTIONAL_PARAMETERS` ("blinds without slats", `aiohomematic/model/data_point.py`),
+  and the existing value-based override in `CustomDpBlind._relevant_data_points` exists
+  precisely because devices may never report it (e.g. blind actuators operated as
+  shutters). Hard-gating on `LEVEL_2` would recreate the same failure class for those
+  devices. Consequence: a blind with a known `LEVEL` but unknown slat position is valid;
+  `tilt_position` is exposed as an attribute and may be `None`.
+  _Rejected alternative_: `frozenset({Field.LEVEL, Field.LEVEL_2})` on `CustomDpBlind` —
+  rejected because permanently-missing `LEVEL_2` would keep the entity restored forever.
+- **D5 — Climate keeps mode-bearing fields**: `mode` is computed from `SET_POINT_MODE`
+  (IP, `climate.py` `CustomDpIpThermostat.mode`) and `CONTROL_MODE` (RF,
+  `CustomDpRfThermostat.mode`), so these stay validity-relevant alongside
+  `TEMPERATURE`/`SETPOINT`. `ACTIVE_PROFILE`, `PARTY_MODE`, `CONCENTRATION`, `HUMIDITY`
+  and all MASTER fields no longer gate validity.
+- **D6 — RGBW/DALI lights gate on `LEVEL` only**: the dynamic per-operation-mode
+  allowlist in `CustomDpIpRGBWLight` and the `CustomDpIpDrgDaliLight` override are
+  removed. Color values are attributes; an unknown color must not keep the light
+  restored. This slightly relaxes the current RGBW behavior (HUE/SATURATION/
+  COLOR_TEMPERATURE no longer gate) — deliberate, consistent with the principle.
+- **D7 — `CustomDpSoundPlayer` gates on `DIRECTION`**: its `is_on` ("is playing") is
+  derived from `ACTIVITY_STATE` (`siren.py` `CustomDpSoundPlayer.is_on`), so `DIRECTION`
+  is the state carrier here — the one class where an activity field is critical.
+- **D8 — No migration guide**: no public API changes (`_validity_irrelevant_data_points`
+  and the removed overrides are protected). Behavior change is documented in the
+  changelog and ADR-0025.
+
+## 3. Field sets per class (contract table)
+
+Inheritance is used where the set is identical to the parent. "Effective" is what the
+contract test asserts.
+
+| Class                            | Declared                                        | Effective set             |
+| -------------------------------- | ----------------------------------------------- | ------------------------- |
+| `CustomDpCover`                  | `{LEVEL}`                                       | `{LEVEL}`                 |
+| `CustomDpWindowDrive`            | inherit                                         | `{LEVEL}`                 |
+| `CustomDpBlind`                  | inherit                                         | `{LEVEL}` (D4)            |
+| `CustomDpIpBlind`                | inherit                                         | `{LEVEL}`                 |
+| `CustomDpGarage`                 | `{DOOR_STATE}`                                  | `{DOOR_STATE}`            |
+| `CustomDpSwitch`                 | `{STATE}`                                       | `{STATE}`                 |
+| `CustomDpIpIrrigationValve`      | `{STATE}`                                       | `{STATE}`                 |
+| `CustomDpDimmer`                 | `{LEVEL}`                                       | `{LEVEL}`                 |
+| `CustomDpColorDimmer`            | inherit                                         | `{LEVEL}`                 |
+| `CustomDpColorDimmerEffect`      | inherit                                         | `{LEVEL}`                 |
+| `CustomDpColorTempDimmer`        | inherit                                         | `{LEVEL}`                 |
+| `CustomDpIpRGBWLight`            | inherit                                         | `{LEVEL}` (D6)            |
+| `CustomDpIpRGBWColorTempLight`   | inherit                                         | `{LEVEL}`                 |
+| `CustomDpIpDrgDaliLight`         | inherit                                         | `{LEVEL}` (D6)            |
+| `CustomDpIpFixedColorLight`      | inherit                                         | `{LEVEL}`                 |
+| `CustomDpSoundPlayerLed`         | inherit                                         | `{LEVEL}`                 |
+| `BaseCustomDpClimate` (abstract) | `{TEMPERATURE, SETPOINT}`                       | —                         |
+| `CustomDpSimpleRfThermostat`     | inherit                                         | `{TEMPERATURE, SETPOINT}` |
+| `CustomDpRfThermostat`           | `{TEMPERATURE, SETPOINT, CONTROL_MODE}`         | ditto (D5)                |
+| `CustomDpIpThermostat`           | `{TEMPERATURE, SETPOINT, SET_POINT_MODE}`       | ditto (D5)                |
+| `CustomDpIpLock`                 | `{LOCK_STATE}`                                  | `{LOCK_STATE}`            |
+| `CustomDpRfLock`                 | `{STATE}`                                       | `{STATE}`                 |
+| `CustomDpButtonLock`             | `{BUTTON_LOCK}`                                 | `{BUTTON_LOCK}`           |
+| `CustomDpIpSiren`                | `{ACOUSTIC_ALARM_ACTIVE, OPTICAL_ALARM_ACTIVE}` | ditto                     |
+| `CustomDpIpSirenSmoke`           | `{SMOKE_DETECTOR_ALARM_STATUS}`                 | ditto                     |
+| `CustomDpSoundPlayer`            | `{DIRECTION}`                                   | `{DIRECTION}` (D7)        |
+| `CustomDpTextDisplay`            | `frozenset()`                                   | empty (D3)                |
+| `CustomDpIpAccessPermission`     | `{STATE}`                                       | `{STATE}`                 |
+
+## 4. Implementation steps
+
+Execute in order. After all edits run `python script/sort_class_members.py` (fixes
+member ordering), then the quality gates in section 7.
+
+### 4.1 `aiohomematic/model/custom/data_point.py`
+
+1. Extend the typing import (line 12):
+   `from typing import Any, Final, Unpack, override` →
+   `from typing import Any, ClassVar, Final, Unpack, override`
+2. Replace the `_relevant_data_points` property (currently returns
+   `self._readable_data_points` with docstring "Returns the list of relevant data
+   points. To be overridden by subclasses.") with:
+
+```python
+    # Fields whose readable data points gate validity (is_refreshed / is_valid /
+    # state_uncertain). Assigned by subclasses; enforced for every concrete class by
+    # tests/contract/test_cdp_validity_contract.py. An empty set means "always valid"
+    # (write-only devices). See ADR-0025.
+    _validity_relevant_fields: ClassVar[frozenset[Field]]
+
+    @property
+    def _relevant_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
+        """Return the readable data points whose fields gate validity."""
+        return tuple(
+            dp
+            for field, dp in self._data_points.items()
+            if field in self._validity_relevant_fields and dp.is_readable
+        )
+```
+
+`Field` is already imported in this module.
+
+### 4.2 `aiohomematic/model/custom/climate.py`
+
+1. Typing import: add `ClassVar` → `from typing import ClassVar, Final, Unpack, cast, override`
+2. `BaseCustomDpClimate`: **delete** the `_validity_irrelevant_data_points` property
+   (lines 216–228) and the `_relevant_data_points` override (lines 230–236). Add next to
+   the `DataPointField` definitions:
+
+```python
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.TEMPERATURE, Field.SETPOINT})
+```
+
+3. `CustomDpRfThermostat`: **delete** its `_validity_irrelevant_data_points` override
+   (lines 515–519). Add:
+
+```python
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset(
+        {Field.TEMPERATURE, Field.SETPOINT, Field.CONTROL_MODE}
+    )
+```
+
+4. `CustomDpIpThermostat`: **delete** its `_validity_irrelevant_data_points` override
+   (lines 729–743). Add:
+
+```python
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset(
+        {Field.TEMPERATURE, Field.SETPOINT, Field.SET_POINT_MODE}
+    )
+```
+
+5. `CustomDpSimpleRfThermostat`: no change (inherits base set).
+6. If `GenericDataPointProtocolAny` becomes unused after the deletions, remove it from
+   the imports (check with `ruff check --select F401`).
+
+### 4.3 `aiohomematic/model/custom/cover.py`
+
+1. Typing import: add `ClassVar`.
+2. `CustomDpCover`: add next to the `DataPointField` definitions:
+
+```python
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.LEVEL})
+```
+
+3. `CustomDpBlind`: **delete** the `_relevant_data_points` override (lines 307–312,
+   the value-based `LEVEL_2` special case — superseded by D4).
+4. `CustomDpGarage`: add:
+
+```python
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.DOOR_STATE})
+```
+
+5. `CustomDpWindowDrive`, `CustomDpIpBlind`: no change (inherit).
+
+### 4.4 `aiohomematic/model/custom/light.py`
+
+1. Typing import: add `ClassVar`.
+2. `CustomDpDimmer`: add:
+
+```python
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.LEVEL})
+```
+
+3. `CustomDpIpRGBWLight`: **delete** the `_relevant_data_points` override
+   (lines 574–588, the `_device_operation_mode`-based allowlist — superseded by D6).
+4. `CustomDpIpDrgDaliLight`: **delete** the `_relevant_data_points` override
+   (lines 712–715).
+5. All other light classes: no change (inherit `{LEVEL}`).
+
+### 4.5 `aiohomematic/model/custom/switch.py`
+
+Typing import: add `ClassVar`. `CustomDpSwitch`: add:
+
+```python
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.STATE})
+```
+
+### 4.6 `aiohomematic/model/custom/valve.py`
+
+Typing import: add `ClassVar`. `CustomDpIpIrrigationValve`: add:
+
+```python
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.STATE})
+```
+
+### 4.7 `aiohomematic/model/custom/lock.py`
+
+Typing import: add `ClassVar` (module currently imports only `Final` from typing).
+
+```python
+# CustomDpIpLock:
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.LOCK_STATE})
+# CustomDpButtonLock:
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.BUTTON_LOCK})
+# CustomDpRfLock:
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.STATE})
+```
+
+### 4.8 `aiohomematic/model/custom/siren.py`
+
+Typing import: add `ClassVar`.
+
+```python
+# CustomDpIpSiren:
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset(
+        {Field.ACOUSTIC_ALARM_ACTIVE, Field.OPTICAL_ALARM_ACTIVE}
+    )
+# CustomDpIpSirenSmoke:
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.SMOKE_DETECTOR_ALARM_STATUS})
+# CustomDpSoundPlayer (D7 — ACTIVITY_STATE carries is_on):
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.DIRECTION})
+```
+
+### 4.9 `aiohomematic/model/custom/text_display.py`
+
+Typing import: add `ClassVar`. `CustomDpTextDisplay` (D3 — write-only device):
+
+```python
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset()
+```
+
+### 4.10 `aiohomematic/model/custom/access_permission.py`
+
+Typing import: add `ClassVar`. `CustomDpIpAccessPermission`:
+
+```python
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.STATE})
+```
+
+## 5. New contract test — `tests/contract/test_cdp_validity_contract.py`
+
+Create with exactly this content:
+
+```python
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""
+Contract tests for custom data point validity gating.
+
+STABILITY GUARANTEE
+-------------------
+``CustomDataPoint`` validity (``is_refreshed``/``is_valid``/``state_uncertain``) is
+gated exclusively by the readable data points of the fields declared in
+``_validity_relevant_fields`` (ADR-0025). This contract pins, for every concrete
+custom data point class, exactly which fields gate validity. Any change to the sets
+below changes Home Assistant entity availability (``value_state``) and must be a
+deliberate, changelog-documented decision.
+
+Background: #3255, #3279 — secondary values (activity/direction readbacks,
+group-channel readbacks, colors, extra sensors) can stay unrefreshed for hours after
+a CCU restart. If they gate validity, entities hang in ``value_state=restored`` until
+a device event arrives.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from aiohomematic.const import Field
+import aiohomematic.model.custom  # noqa: F401  # ensure all CDP classes are defined
+from aiohomematic.model.custom.data_point import CustomDataPoint
+
+# pylint: disable=protected-access
+
+# Effective validity-relevant fields per concrete custom data point class.
+EXPECTED_VALIDITY_RELEVANT_FIELDS: dict[str, frozenset[Field]] = {
+    "CustomDpBlind": frozenset({Field.LEVEL}),
+    "CustomDpButtonLock": frozenset({Field.BUTTON_LOCK}),
+    "CustomDpColorDimmer": frozenset({Field.LEVEL}),
+    "CustomDpColorDimmerEffect": frozenset({Field.LEVEL}),
+    "CustomDpColorTempDimmer": frozenset({Field.LEVEL}),
+    "CustomDpCover": frozenset({Field.LEVEL}),
+    "CustomDpDimmer": frozenset({Field.LEVEL}),
+    "CustomDpGarage": frozenset({Field.DOOR_STATE}),
+    "CustomDpIpAccessPermission": frozenset({Field.STATE}),
+    "CustomDpIpBlind": frozenset({Field.LEVEL}),
+    "CustomDpIpDrgDaliLight": frozenset({Field.LEVEL}),
+    "CustomDpIpFixedColorLight": frozenset({Field.LEVEL}),
+    "CustomDpIpIrrigationValve": frozenset({Field.STATE}),
+    "CustomDpIpLock": frozenset({Field.LOCK_STATE}),
+    "CustomDpIpRGBWColorTempLight": frozenset({Field.LEVEL}),
+    "CustomDpIpRGBWLight": frozenset({Field.LEVEL}),
+    "CustomDpIpSiren": frozenset({Field.ACOUSTIC_ALARM_ACTIVE, Field.OPTICAL_ALARM_ACTIVE}),
+    "CustomDpIpSirenSmoke": frozenset({Field.SMOKE_DETECTOR_ALARM_STATUS}),
+    "CustomDpIpThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT, Field.SET_POINT_MODE}),
+    "CustomDpRfLock": frozenset({Field.STATE}),
+    "CustomDpRfThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT, Field.CONTROL_MODE}),
+    "CustomDpSimpleRfThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT}),
+    "CustomDpSoundPlayer": frozenset({Field.DIRECTION}),
+    "CustomDpSoundPlayerLed": frozenset({Field.LEVEL}),
+    "CustomDpSwitch": frozenset({Field.STATE}),
+    "CustomDpTextDisplay": frozenset(),
+    "CustomDpWindowDrive": frozenset({Field.LEVEL}),
+}
+
+
+def _all_cdp_classes() -> list[type[CustomDataPoint]]:
+    """Return all (direct and indirect) subclasses of CustomDataPoint."""
+    result: list[type[CustomDataPoint]] = []
+
+    def _walk(cls: type[CustomDataPoint]) -> None:
+        for sub in cls.__subclasses__():
+            result.append(sub)
+            _walk(sub)
+
+    _walk(CustomDataPoint)
+    return result
+
+
+def _concrete_cdp_classes() -> list[type[CustomDataPoint]]:
+    """Return all concrete (instantiable) custom data point classes."""
+    return [cls for cls in _all_cdp_classes() if not inspect.isabstract(cls)]
+
+
+class TestCdpValidityContract:
+    """Pin the validity gating of every custom data point class."""
+
+    def test_every_concrete_cdp_class_is_covered(self) -> None:
+        """Every concrete CDP class must have an entry in the contract table."""
+        concrete = {cls.__name__ for cls in _concrete_cdp_classes()}
+        expected = set(EXPECTED_VALIDITY_RELEVANT_FIELDS)
+        assert concrete - expected == set(), (
+            f"New custom data point class(es) without validity contract: "
+            f"{sorted(concrete - expected)}. Add them to EXPECTED_VALIDITY_RELEVANT_FIELDS."
+        )
+        assert expected - concrete == set(), (
+            f"Contract table contains unknown class(es): {sorted(expected - concrete)}."
+        )
+
+    def test_validity_relevant_fields_match_contract(self) -> None:
+        """The effective field set of every concrete CDP class matches the contract."""
+        for cls in _concrete_cdp_classes():
+            declared = getattr(cls, "_validity_relevant_fields", None)
+            assert declared is not None, (
+                f"{cls.__name__} does not resolve _validity_relevant_fields — "
+                f"declare it on the class or a base class."
+            )
+            assert declared == EXPECTED_VALIDITY_RELEVANT_FIELDS[cls.__name__], (
+                f"{cls.__name__}: validity-relevant fields changed. "
+                f"Expected {sorted(EXPECTED_VALIDITY_RELEVANT_FIELDS[cls.__name__])}, "
+                f"got {sorted(declared)}. If intentional, update the contract and changelog."
+            )
+
+    def test_no_relevant_data_points_overrides(self) -> None:
+        """No subclass may override _relevant_data_points — the frozenset is the only mechanism."""
+        for cls in _all_cdp_classes():
+            assert "_relevant_data_points" not in vars(cls), (
+                f"{cls.__name__} overrides _relevant_data_points. "
+                f"Declare _validity_relevant_fields instead (ADR-0025)."
+            )
+
+    def test_base_class_has_no_default(self) -> None:
+        """CustomDataPoint must not define a default — subclasses must decide explicitly."""
+        assert "_validity_relevant_fields" not in vars(CustomDataPoint)
+```
+
+## 6. Behavior tests (regression for the restored-entity pattern)
+
+### 6.1 `tests/test_model_cover.py` — add to the existing test class
+
+Follow the pattern of `tests/test_model_climate.py::test_ip_thermostat_level_excluded_from_validity`
+(same fixture and `@pytest.mark.parametrize` block as the surrounding tests in this
+file; `TEST_DEVICES` already contains the addresses). Add:
+
+```python
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_cover_validity_gated_by_level_only(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """DIRECTION/GROUP_LEVEL must not block cover is_valid after a CCU restart."""
+        central, _mock_client, _ = central_client_factory_with_homegear_client
+        cover = cast(CustomDpCover, get_prepared_custom_data_point(central, "VCU8537918", 4))
+        # Preconditions: DIRECTION is a real, readable data point on this device.
+        assert cover._dp_direction.is_readable
+        # Secondary fields must not gate validity.
+        assert cover._dp_direction not in cover._relevant_data_points
+        assert cover._dp_group_level not in cover._relevant_data_points
+        # Nothing refreshed yet -> invalid.
+        assert cover.is_valid is False
+        # Simulate a post-CCU-restart init where only LEVEL arrives (bulk fetch).
+        cover._dp_level._set_refreshed_at(refreshed_at=datetime.now())
+        # The cover must be valid even though DIRECTION/GROUP_LEVEL never refreshed.
+        assert cover.is_valid is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_blind_validity_not_gated_by_level_2(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """LEVEL_2 (optional slats level) must not block blind is_valid (ADR-0025)."""
+        central, _mock_client, _ = central_client_factory_with_homegear_client
+        cover = cast(CustomDpBlind, get_prepared_custom_data_point(central, "VCU0000144", 1))
+        assert cover._dp_level_2.is_readable
+        assert cover._dp_level_2 not in cover._relevant_data_points
+        assert cover.is_valid is False
+        cover._dp_level._set_refreshed_at(refreshed_at=datetime.now())
+        assert cover.is_valid is True
+```
+
+Required imports in `tests/test_model_cover.py` (add if missing):
+`from datetime import datetime` — `cast`, `CustomDpCover`, `CustomDpBlind`,
+`get_prepared_custom_data_point` are already imported there.
+
+### 6.2 `tests/test_model_switch.py` — add analogous test
+
+Same parametrize block as surrounding tests; device `VCU2128127`, channel 4:
+
+```python
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_switch_validity_gated_by_state_only(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """GROUP_STATE must not block switch is_valid."""
+        central, _mock_client, _ = central_client_factory_with_homegear_client
+        switch = cast(CustomDpSwitch, get_prepared_custom_data_point(central, "VCU2128127", 4))
+        assert switch._dp_group_state not in switch._relevant_data_points
+        assert switch.is_valid is False
+        switch._dp_state._set_refreshed_at(refreshed_at=datetime.now())
+        assert switch.is_valid is True
+```
+
+Add `from datetime import datetime` to the imports if missing.
+
+### 6.3 Existing tests
+
+The three #3255/#3279 tests in `tests/test_model_climate.py`
+(`test_ip_heating_group_humidity_heating_cooling_excluded_from_validity`,
+`test_ip_thermostat_level_excluded_from_validity`,
+`test_rf_thermostat_valve_state_excluded_from_validity`) assert exclusion via
+`_relevant_data_points` and stay green unchanged (the excluded fields are also absent
+from the new sets). If any other test fails because it relied on a secondary field
+gating `is_valid`/`state_uncertain`, adjust the **test expectation** to the new gating —
+do not widen a field set without updating the contract table (section 5) and changelog.
+
+## 7. Quality gates and finalization
+
+1. `python script/sort_class_members.py`
+2. `pytest tests/contract/test_cdp_validity_contract.py tests/test_model_cover.py tests/test_model_switch.py tests/test_model_climate.py -v`
+3. `pytest tests/`
+4. `prek run --all-files`
+5. `ruff check --select F401,F841` (removed overrides may orphan imports, e.g.
+   `GenericDataPointProtocolAny` in `climate.py`/`light.py`)
+6. `grep -rn "_validity_irrelevant_data_points" aiohomematic/ tests/` → must be empty
+   (clean-code policy: no leftovers in code; ADR-0025 may reference the removed
+   identifier when describing the superseded mechanism).
+
+### 7.1 ADR — `docs/adr/0025-cdp-validity-relevant-fields.md`
+
+New ADR (next free number after 0024). Sections: Status (accepted) · Context (three
+coexisting mechanisms; #3255/#3279 failure class: secondary fields gate validity
+but are never re-polled after reconnect because the periodic refresh excludes
+`NO_CREATE` data points) · Decision (single declarative
+`_validity_relevant_fields: ClassVar[frozenset[Field]]`; readable-filtered; empty set =
+always valid; contract test pins all classes) · Consequences (entities become valid as
+soon as their state-carrying fields refresh; secondary attributes may be `None`/stale
+while the entity is valid; new CDP classes fail the contract test until they declare a
+set). Add the entry to `docs/adr/index.md` following the existing format.
+
+### 7.2 Documentation
+
+- `docs/developer/homematicip_local_api_usage.md` (around line 272, the `is_valid`
+  bullet): add one sentence — for custom data points, `is_valid` is gated only by the
+  validity-relevant fields (link ADR-0025).
+
+### 7.3 Changelog and version
+
+1. `git tag --list '2026.7.*' | sort -V | tail -3` — confirm 2026.7.5 is still the
+   latest tag; the new version is **2026.7.6** (adjust NN if a newer tag appeared).
+2. New section at the top of `changelog.md`:
+
+```markdown
+# Version 2026.7.6 (2026-07-XX)
+
+## What's Changed
+
+### Changed
+
+- **Custom data point validity is now gated only by state-carrying fields
+  (ADR-0025).** Secondary values (activity/direction readbacks, group-channel
+  readbacks, colors, extra sensors, MASTER config values) can stay unrefreshed for
+  hours after a CCU restart — nothing re-polls them — and previously dragged the whole
+  custom data point to `is_valid=False`, leaving Home Assistant entities stuck in
+  `value_state=restored` (covers; same class as climate #3255/#3279). Every
+  custom data point class now declares its validity-relevant fields in a single
+  declarative `_validity_relevant_fields` set (cover/blind/dimmer: `LEVEL`;
+  switch/valve/access permission: `STATE`; garage: `DOOR_STATE`; locks:
+  `LOCK_STATE`/`STATE`/`BUTTON_LOCK`; climate: `ACTUAL_TEMPERATURE` + setpoint + mode
+  source; sirens: alarm-active states; sound player: `ACTIVITY_STATE`). The climate
+  blocklist `_validity_irrelevant_data_points` (#3255) and the per-class
+  `_relevant_data_points` overrides (blind `LEVEL_2`, RGBW operation-mode allowlist,
+  DALI) are replaced by the unified mechanism. A new contract test
+  (`tests/contract/test_cdp_validity_contract.py`) pins the field set of all 27
+  classes.
+```
+
+3. Set `aiohomematic/const.py` `VERSION: Final = "2026.7.6"` in the same commit and
+   verify: `head -1 changelog.md` matches `grep "^VERSION" aiohomematic/const.py`.
+
+## 8. Explicitly out of scope
+
+- Re-polling custom-DP field data points after reconnect (the `exclude_no_create` gap
+  in `refresh_data_point_data`) — separate decision with duty-cycle implications;
+  this plan removes the _symptom coupling_, not the polling gap.
+- Home Assistant integration changes (`supported_features` derivation is HA-core
+  emergent behavior and resolves itself once entities report valid positions).

--- a/tests/contract/test_cdp_validity_contract.py
+++ b/tests/contract/test_cdp_validity_contract.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""
+Contract tests for custom data point validity gating.
+
+STABILITY GUARANTEE
+-------------------
+``CustomDataPoint`` validity (``is_refreshed``/``is_valid``/``state_uncertain``) is
+gated exclusively by the readable data points of the fields declared in
+``_validity_relevant_fields`` (ADR-0025). This contract pins, for every concrete
+custom data point class, exactly which fields gate validity. Any change to the sets
+below changes Home Assistant entity availability (``value_state``) and must be a
+deliberate, changelog-documented decision.
+
+Background: #3255, #3279 — secondary values (activity/direction readbacks,
+group-channel readbacks, colors, extra sensors) can stay unrefreshed for hours after
+a CCU restart. If they gate validity, entities hang in ``value_state=restored`` until
+a device event arrives.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from aiohomematic.const import Field
+from aiohomematic.model.custom import CustomDataPoint
+
+# pylint: disable=protected-access
+
+# Effective validity-relevant fields per concrete custom data point class.
+EXPECTED_VALIDITY_RELEVANT_FIELDS: dict[str, frozenset[Field]] = {
+    "CustomDpBlind": frozenset({Field.LEVEL}),
+    "CustomDpButtonLock": frozenset({Field.BUTTON_LOCK}),
+    "CustomDpColorDimmer": frozenset({Field.LEVEL}),
+    "CustomDpColorDimmerEffect": frozenset({Field.LEVEL}),
+    "CustomDpColorTempDimmer": frozenset({Field.LEVEL}),
+    "CustomDpCover": frozenset({Field.LEVEL}),
+    "CustomDpDimmer": frozenset({Field.LEVEL}),
+    "CustomDpGarage": frozenset({Field.DOOR_STATE}),
+    "CustomDpIpAccessPermission": frozenset({Field.STATE}),
+    "CustomDpIpBlind": frozenset({Field.LEVEL}),
+    "CustomDpIpDrgDaliLight": frozenset({Field.LEVEL}),
+    "CustomDpIpFixedColorLight": frozenset({Field.LEVEL}),
+    "CustomDpIpIrrigationValve": frozenset({Field.STATE}),
+    "CustomDpIpLock": frozenset({Field.LOCK_STATE}),
+    "CustomDpIpRGBWColorTempLight": frozenset({Field.LEVEL}),
+    "CustomDpIpRGBWLight": frozenset({Field.LEVEL}),
+    "CustomDpIpSiren": frozenset({Field.ACOUSTIC_ALARM_ACTIVE, Field.OPTICAL_ALARM_ACTIVE}),
+    "CustomDpIpSirenSmoke": frozenset({Field.SMOKE_DETECTOR_ALARM_STATUS}),
+    "CustomDpIpThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT, Field.SET_POINT_MODE}),
+    "CustomDpRfLock": frozenset({Field.STATE}),
+    "CustomDpRfThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT, Field.CONTROL_MODE}),
+    "CustomDpSimpleRfThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT}),
+    "CustomDpSoundPlayer": frozenset({Field.DIRECTION}),
+    "CustomDpSoundPlayerLed": frozenset({Field.LEVEL}),
+    "CustomDpSwitch": frozenset({Field.STATE}),
+    "CustomDpTextDisplay": frozenset(),
+    "CustomDpWindowDrive": frozenset({Field.LEVEL}),
+}
+
+
+def _all_cdp_classes() -> list[type[CustomDataPoint]]:
+    """Return all (direct and indirect) subclasses of CustomDataPoint."""
+    result: list[type[CustomDataPoint]] = []
+
+    def _walk(cls: type[CustomDataPoint]) -> None:
+        for sub in cls.__subclasses__():
+            result.append(sub)
+            _walk(sub)
+
+    _walk(CustomDataPoint)
+    return result
+
+
+def _concrete_cdp_classes() -> list[type[CustomDataPoint]]:
+    """Return all concrete (instantiable) custom data point classes."""
+    return [cls for cls in _all_cdp_classes() if not inspect.isabstract(cls)]
+
+
+class TestCdpValidityContract:
+    """Pin the validity gating of every custom data point class."""
+
+    def test_base_class_has_no_default(self) -> None:
+        """CustomDataPoint must not define a default — subclasses must decide explicitly."""
+        assert "_validity_relevant_fields" not in vars(CustomDataPoint)
+
+    def test_every_concrete_cdp_class_is_covered(self) -> None:
+        """Every concrete CDP class must have an entry in the contract table."""
+        concrete = {cls.__name__ for cls in _concrete_cdp_classes()}
+        expected = set(EXPECTED_VALIDITY_RELEVANT_FIELDS)
+        assert concrete - expected == set(), (
+            f"New custom data point class(es) without validity contract: "
+            f"{sorted(concrete - expected)}. Add them to EXPECTED_VALIDITY_RELEVANT_FIELDS."
+        )
+        assert expected - concrete == set(), (
+            f"Contract table contains unknown class(es): {sorted(expected - concrete)}."
+        )
+
+    def test_no_relevant_data_points_overrides(self) -> None:
+        """No subclass may override _relevant_data_points — the frozenset is the only mechanism."""
+        for cls in _all_cdp_classes():
+            assert "_relevant_data_points" not in vars(cls), (
+                f"{cls.__name__} overrides _relevant_data_points. Declare _validity_relevant_fields instead (ADR-0025)."
+            )
+
+    def test_validity_relevant_fields_match_contract(self) -> None:
+        """The effective field set of every concrete CDP class matches the contract."""
+        for cls in _concrete_cdp_classes():
+            declared = getattr(cls, "_validity_relevant_fields", None)
+            assert declared is not None, (
+                f"{cls.__name__} does not resolve _validity_relevant_fields — declare it on the class or a base class."
+            )
+            assert declared == EXPECTED_VALIDITY_RELEVANT_FIELDS[cls.__name__], (
+                f"{cls.__name__}: validity-relevant fields changed. "
+                f"Expected {sorted(EXPECTED_VALIDITY_RELEVANT_FIELDS[cls.__name__])}, "
+                f"got {sorted(declared)}. If intentional, update the contract and changelog."
+            )

--- a/tests/test_model_cover.py
+++ b/tests/test_model_cover.py
@@ -3,6 +3,7 @@
 """Tests for cover data points of aiohomematic."""
 
 import asyncio
+from datetime import datetime
 from typing import cast
 from unittest.mock import DEFAULT, call
 
@@ -151,6 +152,37 @@ class TestCustomDpCover:
         await cover.set_position(position=40)
         assert call_count == len(mock_client.method_calls)
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_cover_validity_gated_by_level_only(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """DIRECTION/GROUP_LEVEL must not block cover is_valid after a CCU restart."""
+        central, _mock_client, _ = central_client_factory_with_homegear_client
+        cover = cast(CustomDpCover, get_prepared_custom_data_point(central, "VCU8537918", 4))
+        # Preconditions: DIRECTION is a real, readable data point on this device.
+        assert cover._dp_direction.is_readable
+        # Secondary fields must not gate validity.
+        assert cover._dp_direction not in cover._relevant_data_points
+        assert cover._dp_group_level not in cover._relevant_data_points
+        # Nothing refreshed yet -> invalid.
+        assert cover.is_valid is False
+        # Simulate a post-CCU-restart init where only LEVEL arrives (bulk fetch).
+        cover._dp_level._set_refreshed_at(refreshed_at=datetime.now())
+        # The cover must be valid even though DIRECTION/GROUP_LEVEL never refreshed.
+        assert cover.is_valid is True
+
 
 class TestCustomDpWindowDrive:
     """Tests for CustomDpWindowDrive data points."""
@@ -230,6 +262,31 @@ class TestCustomDpWindowDrive:
 
 class TestCustomDpBlind:
     """Tests for CustomDpBlind data points."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_blind_validity_not_gated_by_level_2(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """LEVEL_2 (optional slats level) must not block blind is_valid (ADR-0025)."""
+        central, _mock_client, _ = central_client_factory_with_homegear_client
+        cover = cast(CustomDpBlind, get_prepared_custom_data_point(central, "VCU0000144", 1))
+        assert cover._dp_level_2.is_readable
+        assert cover._dp_level_2 not in cover._relevant_data_points
+        assert cover.is_valid is False
+        cover._dp_level._set_refreshed_at(refreshed_at=datetime.now())
+        assert cover.is_valid is True
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/test_model_switch.py
+++ b/tests/test_model_switch.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2021-2026
 """Tests for switch data points of aiohomematic."""
 
+from datetime import datetime
 from typing import cast
 from unittest.mock import AsyncMock, call
 
@@ -208,6 +209,30 @@ class TestCustomSwitch:
 
         assert switch.device.week_profile.has_schedule is False
         assert mock_client.get_paramset.await_count == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_switch_validity_gated_by_state_only(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """GROUP_STATE must not block switch is_valid."""
+        central, _mock_client, _ = central_client_factory_with_homegear_client
+        switch = cast(CustomDpSwitch, get_prepared_custom_data_point(central, "VCU2128127", 4))
+        assert switch._dp_group_state not in switch._relevant_data_points
+        assert switch.is_valid is False
+        switch._dp_state._set_refreshed_at(refreshed_at=datetime.now())
+        assert switch.is_valid is True
 
 
 class TestGenericSwitch:


### PR DESCRIPTION
## Summary

Custom data point validity (`is_valid`/`value_state`) previously required **all** readable field data points to be refreshed. Secondary values — activity/direction readbacks, group-channel readbacks, colors, extra sensors, MASTER config values — can stay unrefreshed for hours after a CCU restart (nothing re-polls them), dragging the whole custom data point to `is_valid=False` and leaving Home Assistant entities stuck in `value_state=restored`. This is the same failure class previously fixed point-by-point for climate (#3255, #3279), now closed for all categories.

This PR replaces the three coexisting mechanisms (default "all readable", the climate blocklist `_validity_irrelevant_data_points`, per-class `_relevant_data_points` overrides) with **one declarative mechanism**: every custom data point class declares its state-carrying fields in `_validity_relevant_fields: ClassVar[frozenset[Field]]`. See ADR-0025 and `docs/plans/cdp_validity_relevant_fields_2026_07.md` for the full per-class rationale (decisions D1–D8).

## Field sets (highlights)

- cover/blind/dimmer (incl. RGBW/DALI): `LEVEL` — blind `LEVEL_2` deliberately excluded (optional parameter, may never be reported)
- switch/irrigation valve/access permission: `STATE`; garage: `DOOR_STATE`
- locks: `LOCK_STATE` / `STATE` / `BUTTON_LOCK`
- climate: `ACTUAL_TEMPERATURE` + setpoint + mode source (`SET_POINT_MODE` IP / `CONTROL_MODE` RF)
- sirens: alarm-active states; sound player: `ACTIVITY_STATE` (carries `is_on`)
- text display: empty set (write-only device, always valid)

## Tests

- New contract test `tests/contract/test_cdp_validity_contract.py` pins the field set of all 27 concrete classes, forbids future `_relevant_data_points` overrides, and fails on new classes without a declaration.
- New behavior tests for cover/blind/switch (valid as soon as the critical field refreshes).
- Full suite: 3875 passed, 1 skipped; `prek run --all-files` clean.

## Release

- Changelog **2026.7.6** + `VERSION` sync in the same commit.
- No migration guide: no public API changes (all removed members were protected).