### PR TITLE
feat(const): add ALARM_CONTROL_PANEL vocabulary for the openccu-loom backend

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.7.6"
+VERSION: Final = "2026.7.7"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (
@@ -824,6 +824,12 @@ class DataPointCategory(StrEnum):
     ACTION = "action"
     ACTION_NUMBER = "action_number"
     ACTION_SELECT = "action_select"
+    # Loom-only category: aiohomematic itself never spawns an alarm control
+    # panel (the CCU has no alarm engine). The member exists so the shared
+    # category vocabulary stays in lock-step with openccu-loom (whose daemon
+    # models the panel as a first-class entity) and homematicip_local can
+    # derive the HA platform from CATEGORIES for the loom backend.
+    ALARM_CONTROL_PANEL = "alarm_control_panel"
     BINARY_SENSOR = "binary_sensor"
     BUTTON = "button"
     CLIMATE = "climate"
@@ -864,6 +870,8 @@ class DataPointType(StrEnum):
     isinstance checks or custom mapping logic.
     """
 
+    # Loom-only type (see DataPointCategory.ALARM_CONTROL_PANEL).
+    ALARM_CONTROL_PANEL = "alarm_control_panel"
     BINARY_SENSOR = "binary_sensor"
     BUTTON = "button"
     CLIMATE = "climate"
@@ -885,6 +893,7 @@ _CATEGORY_TO_DATA_POINT_TYPE: Final[dict[DataPointCategory, DataPointType]] = {
     DataPointCategory.ACTION: DataPointType.BUTTON,
     DataPointCategory.ACTION_NUMBER: DataPointType.NUMBER,
     DataPointCategory.ACTION_SELECT: DataPointType.SELECT,
+    DataPointCategory.ALARM_CONTROL_PANEL: DataPointType.ALARM_CONTROL_PANEL,
     DataPointCategory.BINARY_SENSOR: DataPointType.BINARY_SENSOR,
     DataPointCategory.BUTTON: DataPointType.BUTTON,
     DataPointCategory.CLIMATE: DataPointType.CLIMATE,
@@ -1764,6 +1773,7 @@ HUB_CATEGORIES: Final[tuple[DataPointCategory, ...]] = (
 CATEGORIES: Final[tuple[DataPointCategory, ...]] = (
     DataPointCategory.ACTION_NUMBER,
     DataPointCategory.ACTION_SELECT,
+    DataPointCategory.ALARM_CONTROL_PANEL,
     DataPointCategory.BINARY_SENSOR,
     DataPointCategory.BUTTON,
     DataPointCategory.CLIMATE,

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,19 @@
+# Version 2026.7.7 (2026-07-16)
+
+## What's Changed
+
+### Added
+
+- **`DataPointCategory.ALARM_CONTROL_PANEL` / `DataPointType.ALARM_CONTROL_PANEL`
+  — loom-only vocabulary.** aiohomematic itself never spawns an alarm control
+  panel (the CCU has no alarm engine); the members exist so the category
+  vocabulary stays in lock-step with `openccu-loom` (daemon ≥ 0.42.0 models the
+  panel as a first-class entity) and `homematicip_local` — which derives its HA
+  platform list from `CATEGORIES` — mounts the `alarm_control_panel` platform
+  for the loom backend. Pure vocabulary: no model class, no behaviour change on
+  the CCU path. `CATEGORIES` and `_CATEGORY_TO_DATA_POINT_TYPE` carry the new
+  member.
+
 # Version 2026.7.6 (2026-07-10)
 
 ## What's Changed


### PR DESCRIPTION
## Summary

Adds `DataPointCategory.ALARM_CONTROL_PANEL` and `DataPointType.ALARM_CONTROL_PANEL`, plus the `CATEGORIES` and `_CATEGORY_TO_DATA_POINT_TYPE` entries — **pure vocabulary, no model class, no behaviour change on the CCU path**.

### Why

openccu-loom ≥ 0.42.0 ships a native alarm engine and models the alarm control panel as a first-class entity; `openccu-loom-client` (SukramJ/openccu-loom-client#62) holds the categorised `LoomDpAlarmControlPanel` twin. aiohomematic itself never spawns one (the CCU has no alarm engine), but:

- `homematicip_local` derives `HMIP_LOCAL_PLATFORMS` from `aiohomematic.const.CATEGORIES`, so `Platform.ALARM_CONTROL_PANEL` only mounts once this member exists.
- Keeping the category catalogue in one place (this enum) avoids a second, drifting vocabulary in the loom stack — the client pins parity against these string values in its `category_golden.json` drift-guard.

The client's announce paths gate on `ValueError` until this ships, so mixed-version installs degrade gracefully.

Companion PRs: SukramJ/openccu-loom-client#62 (client surface), homematicip_local platform PR follows.

## Test plan

- Full suite: 3875 passed, 1 skipped (pre-commit hooks green)
- Version bumped to 2026.7.7 + changelog entry