### PR TITLE
refactor(issues): refocus issue analyzer from diagnosis to deterministic triage

### DIFF
--- a/.github/scripts/analyze_issue.py
+++ b/.github/scripts/analyze_issue.py
@@ -1,14 +1,24 @@
 #!/usr/bin/env python3
 """
-Issue analyzer script for AioHomematic and Homematic(IP) Local.
+Issue triage script for AioHomematic and Homematic(IP) Local.
 
-This script uses Claude AI to analyze newly created issues and provide helpful feedback.
-It includes deep analysis of attached diagnostic files and log files.
+This script performs deterministic triage of newly created issues: it checks that the
+required raw data (integration diagnostics, log file) is attached, validates the reported
+version against the published releases, detects pasted AI analyses, and searches for
+similar issues. Claude is only used for a short summary and documentation-link selection —
+it does NOT diagnose root causes.
+
+An audit of 181 bot-commented issues (2026-07) showed that LLM root-cause analyses were
+fully correct in only 18% of cases and outright wrong in 24%, so all diagnosis sections
+were removed in favor of deterministic checks. Do not re-add root-cause claims to the
+public comment.
 """
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from datetime import date
 import json
 import os
 import re
@@ -17,206 +27,85 @@ from typing import Any, Final, cast
 
 from anthropic import Anthropic
 from github import Auth, Github, GithubException, Repository
-import requests
-
-# Valid major version range for Homematic(IP) Local
-# Version 1.x.x was the original, 2.x.x is current, 3.x.x reserved for future
-VALID_MAJOR_VERSIONS = (1, 2, 3)
 
 # Integration repository for version lookups
-INTEGRATION_REPO = "SukramJ/homematicip_local"
+INTEGRATION_REPO: Final = "SukramJ/homematicip_local"
 
-# Cached version info (populated on first use)
-_cached_versions: dict[str, str | None] = {}
+# Maximum number of releases to scan when building the known-version set
+MAX_RELEASES_TO_SCAN: Final = 100
 
-# Maximum file size to download (5 MB)
-MAX_ATTACHMENT_SIZE: Final = 5 * 1024 * 1024
+# Claude model used for the triage summary (override via the ANALYZER_MODEL env var)
+DEFAULT_ANALYZER_MODEL: Final = "claude-sonnet-4-5"
 
-# Log analysis patterns with priorities (lower = higher priority)
-# These patterns help identify the root cause of issues
-LOG_PATTERNS: Final[dict[str, dict[str, Any]]] = {
-    "no_subscribers": {
-        "pattern": r"No subscribers for (?:Rpc)?ParameterReceivedEvent.*?\[([A-Za-z0-9]+:\d+)\]",
-        "description_de": "Gerät sendet Events, aber keine HA-Entität ist registriert",
-        "description_en": "Device sends events but no HA entity is registered",
-        "priority": 1,
-        "category": "device_not_registered",
-        "severity": "error",
-        "supersedes": ["sticky_unreach", "unreach"],
-    },
-    "unreach_true": {
-        "pattern": r"parameter = UNREACH, value = True",
-        "description_de": "Gerät ist aktuell nicht erreichbar (Funkproblem)",
-        "description_en": "Device is currently unreachable (radio issue)",
-        "priority": 2,
-        "category": "device_issue",
-        "severity": "warning",
-        "supersedes": [],
-    },
-    "sticky_unreach": {
-        "pattern": r"STICKY_UN_REACH.*?(?:true|True)",
-        "description_de": "Vergangene Kommunikationsprobleme (Reset in CCU erforderlich)",
-        "description_en": "Past communication problems (reset required in CCU)",
-        "priority": 3,
-        "category": "device_issue",
-        "severity": "info",
-        "supersedes": [],
-    },
-    "xmlrpc_fault": {
-        "pattern": r"XMLRPCFault|XmlRpcException|XMLRPC Fault",
-        "description_de": "XML-RPC Kommunikationsfehler mit CCU",
-        "description_en": "XML-RPC communication error with CCU",
-        "priority": 2,
-        "category": "connection",
-        "severity": "error",
-        "supersedes": [],
-    },
-    "connection_refused": {
-        "pattern": r"Connection refused|ConnectionRefusedError|connect ECONNREFUSED",
-        "description_de": "Verbindung zur CCU wurde verweigert",
-        "description_en": "Connection to CCU was refused",
-        "priority": 1,
-        "category": "connection",
-        "severity": "error",
-        "supersedes": [],
-    },
-    "timeout": {
-        "pattern": r"TimeoutError|asyncio\.TimeoutError|timed out|timeout",
-        "description_de": "Zeitüberschreitung bei der Kommunikation",
-        "description_en": "Communication timeout",
-        "priority": 2,
-        "category": "connection",
-        "severity": "warning",
-        "supersedes": [],
-    },
-    "config_pending": {
-        "pattern": r"CONFIG_PENDING.*?(?:true|True)",
-        "description_de": "Gerätekonfiguration wird übertragen",
-        "description_en": "Device configuration is being transferred",
-        "priority": 4,
-        "category": "device_issue",
-        "severity": "info",
-        "supersedes": [],
-    },
-    "callback_failed": {
-        "pattern": r"callback.*?(?:failed|error|exception)|init.*?failed",
-        "description_de": "XML-RPC Callback-Registrierung fehlgeschlagen",
-        "description_en": "XML-RPC callback registration failed",
-        "priority": 1,
-        "category": "interface",
-        "severity": "error",
-        "supersedes": [],
-    },
-    "ping_pong_missing": {
-        "pattern": r"(?:PING|PONG).*?(?:missing|failed|timeout)|pending PING count",
-        "description_de": "Ping/Pong-Überwachung zeigt Verbindungsprobleme",
-        "description_en": "Ping/Pong monitoring shows connection issues",
-        "priority": 2,
-        "category": "connection",
-        "severity": "warning",
-        "supersedes": [],
-    },
+# Documentation links
+DOCS_LINKS: Final[dict[str, str]] = {
+    "main_readme": "https://sukramj.github.io/aiohomematic/",
+    "homematicip_local_readme": "https://github.com/sukramj/homematicip_local#homematicip_local",
+    "troubleshooting": "https://sukramj.github.io/aiohomematic/user/troubleshooting/homeassistant_troubleshooting/",
+    "releases": "https://github.com/sukramj/homematicip_local/releases",
+    "architecture": "https://sukramj.github.io/aiohomematic/architecture/",
+    "naming": "https://sukramj.github.io/aiohomematic/contributor/coding/naming/",
+    "unignore": "https://sukramj.github.io/aiohomematic/user/advanced/unignore/",
+    "lifecycle": "https://sukramj.github.io/aiohomematic/developer/homeassistant_lifecycle/",
+    "glossary": "https://sukramj.github.io/aiohomematic/reference/glossary/",
+    "discussions": "https://github.com/sukramj/aiohomematic/discussions",
 }
 
 
-@dataclass
-class AttachmentAnalysis:
-    """Structured analysis results from attached files."""
+# =============================================================================
+# Issue-form parsing
+# =============================================================================
 
-    # From diagnostics JSON
-    registered_models: list[str] = field(default_factory=list)
-    registered_device_addresses: set[str] = field(default_factory=set)
-    interface_health: dict[str, Any] = field(default_factory=dict)
-    system_health: dict[str, Any] = field(default_factory=dict)
-    incident_store: dict[str, Any] = field(default_factory=dict)
-    metrics: dict[str, Any] = field(default_factory=dict)
+# Value GitHub inserts for empty issue-form fields
+FORM_NO_RESPONSE: Final = "_No response_"
 
-    # From log analysis
-    no_subscriber_addresses: set[str] = field(default_factory=set)
-    event_sending_addresses: set[str] = field(default_factory=set)
-    log_pattern_matches: dict[str, list[str]] = field(default_factory=dict)
-
-    # Cross-reference results
-    unregistered_devices: set[str] = field(default_factory=set)
-    orphan_events: list[str] = field(default_factory=list)
-
-    # Prioritized findings
-    findings: list[dict[str, Any]] = field(default_factory=list)
-
-    # Raw data availability
-    has_diagnostics: bool = False
-    has_logs: bool = False
-    diagnostics_url: str = ""
-    log_url: str = ""
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert to dictionary for JSON serialization."""
-        return {
-            "registered_models": self.registered_models,
-            "registered_device_count": len(self.registered_device_addresses),
-            "interface_health": self.interface_health,
-            "system_health_summary": {
-                "central_state": self.system_health.get("central_state", "unknown"),
-                "all_clients_healthy": self.system_health.get("all_clients_healthy", False),
-                "overall_health_score": self.system_health.get("overall_health_score", 0),
-            },
-            "incidents_count": self.incident_store.get("total_incidents", 0),
-            "no_subscriber_count": len(self.no_subscriber_addresses),
-            "unregistered_devices": list(self.unregistered_devices),
-            "orphan_events_sample": self.orphan_events[:5],
-            "log_pattern_summary": {k: len(v) for k, v in self.log_pattern_matches.items()},
-            "prioritized_findings": self.findings,
-            "has_diagnostics": self.has_diagnostics,
-            "has_logs": self.has_logs,
-        }
+# Substring markers (casefold) identifying the integration-version form field in
+# both template languages. The "last working version" field does not match these.
+VERSION_FIELD_MARKERS: Final[tuple[str, ...]] = (
+    "what version of homematic",
+    "bei welcher version von homematic",
+)
 
 
-def fetch_latest_versions(gh: Github) -> tuple[str | None, str | None]:
+def parse_form_fields(issue_body: str) -> dict[str, str]:
     """
-    Fetch the latest stable and pre-release versions from GitHub Releases.
+    Parse a GitHub issue-form body into a mapping of field label to value.
 
-    Returns tuple of (stable_version, prerelease_version).
-    Uses caching to avoid repeated API calls.
+    Issue forms render each field as a "### <label>" heading followed by the value.
+    Empty fields ("_No response_") are normalized to an empty string.
     """
-    if "stable" in _cached_versions:
-        return _cached_versions.get("stable"), _cached_versions.get("prerelease")
+    fields: dict[str, str] = {}
+    if not issue_body:
+        return fields
 
-    try:
-        repo = gh.get_repo(INTEGRATION_REPO)
-        releases = repo.get_releases()
+    chunks = re.split(r"^### ", issue_body, flags=re.MULTILINE)
+    for chunk in chunks[1:]:
+        label, _, value = chunk.partition("\n")
+        value = value.strip()
+        if value == FORM_NO_RESPONSE:
+            value = ""
+        fields[label.strip()] = value
 
-        stable_version: str | None = None
-        prerelease_version: str | None = None
+    return fields
 
-        for release in releases:
-            if release.draft:
-                continue
 
-            tag = release.tag_name.lstrip("v")  # Remove 'v' prefix if present
+def get_form_field(fields: Mapping[str, str], *, markers: tuple[str, ...]) -> str | None:
+    """
+    Return the value of the first form field whose label contains one of the markers.
 
-            if release.prerelease:
-                if prerelease_version is None:
-                    prerelease_version = tag
-            elif stable_version is None:
-                stable_version = tag
-                # If we have both, we're done
-                if prerelease_version is not None:
-                    break
+    Returns None when no matching field exists (e.g. the issue was created without
+    the template), and an empty string when the field exists but was left blank.
+    """
+    for label, value in fields.items():
+        lowered = label.casefold()
+        if any(marker in lowered for marker in markers):
+            return value
+    return None
 
-            # Stop after checking first 20 releases
-            if stable_version is not None:
-                break
 
-        _cached_versions["stable"] = stable_version
-        _cached_versions["prerelease"] = prerelease_version
-
-    except GithubException as e:
-        print(f"Warning: Could not fetch versions from GitHub: {e}")
-        # Fallback to None - validation will still work but without version comparison
-        _cached_versions["stable"] = None
-        _cached_versions["prerelease"] = None
-
-    return _cached_versions.get("stable"), _cached_versions.get("prerelease")
+# =============================================================================
+# Version check (deterministic — compared against published releases only)
+# =============================================================================
 
 
 def parse_version(version_str: str) -> tuple[int, int, int, str] | None:
@@ -241,97 +130,95 @@ def parse_version(version_str: str) -> tuple[int, int, int, str] | None:
     return (major, minor, patch, prerelease)
 
 
-def validate_integration_version(
-    version_str: str,
-    *,
-    current_stable: str | None,
-    current_prerelease: str | None,
-) -> dict[str, Any]:
+@dataclass(frozen=True)
+class ReleaseInfo:
+    """Published release versions of the integration."""
+
+    stable: str | None = None
+    prerelease: str | None = None
+    all_versions: frozenset[str] = field(default_factory=frozenset)
+
+
+def fetch_release_info(gh: Github) -> ReleaseInfo:
     """
-    Validate if the reported version is a valid Homematic(IP) Local version.
+    Fetch the published release versions from the integration repository.
 
-    Args:
-        version_str: The version string to validate.
-        current_stable: Current stable version from GitHub Releases.
-        current_prerelease: Current pre-release version from GitHub Releases.
-
-    Returns a dict with validation results.
-
+    Returns the latest stable version, the latest pre-release version and the set of
+    all known release versions (tag names without a leading "v").
     """
-    result: dict[str, Any] = {
-        "reported_version": version_str,
-        "is_valid_format": False,
-        "is_valid_homematicip_local": False,
-        "is_prerelease": False,
-        "needs_update": False,
-        "current_stable": current_stable or "unknown",
-        "current_prerelease": current_prerelease or "none",
-        "issue": None,
-        "issue_description": None,
-    }
+    stable: str | None = None
+    prerelease: str | None = None
+    versions: set[str] = set()
 
-    parsed = parse_version(version_str)
-    if not parsed:
-        result["issue"] = "invalid_format"
-        result["issue_description"] = f"Version '{version_str}' does not match expected format (e.g., 2.0.3 or 2.1.0b1)"
-        return result
+    try:
+        repo = gh.get_repo(INTEGRATION_REPO)
+        for index, release in enumerate(repo.get_releases()):
+            if index >= MAX_RELEASES_TO_SCAN:
+                break
+            if release.draft:
+                continue
+            tag = release.tag_name.removeprefix("v")
+            versions.add(tag)
+            if release.prerelease:
+                if prerelease is None:
+                    prerelease = tag
+            elif stable is None:
+                stable = tag
+    except GithubException as e:
+        print(f"Warning: Could not fetch releases from GitHub: {e}")
 
-    major, minor, patch, prerelease = parsed
-    result["is_valid_format"] = True
-    result["is_prerelease"] = bool(prerelease)
-
-    # Check for valid major version (1.x.x, 2.x.x, or 3.x.x)
-    if major not in VALID_MAJOR_VERSIONS:
-        result["issue"] = "invalid_major_version"
-        result["issue_description"] = (
-            f"Version '{version_str}' is not a valid Homematic(IP) Local version. "
-            f"Valid versions use major versions 1, 2, or 3. "
-            f"You may have reported the CCU firmware version instead of the integration version, "
-            f"or you are using an old/different integration."
-        )
-        return result
-
-    result["is_valid_homematicip_local"] = True
-
-    # Compare with current stable version (only if we have version info)
-    if current_stable:
-        current_parsed = parse_version(current_stable)
-        if current_parsed:
-            current_major, current_minor, current_patch, _ = current_parsed
-            reported_tuple = (major, minor, patch)
-            current_tuple = (current_major, current_minor, current_patch)
-
-            if reported_tuple < current_tuple:
-                result["needs_update"] = True
-                result["issue"] = "outdated_version"
-                result["issue_description"] = (
-                    f"Version '{version_str}' is outdated. "
-                    f"Current stable version is {current_stable}. "
-                    f"Please update to the latest version before reporting issues."
-                )
-
-    return result
+    return ReleaseInfo(stable=stable, prerelease=prerelease, all_versions=frozenset(versions))
 
 
-def extract_version_from_issue(issue_body: str) -> str | None:
-    """Extract the reported version from issue body."""
-    # Look for version pattern in issue body (from template field)
-    # The template asks for version in format like "1.8x.x"
-    patterns = [
-        r"(?:version|Version)[:\s]*(\d+\.\d+\.\d+(?:b\d+)?)",
-        r"(\d+\.\d+\.\d+(?:b\d+)?)",
-    ]
+@dataclass(frozen=True)
+class VersionCheck:
+    """Deterministic result of comparing the reported version against known releases."""
 
-    for pattern in patterns:
-        match = re.search(pattern, issue_body)
-        if match:
-            return match.group(1)
+    # One of: "missing", "no_data", "ok", "outdated", "unknown"
+    status: str
+    reported: str = ""
+    stable: str = ""
+    prerelease: str = ""
 
-    return None
+
+def check_reported_version(reported: str | None, *, releases: ReleaseInfo) -> VersionCheck:
+    """
+    Check the version reported in the form field against the published releases.
+
+    The check is purely deterministic: a version is only flagged as "unknown" when it
+    matches none of the actually published release versions, and as "outdated" only
+    when it is a known release older than the current stable one. When the release
+    list could not be fetched, no statement about validity is made ("no_data").
+    """
+    stable = releases.stable or ""
+    prerelease = releases.prerelease or ""
+
+    if reported is None or not reported.strip():
+        return VersionCheck(status="missing", stable=stable, prerelease=prerelease)
+
+    normalized = reported.strip().removeprefix("v")
+
+    if not releases.all_versions:
+        return VersionCheck(status="no_data", reported=normalized, stable=stable, prerelease=prerelease)
+
+    if normalized in releases.all_versions:
+        rep_parsed = parse_version(normalized)
+        stable_parsed = parse_version(stable) if stable else None
+        if rep_parsed and stable_parsed and rep_parsed[:3] < stable_parsed[:3]:
+            return VersionCheck(status="outdated", reported=normalized, stable=stable, prerelease=prerelease)
+        return VersionCheck(status="ok", reported=normalized, stable=stable, prerelease=prerelease)
+
+    # Tolerate shortened versions like "2.8" when a release "2.8.x" exists.
+    if "." in normalized and any(
+        version.startswith((f"{normalized}.", f"{normalized}b")) for version in releases.all_versions
+    ):
+        return VersionCheck(status="ok", reported=normalized, stable=stable, prerelease=prerelease)
+
+    return VersionCheck(status="unknown", reported=normalized, stable=stable, prerelease=prerelease)
 
 
 # =============================================================================
-# Attachment Analysis Functions
+# Attachment / screenshot detection (deterministic)
 # =============================================================================
 
 
@@ -378,402 +265,49 @@ def extract_attachment_urls(issue_body: str) -> tuple[list[str], list[str]]:
     return json_urls, log_urls
 
 
-def download_attachment(url: str, *, max_size: int = MAX_ATTACHMENT_SIZE) -> str | None:
+# Fenced code blocks and log-like lines used to detect inline log excerpts
+_FENCED_BLOCK_PATTERN: Final = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
+_LOG_LINE_PATTERN: Final = re.compile(r"\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}|\b(?:ERROR|WARNING|DEBUG|INFO|Traceback)\b")
+
+# Minimum number of log-like lines in a fenced block to count as an inline log
+MIN_INLINE_LOG_LINES: Final = 5
+
+
+def has_inline_log(issue_body: str) -> bool:
+    """Return True if the issue body contains a fenced code block that looks like a log excerpt."""
+    for block in _FENCED_BLOCK_PATTERN.findall(issue_body or ""):
+        log_lines = sum(1 for line in block.splitlines() if _LOG_LINE_PATTERN.search(line))
+        if log_lines >= MIN_INLINE_LOG_LINES:
+            return True
+    return False
+
+
+def detect_attachments(issue_body: str) -> tuple[bool, bool]:
     """
-    Download an attachment from GitHub.
+    Detect whether diagnostics and log data are present in the issue.
 
-    Returns the content as string, or None if download fails.
+    Returns tuple of (has_diagnostics, has_logs). Inline log excerpts in fenced code
+    blocks count as log data to avoid pointless "log missing" requests.
     """
-    try:
-        # Use streaming to check size before downloading
-        with requests.get(url, stream=True, timeout=30, allow_redirects=True) as response:
-            response.raise_for_status()
+    json_urls, log_urls = extract_attachment_urls(issue_body or "")
+    has_diagnostics = bool(json_urls)
+    has_logs = bool(log_urls) or has_inline_log(issue_body or "")
+    return has_diagnostics, has_logs
 
-            # Check content length if available
-            content_length = response.headers.get("content-length")
-            if content_length and int(content_length) > max_size:
-                print(f"Attachment too large: {content_length} bytes")
-                return None
 
-            # Download with size limit
-            content_chunks: list[bytes] = []
-            total_size = 0
-            for chunk in response.iter_content(chunk_size=8192):
-                total_size += len(chunk)
-                if total_size > max_size:
-                    print("Attachment exceeded size limit during download")
-                    return None
-                content_chunks.append(chunk)
+_SCREENSHOT_PATTERN: Final = re.compile(
+    r"user-attachments/assets/|!\[[^\]]*\]\(|\.(?:png|jpe?g|gif|webp)\b", re.IGNORECASE
+)
 
-            content = b"".join(content_chunks)
 
-            # Try to decode as UTF-8
-            try:
-                return content.decode("utf-8")
-            except UnicodeDecodeError:
-                return content.decode("latin-1")
+def detect_screenshots(issue_body: str) -> bool:
+    """Return True if the issue body contains screenshots or other images."""
+    return bool(_SCREENSHOT_PATTERN.search(issue_body or ""))
 
-    except requests.RequestException as e:
-        print(f"Failed to download attachment from {url}: {e}")
-        return None
 
-
-def analyze_diagnostics_json(content: str) -> dict[str, Any]:
-    """
-    Parse and extract structured data from diagnostics JSON file.
-
-    Returns extracted data as a dictionary.
-    """
-    result: dict[str, Any] = {
-        "models": [],
-        "device_addresses": set(),
-        "system_health": {},
-        "client_health": {},
-        "incident_store": {},
-        "metrics": {},
-        "interfaces": [],
-    }
-
-    try:
-        data = json.loads(content)
-
-        # Handle nested structure: data -> data -> ...
-        inner_data = data.get("data", data)
-
-        # Extract models list
-        result["models"] = inner_data.get("models", [])
-
-        # Extract system health
-        result["system_health"] = inner_data.get("system_health", {})
-
-        # Extract client health per interface
-        if "system_health" in inner_data:
-            result["client_health"] = inner_data["system_health"].get("client_health", {})
-
-        # Extract incident store
-        result["incident_store"] = inner_data.get("incident_store", {})
-
-        # Extract metrics
-        result["metrics"] = inner_data.get("metrics", {})
-
-        # Extract interfaces from config
-        config = inner_data.get("config", {})
-        if isinstance(config, dict):
-            config_data = config.get("data", config)
-            interfaces = config_data.get("interface", {})
-            result["interfaces"] = list(interfaces.keys()) if isinstance(interfaces, dict) else []
-
-        # Try to extract device addresses from various sources
-        # This might be in device descriptions or other places
-        if "device_descriptions" in inner_data:
-            for addr in inner_data["device_descriptions"]:
-                if isinstance(addr, str) and ":" not in addr:
-                    result["device_addresses"].add(addr)
-
-    except json.JSONDecodeError as e:
-        print(f"Failed to parse diagnostics JSON: {e}")
-
-    return result
-
-
-def analyze_log_file(content: str, *, max_lines: int = 50000) -> dict[str, Any]:
-    """
-    Analyze log file content for known patterns.
-
-    Returns analysis results including pattern matches and extracted addresses.
-    """
-    result: dict[str, Any] = {
-        "pattern_matches": {},
-        "no_subscriber_addresses": set(),
-        "event_addresses": set(),
-        "unreach_addresses": set(),
-        "sample_matches": {},
-    }
-
-    # Limit lines to prevent excessive processing
-    lines = content.split("\n")[:max_lines]
-    content_limited = "\n".join(lines)
-
-    for pattern_name, pattern_info in LOG_PATTERNS.items():
-        pattern = pattern_info["pattern"]
-        matches = re.findall(pattern, content_limited, re.IGNORECASE)
-
-        if matches:
-            result["pattern_matches"][pattern_name] = len(matches)
-
-            # Store sample matches (up to 5)
-            if isinstance(matches[0], str):
-                result["sample_matches"][pattern_name] = matches[:5]
-            else:
-                result["sample_matches"][pattern_name] = [m[0] if isinstance(m, tuple) else m for m in matches[:5]]
-
-    # Extract specific addresses from "No subscribers" events
-    no_sub_pattern = r"No subscribers for (?:Rpc)?ParameterReceivedEvent.*?\[([A-Za-z0-9]+:\d+)\]"
-    no_sub_matches = re.findall(no_sub_pattern, content_limited)
-    for match in no_sub_matches:
-        # Extract device address (before the colon)
-        device_addr = match.split(":")[0] if ":" in match else match
-        result["no_subscriber_addresses"].add(device_addr)
-
-    # Extract addresses from EVENT lines
-    event_pattern = r"EVENT.*?channel_address\s*=\s*([A-Za-z0-9]+:\d+)"
-    event_matches = re.findall(event_pattern, content_limited)
-    for match in event_matches:
-        device_addr = match.split(":")[0] if ":" in match else match
-        result["event_addresses"].add(device_addr)
-
-    # Extract addresses from UNREACH events
-    unreach_pattern = r"channel_address\s*=\s*([A-Za-z0-9]+:\d+).*?UNREACH.*?True"
-    unreach_matches = re.findall(unreach_pattern, content_limited)
-    for match in unreach_matches:
-        device_addr = match.split(":")[0] if ":" in match else match
-        result["unreach_addresses"].add(device_addr)
-
-    return result
-
-
-def cross_reference_devices(
-    *,
-    registered_models: list[str],
-    no_subscriber_addresses: set[str],
-    event_addresses: set[str],
-) -> dict[str, Any]:
-    """
-    Cross-reference registered devices with event-sending devices.
-
-    Identifies devices that send events but are not registered in HA.
-    """
-    result: dict[str, Any] = {
-        "unregistered_sending_events": [],
-        "orphan_event_count": 0,
-        "analysis_notes": [],
-    }
-
-    # If we have no-subscriber events, these devices are definitely not registered
-    if no_subscriber_addresses:
-        result["unregistered_sending_events"] = list(no_subscriber_addresses)
-        result["orphan_event_count"] = len(no_subscriber_addresses)
-        result["analysis_notes"].append(
-            f"Found {len(no_subscriber_addresses)} device(s) sending events without registered entities"
-        )
-
-    # Check if event-sending devices match known model patterns
-    # Classic HM devices typically start with specific prefixes (JEQ, LEQ, etc.)
-    classic_hm_addresses = {
-        addr for addr in event_addresses if addr.startswith(("JEQ", "LEQ", "MEQ", "NEQ", "OEQ", "SEQ"))
-    }
-
-    if classic_hm_addresses and "BidCos-RF" not in str(registered_models):
-        result["analysis_notes"].append(
-            f"Classic HM devices detected ({len(classic_hm_addresses)}) but BidCos-RF interface may not be active"
-        )
-
-    return result
-
-
-def prioritize_findings(
-    *,
-    log_analysis: dict[str, Any],
-    cross_ref: dict[str, Any],
-    diagnostics: dict[str, Any],
-    is_german: bool,
-) -> list[dict[str, Any]]:
-    """
-    Prioritize and deduplicate findings based on root cause analysis.
-
-    Higher priority findings supersede lower priority ones for the same issue.
-    """
-    findings: list[dict[str, Any]] = []
-    suppressed_patterns: set[str] = set()
-
-    # Sort patterns by priority
-    sorted_patterns = sorted(LOG_PATTERNS.items(), key=lambda x: x[1]["priority"])
-
-    for pattern_name, pattern_info in sorted_patterns:
-        if pattern_name in suppressed_patterns:
-            continue
-
-        match_count = log_analysis.get("pattern_matches", {}).get(pattern_name, 0)
-        if match_count == 0:
-            continue
-
-        # This pattern matched - suppress lower priority patterns it supersedes
-        for superseded in pattern_info.get("supersedes", []):
-            suppressed_patterns.add(superseded)
-
-        description = pattern_info["description_de"] if is_german else pattern_info["description_en"]
-
-        finding: dict[str, Any] = {
-            "category": pattern_info["category"],
-            "severity": pattern_info["severity"],
-            "priority": pattern_info["priority"],
-            "pattern": pattern_name,
-            "count": match_count,
-            "description": description,
-        }
-
-        # Add specific details for certain patterns
-        if pattern_name == "no_subscribers":
-            addresses = list(log_analysis.get("no_subscriber_addresses", set()))[:5]
-            if addresses:
-                if is_german:
-                    finding["description"] += f". Betroffene Geräte: {', '.join(addresses)}"
-                    finding["recommendation"] = (
-                        "Diese Geräte sind nicht in Home Assistant registriert. "
-                        "Prüfen Sie, ob die Geräte in HA deaktiviert oder nie hinzugefügt wurden."
-                    )
-                else:
-                    finding["description"] += f". Affected devices: {', '.join(addresses)}"
-                    finding["recommendation"] = (
-                        "These devices are not registered in Home Assistant. "
-                        "Check if devices are disabled in HA or were never added."
-                    )
-
-        findings.append(finding)
-
-    # Add cross-reference findings
-    if cross_ref.get("unregistered_sending_events"):
-        # Check if we already have a no_subscribers finding
-        has_no_sub = any(f["pattern"] == "no_subscribers" for f in findings)
-        if not has_no_sub:
-            devices = cross_ref["unregistered_sending_events"][:5]
-            if is_german:
-                findings.insert(
-                    0,
-                    {
-                        "category": "device_not_registered",
-                        "severity": "error",
-                        "priority": 1,
-                        "pattern": "cross_reference",
-                        "count": len(cross_ref["unregistered_sending_events"]),
-                        "description": f"Geräte senden Events aber sind nicht in HA registriert: {', '.join(devices)}",
-                        "recommendation": "Prüfen Sie, ob diese Geräte in Home Assistant deaktiviert oder nie hinzugefügt wurden.",
-                    },
-                )
-            else:
-                findings.insert(
-                    0,
-                    {
-                        "category": "device_not_registered",
-                        "severity": "error",
-                        "priority": 1,
-                        "pattern": "cross_reference",
-                        "count": len(cross_ref["unregistered_sending_events"]),
-                        "description": f"Devices send events but are not registered in HA: {', '.join(devices)}",
-                        "recommendation": "Check if these devices are disabled in Home Assistant or were never added.",
-                    },
-                )
-
-    # Add incident store findings
-    incidents = diagnostics.get("incident_store", {})
-    if incidents.get("total_incidents", 0) > 0:
-        recent = incidents.get("recent_incidents", [])
-        if recent:
-            last_incident = recent[0]
-            if is_german:
-                findings.append(
-                    {
-                        "category": "connection",
-                        "severity": "warning",
-                        "priority": 3,
-                        "pattern": "incident_store",
-                        "count": incidents["total_incidents"],
-                        "description": f"Aufgezeichnete Vorfälle: {last_incident.get('message', 'Unbekannt')}",
-                    }
-                )
-            else:
-                findings.append(
-                    {
-                        "category": "connection",
-                        "severity": "warning",
-                        "priority": 3,
-                        "pattern": "incident_store",
-                        "count": incidents["total_incidents"],
-                        "description": f"Recorded incidents: {last_incident.get('message', 'Unknown')}",
-                    }
-                )
-
-    # Sort findings by priority (lower number = higher priority)
-    findings.sort(key=lambda x: (x.get("priority", 99), -x.get("count", 0)))
-
-    return findings
-
-
-def perform_deep_analysis(issue_body: str) -> AttachmentAnalysis:
-    """
-    Perform deep analysis of attached files.
-
-    Downloads and analyzes diagnostic JSON and log files.
-    """
-    analysis = AttachmentAnalysis()
-
-    # Extract attachment URLs
-    json_urls, log_urls = extract_attachment_urls(issue_body)
-
-    print(f"Found {len(json_urls)} JSON URLs and {len(log_urls)} log URLs")
-
-    # Analyze diagnostics JSON
-    if json_urls:
-        analysis.diagnostics_url = json_urls[0]
-        content = download_attachment(json_urls[0])
-        if content:
-            analysis.has_diagnostics = True
-            diag_data = analyze_diagnostics_json(content)
-            analysis.registered_models = diag_data.get("models", [])
-            analysis.registered_device_addresses = diag_data.get("device_addresses", set())
-            analysis.system_health = diag_data.get("system_health", {})
-            analysis.interface_health = diag_data.get("client_health", {})
-            analysis.incident_store = diag_data.get("incident_store", {})
-            analysis.metrics = diag_data.get("metrics", {})
-            print(f"Parsed diagnostics: {len(analysis.registered_models)} models")
-
-    # Analyze log file
-    if log_urls:
-        analysis.log_url = log_urls[0]
-        content = download_attachment(log_urls[0])
-        if content:
-            analysis.has_logs = True
-            log_data = analyze_log_file(content)
-            analysis.no_subscriber_addresses = log_data.get("no_subscriber_addresses", set())
-            analysis.event_sending_addresses = log_data.get("event_addresses", set())
-            analysis.log_pattern_matches = {
-                k: log_data.get("sample_matches", {}).get(k, []) for k in log_data.get("pattern_matches", {})
-            }
-            print(f"Analyzed log: {len(analysis.no_subscriber_addresses)} no-subscriber addresses")
-
-    # Cross-reference devices
-    cross_ref = cross_reference_devices(
-        registered_models=analysis.registered_models,
-        no_subscriber_addresses=analysis.no_subscriber_addresses,
-        event_addresses=analysis.event_sending_addresses,
-    )
-    analysis.unregistered_devices = set(cross_ref.get("unregistered_sending_events", []))
-    analysis.orphan_events = cross_ref.get("unregistered_sending_events", [])
-
-    return analysis
-
-
-# Documentation links
-DOCS_LINKS = {
-    "main_readme": "https://sukramj.github.io/aiohomematic/",
-    "homematicip_local_readme": "https://github.com/sukramj/homematicip_local#homematicip_local",
-    "troubleshooting": "https://sukramj.github.io/aiohomematic/user/troubleshooting/homeassistant_troubleshooting/",
-    "releases": "https://github.com/sukramj/homematicip_local/releases",
-    "architecture": "https://sukramj.github.io/aiohomematic/architecture/",
-    "naming": "https://sukramj.github.io/aiohomematic/contributor/coding/naming/",
-    "unignore": "https://sukramj.github.io/aiohomematic/user/advanced/unignore/",
-    "lifecycle": "https://sukramj.github.io/aiohomematic/developer/homeassistant_lifecycle/",
-    "glossary": "https://sukramj.github.io/aiohomematic/reference/glossary/",
-    "discussions": "https://github.com/sukramj/aiohomematic/discussions",
-}
-
-# Required information fields from issue template
-REQUIRED_FIELDS = [
-    "version",
-    "installation_type",
-    "backend_type",
-    "problem_description",
-]
+# =============================================================================
+# Template language detection
+# =============================================================================
 
 # German template markers - if any of these are found, the issue uses the German template
 GERMAN_TEMPLATE_MARKERS = [
@@ -804,6 +338,10 @@ def detect_template_language(issue_body: str) -> str:
 
     return "en"
 
+
+# =============================================================================
+# AI-paste detection
+# =============================================================================
 
 # Markers that strongly indicate pasted AI/LLM output - any single match triggers detection.
 STRONG_AI_MARKERS: Final[tuple[str, ...]] = (
@@ -901,313 +439,165 @@ def detect_ai_generated_analysis(issue_body: str) -> dict[str, Any]:
     return result
 
 
-CLAUDE_ANALYSIS_PROMPT = """You are an AI assistant helping to analyze GitHub issues for the AioHomematic and Homematic(IP) Local projects.
+# =============================================================================
+# Search terms and similar issues
+# =============================================================================
 
-**CRITICAL - Response Language:**
-The issue template language has been detected as: **{template_language}**
-- If "de" (German): You MUST respond in German. All text fields in your JSON response (summary, descriptions, explanations, recommendations) MUST be in German.
-- If "en" (English): You MUST respond in English. All text fields in your JSON response MUST be in English.
-This is mandatory and overrides any other language detection based on content.
+# Device model designations like "HmIP-eTRV-2", "HM-PB-2-WM55", "HB-UNI-Sen-..."
+_DEVICE_MODEL_PATTERN: Final = re.compile(r"\b(?:HmIPW?|HM|HB)-[A-Za-z0-9][A-Za-z0-9-]*\b", re.IGNORECASE)
 
-Context:
-- This repository (aiohomematic) is a Python library for controlling Homematic and HomematicIP devices
-- Issues may relate to either the library itself or the Home Assistant integration "Homematic(IP) Local"
-- Issues should follow a specific template with required information
-
-CRITICAL - Required Information for Support:
-- **Meaningful support is ONLY possible if all required information is provided!**
-- The two MOST IMPORTANT pieces of information are:
-  1. **Integration diagnostics (.json file)** - Downloaded via Settings -> Devices -> Select integration -> Download diagnostics
-  2. **Log file** - The complete Home Assistant log file (not just excerpts)
-- Without these, the issue should be flagged as incomplete
-- Exception: For initial setup/installation issues, diagnostics may not be available yet
-
-CRITICAL - Version Validation:
-- Valid Homematic(IP) Local versions: 1.x.x (current) or 2.x.x (future major version)
-- Current stable version: {current_stable}
-- Current pre-release version: {current_prerelease} (pre-releases contain 'b', e.g., 1.91.0b32)
-- If a user reports a version that does NOT start with 1.x.x or 2.x.x (e.g., 3.69.7), this is INVALID:
-  - They may have confused the integration version with the CCU firmware version (CCU3 uses 3.x.x)
-  - They may be using an old/different integration not based on aiohomematic
-  - This MUST be flagged as a critical issue requiring clarification
-- If the reported version is older than the current stable version, the user should be asked to update first
-- Support can only be provided for the current stable version or newer
-
-Version check result for this issue:
-{version_check_json}
-
-Terminology (from our Glossary):
-- Integration: A Home Assistant component connecting to external services. Homematic(IP) Local is an INTEGRATION.
-- App: A separate application running alongside Home Assistant (e.g., OpenCCU App). NOT the same as Integration. (Formerly called "Add-on", renamed in HA 2026.2.)
-- Plugin: NOT an official Home Assistant term - users should use "Integration" or "App" instead.
-- Backend: The CCU hardware/software (OpenCCU, CCU3, Debmatic, Homegear) that manages Homematic devices.
-- Interface: Communication channel to device types (HmIP-RF, BidCos-RF, BidCos-Wired, VirtualDevices/CUxD, Groups).
-- Device: Physical or virtual Homematic device with unique address containing channels.
-- Channel: Logical unit within device grouping related functionality.
-- Parameter: Named value on a channel (VALUES for runtime, MASTER for config).
-- Data Point / Entity: Representation of a parameter in Home Assistant.
-
-=== DEEP ANALYSIS RESULTS (Pre-analyzed from attachments) ===
-{deep_analysis_json}
-
-CRITICAL - Root Cause Analysis Priority Rules:
-When analyzing device availability issues, you MUST follow these priority rules:
-
-1. **HIGHEST PRIORITY - "No subscribers" / "device_not_registered"**:
-   - If the deep analysis shows "no_subscriber_count" > 0 or "unregistered_devices" is not empty,
-     this means devices are SENDING events but NO Home Assistant entities are listening.
-   - This is NOT a radio/communication issue - the CCU communication works fine!
-   - The devices are simply not registered in Home Assistant (disabled or never added).
-   - DO NOT suggest STICKY_UN_REACH reset - that is the WRONG diagnosis!
-   - CORRECT recommendation: Check if devices are disabled in HA or need to be added.
-
-2. **LOWER PRIORITY - STICKY_UN_REACH**:
-   - Only relevant if devices ARE registered but had past communication issues.
-   - If "no_subscribers" findings exist, STICKY_UN_REACH is NOT the root cause.
-   - STICKY_UN_REACH means "past radio issues" - but if events are arriving, radio works!
-
-3. **Priority Hierarchy**:
-   - device_not_registered (priority 1) SUPERSEDES sticky_unreach (priority 3)
-   - connection_refused (priority 1) indicates backend not reachable
-   - xmlrpc_fault (priority 2) indicates communication errors
-   - If a higher priority issue exists, do NOT mention lower priority issues as the cause.
-
-Your task:
-1. Analyze the issue content and determine if it's complete and well-formed
-2. Check for terminology misuse (e.g., "Plugin" instead of "Integration", "Add-on" instead of "App", confusion between Integration and App)
-3. Identify any missing required information
-4. USE THE DEEP ANALYSIS RESULTS above - this is VERIFIED data from the actual files!
-   - The "prioritized_findings" list is already sorted by priority
-   - Trust this data over symptom-based guessing
-5. Suggest relevant documentation links from the available docs
-6. Identify key terms for searching similar issues
-
-Issue Title: {title}
-
-Issue Body:
-{body}
-
-Available documentation:
-{docs}
-
-Please respond in JSON format with the following structure:
-{{
-  "is_complete": boolean,
-  "version_issue": {{
-    "has_issue": boolean,
-    "severity": "critical|warning|info|none",
-    "message": "explanation of the version issue in detected language (or null if no issue)"
-  }},
-  "missing_information": [
-    {{
-      "field": "field name",
-      "description": "what information is missing",
-      "language": "de" or "en" (detected from issue)
-    }}
-  ],
-  "terminology_issues": [
-    {{
-      "term_used": "incorrect term used",
-      "correct_term": "what they should use instead",
-      "explanation": "brief explanation in detected language"
-    }}
-  ],
-  "attachment_analysis": {{
-    "has_diagnostics": boolean,
-    "has_logs": boolean,
-    "findings": [
-      {{
-        "category": "device_not_registered|device_issue|connection|interface|config|other",
-        "description": "what was found",
-        "severity": "info|warning|error",
-        "recommendation": "optional - specific action to take"
-      }}
-    ]
-  }},
-  "suggested_docs": [
-    {{
-      "doc_key": "key from available docs",
-      "reason": "why this doc is relevant"
-    }}
-  ],
-  "search_terms": ["term1", "term2", ...],
-  "language": "de" or "en",
-  "is_bug_report": boolean,
-  "is_device_related": boolean,
-  "has_screenshots": boolean,
-  "summary": "brief summary of the issue in the detected language"
-}}
-
-IMPORTANT:
-- Use the prioritized_findings from deep analysis as the PRIMARY source for attachment_analysis.findings
-- If "device_not_registered" findings exist, this is the root cause - not STICKY_UN_REACH
-- Be helpful and constructive
-- Only flag missing information if it's genuinely required
-- If terminology is misused, gently suggest correct terms and link to glossary
-- For device-related issues (missing entities, wrong values, strange behavior): Check if the issue contains screenshots. If not, flag this as missing information - screenshots are much more helpful than long text descriptions for device issues!
-- Detect screenshots by looking for image URLs (e.g., user-attachments/assets, imgur, png, jpg, gif extensions)"""
+# Interface designations that match the device-model pattern but are useless as search terms
+_NON_DEVICE_TERMS: Final = frozenset({"hmip-rf", "hm-rf"})
 
 
-def get_claude_analysis(
-    title: str,
-    body: str,
-    api_key: str,
-    *,
-    gh: Github,
-    deep_analysis: AttachmentAnalysis | None = None,
-) -> dict[str, Any]:
-    """Use Claude to analyze the issue with deep analysis results."""
-    client = Anthropic(api_key=api_key)
-
-    docs_str = "\n".join([f"- {key}: {url}" for key, url in DOCS_LINKS.items()])
-
-    # Detect template language from issue body
-    template_language = detect_template_language(body or "")
-    print(f"Detected template language: {template_language}")
-
-    # Fetch current versions from GitHub Releases
-    current_stable, current_prerelease = fetch_latest_versions(gh)
-
-    # Extract and validate version from issue body
-    extracted_version = extract_version_from_issue(body or "")
-    if extracted_version:
-        version_check = validate_integration_version(
-            extracted_version,
-            current_stable=current_stable,
-            current_prerelease=current_prerelease,
-        )
-    else:
-        version_check = {
-            "reported_version": None,
-            "is_valid_format": False,
-            "is_valid_homematicip_local": False,
-            "issue": "no_version_found",
-            "issue_description": "No version number found in issue body",
-            "current_stable": current_stable or "unknown",
-            "current_prerelease": current_prerelease or "none",
-        }
-
-    # Prepare deep analysis JSON
-    if deep_analysis:
-        deep_analysis_dict = deep_analysis.to_dict()
-    else:
-        deep_analysis_dict = {
-            "has_diagnostics": False,
-            "has_logs": False,
-            "note": "No attachments could be downloaded or analyzed",
-        }
-
-    prompt = CLAUDE_ANALYSIS_PROMPT.format(
-        title=title,
-        body=body or "(empty)",
-        docs=docs_str,
-        current_stable=current_stable or "unknown",
-        current_prerelease=current_prerelease or "none",
-        version_check_json=json.dumps(version_check, indent=2),
-        deep_analysis_json=json.dumps(deep_analysis_dict, indent=2),
-        template_language="de (German)" if template_language == "de" else "en (English)",
-    )
-
-    message = client.messages.create(
-        model="claude-sonnet-4-5", max_tokens=2000, messages=[{"role": "user", "content": prompt}]
-    )
-
-    # Parse the JSON response
-    response_text = message.content[0].text
-    # Extract JSON from potential markdown code blocks
-    if "```json" in response_text:
-        response_text = response_text.split("```json")[1].split("```")[0].strip()
-    elif "```" in response_text:
-        response_text = response_text.split("```")[1].split("```")[0].strip()
-
-    analysis = cast(dict[str, Any], json.loads(response_text))
-
-    # Override language with detected template language (template language takes precedence)
-    analysis["language"] = template_language
-
-    # Merge deep analysis findings if Claude didn't include them
-    if deep_analysis and deep_analysis.findings:
-        attachment_analysis = analysis.get("attachment_analysis", {})
-        claude_findings = attachment_analysis.get("findings", [])
-
-        # If Claude returned fewer findings than our deep analysis, use ours
-        if len(claude_findings) < len(deep_analysis.findings):
-            # Use template language for findings
-            is_german = template_language == "de"
-
-            # Prioritize findings
-            prioritized = prioritize_findings(
-                log_analysis={
-                    "pattern_matches": {k: len(v) for k, v in deep_analysis.log_pattern_matches.items()},
-                    "no_subscriber_addresses": deep_analysis.no_subscriber_addresses,
-                },
-                cross_ref={
-                    "unregistered_sending_events": list(deep_analysis.unregistered_devices),
-                },
-                diagnostics={
-                    "incident_store": deep_analysis.incident_store,
-                },
-                is_german=is_german,
-            )
-
-            # Convert to Claude's format
-            attachment_analysis["findings"] = [
-                {
-                    "category": f["category"],
-                    "description": f["description"],
-                    "severity": f["severity"],
-                    "recommendation": f.get("recommendation", ""),
-                }
-                for f in prioritized
-            ]
-            attachment_analysis["has_diagnostics"] = deep_analysis.has_diagnostics
-            attachment_analysis["has_logs"] = deep_analysis.has_logs
-            analysis["attachment_analysis"] = attachment_analysis
-
-    return analysis
+def extract_device_model(text: str) -> str | None:
+    """Return the first device model designation found in the text, or None."""
+    for match in _DEVICE_MODEL_PATTERN.finditer(text or ""):
+        candidate = match.group(0).rstrip("-")
+        if candidate.casefold() not in _NON_DEVICE_TERMS:
+            return candidate
+    return None
 
 
 def search_similar_issues(
-    repo: Repository.Repository, search_terms: list[str], current_issue_number: int
+    gh: Github,
+    *,
+    repo_full_name: str,
+    search_terms: list[str],
+    current_issue_number: int,
 ) -> list[dict[str, Any]]:
-    """Search for similar issues and discussions."""
+    """Search for similar issues via the GitHub search API using the given terms."""
     similar_items: list[dict[str, Any]] = []
+    seen: set[int] = set()
 
-    # Limit search terms to top 3 most relevant
-    search_terms = search_terms[:3]
-
-    for term in search_terms:
-        if not term or len(term) < 3:
+    for raw_term in search_terms[:3]:
+        # Strip search-syntax characters so terms cannot break the query
+        term = re.sub(r"[:\"\[\]<>()]", " ", raw_term).strip()
+        if len(term) < 3:
             continue
 
-        # Search in issues
+        query = f"repo:{repo_full_name} is:issue {term}"
         try:
-            issues = repo.get_issues(state="all", sort="updated", direction="desc")
-            similar_items.extend(
-                {
-                    "type": "issue",
-                    "number": issue.number,
-                    "title": issue.title,
-                    "url": issue.html_url,
-                    "state": issue.state,
-                    "search_term": term,
-                }
-                for issue in issues[:5]  # Limit to 5 results per term
-                if issue.number != current_issue_number
-            )
-        except GithubException:
-            pass
+            results = gh.search_issues(query)
+            for issue in results[:3]:
+                if issue.number == current_issue_number or issue.number in seen:
+                    continue
+                seen.add(issue.number)
+                similar_items.append(
+                    {
+                        "type": "issue",
+                        "number": issue.number,
+                        "title": issue.title,
+                        "url": issue.html_url,
+                        "state": issue.state,
+                        "search_term": term,
+                    }
+                )
+        except GithubException as e:
+            print(f"Warning: similar-issue search failed for '{term}': {e}")
+            continue
 
-    # Remove duplicates
-    seen = set()
-    unique_items = []
-    for item in similar_items:
-        key = (item["type"], item["number"])
-        if key not in seen:
-            seen.add(key)
-            unique_items.append(item)
+        if len(similar_items) >= 5:
+            break
 
-    return unique_items[:5]  # Return top 5 overall
+    return similar_items[:5]
+
+
+# =============================================================================
+# Claude triage summary (no diagnosis!)
+# =============================================================================
+
+CLAUDE_TRIAGE_PROMPT = """You are a triage assistant for GitHub issues of the aiohomematic / Homematic(IP) Local projects (a Python library and Home Assistant integration for Homematic home-automation devices).
+
+Today's date is {today}. Keep this in mind: version numbers and timestamps matching the current year are normal, not anomalies.
+
+The issue template language is {template_language}. Write ALL output text in that language.
+
+Your ONLY tasks (pure triage):
+1. "summary": summarize the issue in at most 2 sentences (what the reporter observes, which device/feature is affected).
+2. "suggested_docs": pick 0-2 documentation keys from the list below that genuinely help THIS issue. Return an empty list when none clearly applies.
+3. "search_terms": 1-3 short search terms for finding duplicate issues (device model, distinctive error message fragment, feature name).
+4. "is_device_related": true if the issue is about a specific device's entities, values or behavior.
+5. "is_feature_request": true if this is a feature request rather than a bug report.
+
+STRICT RULES:
+- Do NOT diagnose root causes, do NOT judge versions, do NOT analyze logs, do NOT recommend fixes. Triage only.
+- The summary must describe, not explain: no "probably", no "caused by", no suspected reasons.
+
+Available documentation keys:
+{docs}
+
+Issue title: {title}
+
+Issue body:
+{body}
+
+Respond with ONLY a JSON object of this shape:
+{{"summary": "...", "suggested_docs": [{{"doc_key": "...", "reason": "..."}}], "search_terms": ["..."], "is_device_related": true, "is_feature_request": false}}"""
+
+
+def get_claude_triage(
+    *,
+    title: str,
+    body: str,
+    api_key: str,
+    template_language: str,
+) -> dict[str, Any] | None:
+    """
+    Get a triage summary from Claude (summary, doc links, search terms, routing flags).
+
+    Returns None on any failure so the deterministic triage comment can still be posted.
+    """
+    docs_str = "\n".join(f"- {key}: {url}" for key, url in DOCS_LINKS.items())
+    prompt = CLAUDE_TRIAGE_PROMPT.format(
+        today=date.today().isoformat(),
+        template_language="German" if template_language == "de" else "English",
+        docs=docs_str,
+        title=title,
+        body=(body or "(empty)")[:8000],
+    )
+
+    try:
+        client = Anthropic(api_key=api_key)
+        message = client.messages.create(
+            model=os.getenv("ANALYZER_MODEL") or DEFAULT_ANALYZER_MODEL,
+            max_tokens=600,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        response_text = message.content[0].text
+        # Extract JSON from potential markdown code blocks
+        if "```json" in response_text:
+            response_text = response_text.split("```json")[1].split("```")[0].strip()
+        elif "```" in response_text:
+            response_text = response_text.split("```")[1].split("```")[0].strip()
+        triage = cast(dict[str, Any], json.loads(response_text))
+    except Exception as e:
+        print(f"Warning: Claude triage failed (continuing with deterministic checks only): {e}")
+        return None
+
+    return triage
+
+
+# =============================================================================
+# Comment formatting
+# =============================================================================
+
+
+@dataclass
+class TriageResult:
+    """Aggregated triage results used to render the issue comment."""
+
+    language: str = "en"
+    summary: str | None = None
+    version_check: VersionCheck = field(default_factory=lambda: VersionCheck(status="no_data"))
+    has_diagnostics: bool = False
+    has_logs: bool = False
+    ai_detection: dict[str, Any] = field(default_factory=dict)
+    is_feature_request: bool = False
+    is_device_related: bool = False
+    has_screenshots: bool = False
+    suggested_docs: list[dict[str, str]] = field(default_factory=list)
+    similar_items: list[dict[str, Any]] = field(default_factory=list)
 
 
 def has_bot_comment(issue: Any) -> bool:
@@ -1220,62 +610,58 @@ def has_bot_comment(issue: Any) -> bool:
     return False
 
 
-def _format_version_issue(
-    analysis: dict[str, Any],
-    is_german: bool,
-    *,
-    current_stable: str,
-    current_prerelease: str,
-) -> str:
-    """Format version issue section of the comment."""
-    # If we couldn't determine current versions, don't comment on version issues
-    if current_stable == "unknown":
+def _format_version_notice(version_check: VersionCheck, *, is_german: bool) -> str:
+    """
+    Format a neutral, deterministic version notice.
+
+    Only emitted for statuses that are established by comparing against the actually
+    published releases ("outdated", "unknown"). Never renders a "critical" banner.
+    """
+    if version_check.status not in ("outdated", "unknown") or not version_check.stable:
         return ""
 
-    version_issue = analysis.get("version_issue", {})
-    if not version_issue.get("has_issue"):
-        return ""
-    if version_issue.get("severity") not in ("critical", "warning"):
-        return ""
+    releases_url = DOCS_LINKS["releases"]
 
-    severity = version_issue.get("severity", "warning")
-    message = version_issue.get("message", "")
-
-    is_critical = severity == "critical"
-    emoji = "🚨" if is_critical else "⚠️"
-    header = (
-        ("KRITISCH: Versionsproblem" if is_german else "CRITICAL: Version Issue")
-        if is_critical
-        else ("Versionshinweis" if is_german else "Version Notice")
-    )
-
-    result = f"### {emoji} {header}\n\n{message}\n\n"
+    if version_check.status == "outdated":
+        if is_german:
+            return (
+                "### ℹ️ Versionshinweis\n\n"
+                f"Die gemeldete Version **{version_check.reported}** ist nicht die aktuelle stabile Version "
+                f"(**{version_check.stable}**). Bitte aktualisiere zuerst auf die "
+                f"[aktuelle Version]({releases_url}) und prüfe, ob das Problem weiterhin besteht.\n\n"
+            )
+        return (
+            "### ℹ️ Version notice\n\n"
+            f"The reported version **{version_check.reported}** is not the current stable version "
+            f"(**{version_check.stable}**). Please update to the [latest version]({releases_url}) "
+            "first and check whether the problem persists.\n\n"
+        )
 
     if is_german:
-        result += (
-            f"**Aktuelle stabile Version:** {current_stable}\n"
-            f"**Aktuelle Pre-Release:** {current_prerelease}\n\n"
-            f"Bitte stelle sicher, dass du die [aktuelle Version]({DOCS_LINKS['releases']}) verwendest, "
-            f"bevor du ein Problem meldest. Support kann nur für die aktuelle Version geleistet werden.\n\n"
+        return (
+            "### ℹ️ Versionshinweis\n\n"
+            f'Die Angabe "{version_check.reported}" im Versionsfeld entspricht keiner veröffentlichten Version '
+            f"von Homematic(IP) Local (aktuelle stabile Version: **{version_check.stable}**). "
+            "Möglicherweise wurde versehentlich die Version von Home Assistant oder des CCU-Backends "
+            "eingetragen - bitte das Feld korrigieren.\n\n"
         )
-    else:
-        result += (
-            f"**Current stable version:** {current_stable}\n"
-            f"**Current pre-release:** {current_prerelease}\n\n"
-            f"Please ensure you are using the [latest version]({DOCS_LINKS['releases']}) "
-            f"before reporting issues. Support can only be provided for the current version.\n\n"
-        )
-
-    return result
+    return (
+        "### ℹ️ Version notice\n\n"
+        f'The value "{version_check.reported}" in the version field does not match any published version '
+        f"of Homematic(IP) Local (current stable version: **{version_check.stable}**). "
+        "You may have entered the Home Assistant or CCU backend version by mistake — please correct the field.\n\n"
+    )
 
 
 def _format_missing_required_info(
+    *,
     has_diagnostics: bool,
     has_logs: bool,
+    version_missing: bool,
     is_german: bool,
 ) -> str:
     """Format missing required information section."""
-    if has_diagnostics and has_logs:
+    if has_diagnostics and has_logs and not version_missing:
         return ""
 
     if is_german:
@@ -1288,6 +674,8 @@ def _format_missing_required_info(
             result += "- ❌ **Integrationsdiagnose (.json-Datei)** - Herunterladen via: Einstellungen → Geräte → Integration auswählen → Diagnose herunterladen\n"
         if not has_logs:
             result += "- ❌ **Protokolldatei** - Am besten ein DEBUG-Log hochladen. Aktivieren via: Einstellungen → Geräte → Integration auswählen → Debug-Protokollierung aktivieren. Danach Problem reproduzieren und Log herunterladen (Einstellungen → System → Protokolle → Unveränderte Protokolle laden)\n"
+        if version_missing:
+            result += "- ❌ **Version der Integration** - Das Versionsfeld ist leer. Bitte die Version von Homematic(IP) Local angeben (zu finden in: HACS → Integrationen)\n"
         result += (
             "\n⚠️ **Issues ohne diese Informationen können nicht bearbeitet werden und werden ggf. geschlossen.**\n\n"
         )
@@ -1299,38 +687,12 @@ def _format_missing_required_info(
             result += "- ❌ **Integration diagnostics (.json file)** - Download via: Settings → Devices → Select integration → Download diagnostics\n"
         if not has_logs:
             result += "- ❌ **Log file** - Preferably a DEBUG log. Enable via: Settings → Devices → Select integration → Enable debug logging. Then reproduce the issue and download log (Settings → System → Logs → Load unchanged logs)\n"
+        if version_missing:
+            result += "- ❌ **Integration version** - The version field is empty. Please provide the Homematic(IP) Local version (found in: HACS → Integrations)\n"
         result += "\n⚠️ **Issues without this information cannot be processed and may be closed.**\n\n"
         result += "_Exception: For initial setup issues, diagnostics may not be available yet._\n\n"
 
     return result
-
-
-def _format_screenshot_hint(
-    is_device_related: bool,
-    has_screenshots: bool,
-    is_german: bool,
-) -> str:
-    """Format screenshot hint for device-related issues."""
-    if not is_device_related or has_screenshots:
-        return ""
-
-    if is_german:
-        return (
-            "### 📸 Screenshots empfohlen\n\n"
-            "Bei Geräteproblemen (fehlende Entitäten, falsche Werte, seltsames Verhalten) "
-            "sind **Screenshots viel hilfreicher als lange Textbeschreibungen**!\n\n"
-            "Bitte zeige uns, was Du siehst:\n"
-            "- Screenshot der betroffenen Entität in Home Assistant\n"
-            "- Screenshot des Geräts/Kanals in der CCU-Oberfläche\n\n"
-        )
-    return (
-        "### 📸 Screenshots Recommended\n\n"
-        "For device-related issues (missing entities, wrong values, strange behavior), "
-        "**screenshots are much more helpful than long text descriptions**!\n\n"
-        "Please show us what you see:\n"
-        "- Screenshot of the affected entity in Home Assistant\n"
-        "- Screenshot of the device/channel in the CCU interface\n\n"
-    )
 
 
 def _format_ai_analysis_hint(
@@ -1363,132 +725,94 @@ def _format_ai_analysis_hint(
     )
 
 
-def format_comment(
-    analysis: dict[str, Any],
-    similar_items: list[dict[str, Any]],
+def _format_screenshot_hint(
     *,
-    current_stable: str,
-    current_prerelease: str,
+    is_device_related: bool,
+    has_screenshots: bool,
+    is_german: bool,
 ) -> str:
-    """Format the comment to post on the issue."""
-    lang = analysis.get("language", "en")
-    is_german = lang == "de"
+    """Format screenshot hint for device-related issues."""
+    if not is_device_related or has_screenshots:
+        return ""
 
-    # Header
     if is_german:
-        comment = "## Automatische Issue-Analyse\n\n"
-        comment += f"**Zusammenfassung:** {analysis.get('summary', 'Issue wurde erkannt')}\n\n"
-    else:
-        comment = "## Automatic Issue Analysis\n\n"
-        comment += f"**Summary:** {analysis.get('summary', 'Issue detected')}\n\n"
-
-    # Version issue (highest priority - show first if critical)
-    comment += _format_version_issue(
-        analysis,
-        is_german,
-        current_stable=current_stable,
-        current_prerelease=current_prerelease,
+        return (
+            "### 📸 Screenshots empfohlen\n\n"
+            "Bei Geräteproblemen (fehlende Entitäten, falsche Werte, seltsames Verhalten) "
+            "sind **Screenshots viel hilfreicher als lange Textbeschreibungen**!\n\n"
+            "Bitte zeige uns, was Du siehst:\n"
+            "- Screenshot der betroffenen Entität in Home Assistant\n"
+            "- Screenshot des Geräts/Kanals in der CCU-Oberfläche\n\n"
+        )
+    return (
+        "### 📸 Screenshots Recommended\n\n"
+        "For device-related issues (missing entities, wrong values, strange behavior), "
+        "**screenshots are much more helpful than long text descriptions**!\n\n"
+        "Please show us what you see:\n"
+        "- Screenshot of the affected entity in Home Assistant\n"
+        "- Screenshot of the device/channel in the CCU interface\n\n"
     )
 
-    # Terminology issues
-    terminology_issues = analysis.get("terminology_issues", [])
-    if terminology_issues:
-        if is_german:
-            comment += "### Hinweise zur Terminologie\n\n"
-            comment += (
-                "Um Verwirrung zu vermeiden, beachte bitte die korrekte "
-                f"[Terminologie (Glossar)]({DOCS_LINKS['glossary']}):\n\n"
-            )
-        else:
-            comment += "### Terminology Notes\n\n"
-            comment += (
-                f"To avoid confusion, please note the correct [terminology (Glossary)]({DOCS_LINKS['glossary']}):\n\n"
-            )
 
-        for item in terminology_issues:
-            comment += f"- **{item['term_used']}** → **{item['correct_term']}**: {item['explanation']}\n"
-        comment += "\n"
+def _format_feature_request_hint(*, is_feature_request: bool, is_german: bool) -> str:
+    """Format a routing hint pointing feature requests to the discussions."""
+    if not is_feature_request:
+        return ""
 
-    # Check for missing diagnostics/logs (critical for support)
-    attachment_analysis = analysis.get("attachment_analysis", {})
-    has_diagnostics = attachment_analysis.get("has_diagnostics", False)
-    has_logs = attachment_analysis.get("has_logs", False)
-    comment += _format_missing_required_info(has_diagnostics, has_logs, is_german)
+    discussions_url = DOCS_LINKS["discussions"]
+    if is_german:
+        return (
+            "### 💡 Feature-Wunsch?\n\n"
+            "Diese Meldung sieht nach einem Feature-Wunsch aus. Neue Funktionen werden in den "
+            f"[Diskussionen]({discussions_url}) besprochen — dieses Issue-Formular ist für Fehlermeldungen gedacht.\n\n"
+        )
+    return (
+        "### 💡 Feature request?\n\n"
+        "This report looks like a feature request. New features are discussed in the "
+        f"[discussions]({discussions_url}) — this issue form is meant for bug reports.\n\n"
+    )
+
+
+def format_comment(triage: TriageResult) -> str:
+    """Format the triage comment to post on the issue."""
+    is_german = triage.language == "de"
+
+    # Header (kept identical to the previous bot so duplicate detection keeps working)
+    if is_german:
+        comment = "## Automatische Issue-Analyse\n\n"
+        if triage.summary:
+            comment += f"**Zusammenfassung:** {triage.summary}\n\n"
+    else:
+        comment = "## Automatic Issue Analysis\n\n"
+        if triage.summary:
+            comment += f"**Summary:** {triage.summary}\n\n"
+
+    # Deterministic version notice (neutral, never "critical")
+    comment += _format_version_notice(triage.version_check, is_german=is_german)
+
+    # Missing required raw data (diagnostics / log / version field)
+    comment += _format_missing_required_info(
+        has_diagnostics=triage.has_diagnostics,
+        has_logs=triage.has_logs,
+        version_missing=triage.version_check.status == "missing",
+        is_german=is_german,
+    )
 
     # Redirect hint when the report contains a pasted AI-generated analysis
-    comment += _format_ai_analysis_hint(analysis.get("ai_analysis_detection", {}), is_german)
+    comment += _format_ai_analysis_hint(triage.ai_detection, is_german)
+
+    # Routing hint for feature requests
+    comment += _format_feature_request_hint(is_feature_request=triage.is_feature_request, is_german=is_german)
 
     # Screenshot hint for device-related issues
-    is_device_related = analysis.get("is_device_related", False)
-    has_screenshots = analysis.get("has_screenshots", False)
-    comment += _format_screenshot_hint(is_device_related, has_screenshots, is_german)
+    comment += _format_screenshot_hint(
+        is_device_related=triage.is_device_related,
+        has_screenshots=triage.has_screenshots,
+        is_german=is_german,
+    )
 
-    # Other missing information
-    missing = analysis.get("missing_information", [])
-    # Filter out diagnostics/logs from missing list since we handle them separately
-    missing = [
-        m
-        for m in missing
-        if m.get("field", "").lower() not in ("diagnostics", "logs", "log", "diagnostik", "protokoll")
-    ]
-    if missing:
-        if is_german:
-            comment += "### Weitere fehlende Informationen\n\n"
-        else:
-            comment += "### Additional Missing Information\n\n"
-
-        for item in missing:
-            comment += f"- **{item['field']}**: {item['description']}\n"
-        comment += "\n"
-
-    # Attachment analysis findings
-    findings = attachment_analysis.get("findings", [])
-    if findings:
-        if is_german:
-            comment += "### Analyse der angehängten Daten\n\n"
-            if attachment_analysis.get("has_diagnostics"):
-                comment += "✅ Diagnostik-Daten analysiert. "
-            if attachment_analysis.get("has_logs"):
-                comment += "✅ Protokoll-Daten analysiert. "
-            comment += "\n\n**Erkenntnisse:**\n\n"
-        else:
-            comment += "### Attachment Analysis\n\n"
-            if attachment_analysis.get("has_diagnostics"):
-                comment += "✅ Diagnostics data analyzed. "
-            if attachment_analysis.get("has_logs"):
-                comment += "✅ Log data analyzed. "
-            comment += "\n\n**Findings:**\n\n"
-
-        severity_emoji = {"info": "ℹ️", "warning": "⚠️", "error": "❌"}
-        category_labels = {
-            "device_not_registered": "Gerät nicht registriert" if is_german else "Device Not Registered",
-            "device_issue": "Geräteproblem" if is_german else "Device Issue",
-            "connection": "Verbindung" if is_german else "Connection",
-            "interface": "Schnittstelle" if is_german else "Interface",
-            "config": "Konfiguration" if is_german else "Configuration",
-            "other": "Sonstiges" if is_german else "Other",
-        }
-
-        for finding in findings:
-            emoji = severity_emoji.get(finding.get("severity", "info"), "ℹ️")
-            category = finding.get("category", "other")
-            category_label = category_labels.get(category, category)
-            description = finding.get("description", "")
-            recommendation = finding.get("recommendation", "")
-
-            comment += f"- {emoji} **[{category_label}]** {description}\n"
-
-            # Add recommendation if present
-            if recommendation:
-                if is_german:
-                    comment += f"  - 💡 **Empfehlung:** {recommendation}\n"
-                else:
-                    comment += f"  - 💡 **Recommendation:** {recommendation}\n"
-
-        comment += "\n"
-
-    # Suggested documentation
-    suggested_docs = analysis.get("suggested_docs", [])
+    # Suggested documentation (at most 2 links)
+    suggested_docs = [doc for doc in triage.suggested_docs if doc.get("doc_key") in DOCS_LINKS][:2]
     if suggested_docs:
         if is_german:
             comment += "### Hilfreiche Dokumentation\n\n"
@@ -1499,14 +823,15 @@ def format_comment(
 
         for doc in suggested_docs:
             doc_key = doc["doc_key"]
-            if doc_key in DOCS_LINKS:
-                url = DOCS_LINKS[doc_key]
-                reason = doc["reason"]
-                comment += f"- [{doc_key}]({url})\n  _{reason}_\n"
+            url = DOCS_LINKS[doc_key]
+            reason = doc.get("reason", "")
+            comment += f"- [{doc_key}]({url})\n"
+            if reason:
+                comment += f"  _{reason}_\n"
         comment += "\n"
 
-    # Similar issues
-    if similar_items:
+    # Similar issues (real search-API results)
+    if triage.similar_items:
         if is_german:
             comment += "### Ähnliche Issues und Diskussionen\n\n"
             comment += "Die folgenden Issues oder Diskussionen könnten relevant sein:\n\n"
@@ -1514,7 +839,7 @@ def format_comment(
             comment += "### Similar Issues and Discussions\n\n"
             comment += "The following issues or discussions might be relevant:\n\n"
 
-        for item in similar_items:
+        for item in triage.similar_items:
             state_emoji = "✅" if item["state"] == "closed" else "🔄"
             comment += f"- {state_emoji} #{item['number']}: [{item['title']}]({item['url']})\n"
         comment += "\n"
@@ -1533,6 +858,10 @@ def format_comment(
 
     return comment
 
+
+# =============================================================================
+# Label maintenance
+# =============================================================================
 
 # Triage label applied when an issue lacks the raw data required for analysis.
 NEEDS_RAW_DATA_LABEL: Final = "needs-raw-data"
@@ -1594,8 +923,13 @@ def remove_needs_raw_data_label(issue: Any) -> None:
         print(f"Warning: could not remove label '{NEEDS_RAW_DATA_LABEL}': {e}")
 
 
+# =============================================================================
+# Main
+# =============================================================================
+
+
 def main() -> None:
-    """Analyze issue and post comment."""
+    """Triage the issue and post a comment."""
     # Get environment variables
     github_token = os.getenv("GITHUB_TOKEN") or ""
     anthropic_api_key = os.getenv("ANTHROPIC_API_KEY") or ""
@@ -1615,105 +949,106 @@ def main() -> None:
     issue_title = os.getenv("ISSUE_TITLE") or issue.title
     issue_body = os.getenv("ISSUE_BODY") or issue.body or ""
 
-    print(f"Analyzing issue #{issue_number}: {issue_title}")
+    print(f"Triaging issue #{issue_number}: {issue_title}")
 
-    # Fetch latest versions from GitHub Releases
-    current_stable, current_prerelease = fetch_latest_versions(gh)
-    print(f"Current versions - stable: {current_stable}, prerelease: {current_prerelease}")
+    # Deterministic checks
+    fields = parse_form_fields(issue_body)
+    template_language = detect_template_language(issue_body)
+    print(f"Detected template language: {template_language}")
 
-    # Perform deep analysis of attachments BEFORE Claude analysis
-    deep_analysis: AttachmentAnalysis | None = None
-    try:
-        print("Performing deep analysis of attachments...")
-        deep_analysis = perform_deep_analysis(issue_body)
-        print(f"Deep analysis complete: diagnostics={deep_analysis.has_diagnostics}, logs={deep_analysis.has_logs}")
-        if deep_analysis.no_subscriber_addresses:
-            print(f"Found {len(deep_analysis.no_subscriber_addresses)} devices with no subscribers")
-        if deep_analysis.unregistered_devices:
-            print(f"Found {len(deep_analysis.unregistered_devices)} unregistered devices sending events")
-    except Exception as e:
-        print(f"Warning: Deep analysis failed (continuing with basic analysis): {e}")
-        deep_analysis = None
-
-    # Get Claude's analysis with deep analysis results
-    try:
-        analysis = get_claude_analysis(
-            issue_title,
-            issue_body,
-            anthropic_api_key,
-            gh=gh,
-            deep_analysis=deep_analysis,
-        )
-        print(f"Analysis complete: {json.dumps(analysis, indent=2)}")
-    except Exception as e:
-        print(f"Error getting Claude analysis: {e}")
-        sys.exit(1)
-
-    # Detect a pasted AI-generated analysis and flag it for a redirect hint
+    has_diagnostics, has_logs = detect_attachments(issue_body)
+    has_screenshots = detect_screenshots(issue_body)
     ai_detection = detect_ai_generated_analysis(issue_body)
-    analysis["ai_analysis_detection"] = ai_detection
     if ai_detection["detected"]:
-        print(f"Detected likely AI-generated analysis (strong={ai_detection['strong']}, markers={ai_detection['markers']})")
+        print(
+            f"Detected likely AI-generated analysis (strong={ai_detection['strong']}, markers={ai_detection['markers']})"
+        )
+
+    releases = fetch_release_info(gh)
+    print(
+        f"Known releases - stable: {releases.stable}, prerelease: {releases.prerelease}, total: {len(releases.all_versions)}"
+    )
+
+    reported_version = get_form_field(fields, markers=VERSION_FIELD_MARKERS)
+    version_check = check_reported_version(reported_version, releases=releases)
+    print(f"Version check: status={version_check.status}, reported={version_check.reported!r}")
+
+    # Optional Claude triage (summary, doc links, search terms) — never blocks the comment
+    triage_llm = get_claude_triage(
+        title=issue_title,
+        body=issue_body,
+        api_key=anthropic_api_key,
+        template_language=template_language,
+    )
+
+    # Build search terms: device model (deterministic) first, then LLM-provided terms
+    search_terms: list[str] = []
+    if (device_model := extract_device_model(f"{issue_title}\n{issue_body}")) is not None:
+        search_terms.append(device_model)
+    if triage_llm:
+        for term in triage_llm.get("search_terms", []):
+            if isinstance(term, str) and term.casefold() not in {t.casefold() for t in search_terms}:
+                search_terms.append(term)
+
+    similar_items: list[dict[str, Any]] = []
+    if search_terms:
+        similar_items = search_similar_issues(
+            gh,
+            repo_full_name=repo_name,
+            search_terms=search_terms,
+            current_issue_number=issue_number,
+        )
+        print(f"Found {len(similar_items)} similar items")
 
     # Maintain the needs-raw-data triage label: add it when the raw diagnostics/log data
     # is missing or a pasted AI analysis was detected, and remove it once the required
     # data has been provided (e.g. on a later edit).
-    attachment_info = analysis.get("attachment_analysis", {})
-    missing_required_info = not attachment_info.get("has_diagnostics") or not attachment_info.get("has_logs")
+    missing_required_info = not has_diagnostics or not has_logs
     if missing_required_info or ai_detection["detected"]:
         apply_needs_raw_data_label(issue, repo)
     else:
         remove_needs_raw_data_label(issue)
 
-    # Search for similar issues
-    search_terms = analysis.get("search_terms", [])
-    similar_items = []
-    if search_terms:
-        try:
-            similar_items = search_similar_issues(repo, search_terms, issue_number)
-            print(f"Found {len(similar_items)} similar items")
-        except Exception as e:
-            print(f"Error searching for similar issues: {e}")
-
     # Check if bot has already commented (to avoid duplicates on edit)
     is_manual_trigger = not os.getenv("ISSUE_TITLE")  # Manual trigger doesn't have ISSUE_TITLE in env
-    already_commented = has_bot_comment(issue)
-
-    if already_commented and not is_manual_trigger:
+    if has_bot_comment(issue) and not is_manual_trigger:
         print("Bot has already commented on this issue, skipping to avoid duplicates")
         return
 
-    # Format and post comment
-    comment_body = format_comment(
-        analysis,
-        similar_items,
-        current_stable=current_stable or "unknown",
-        current_prerelease=current_prerelease or "none",
+    triage = TriageResult(
+        language=template_language,
+        summary=triage_llm.get("summary") if triage_llm else None,
+        version_check=version_check,
+        has_diagnostics=has_diagnostics,
+        has_logs=has_logs,
+        ai_detection=ai_detection,
+        is_feature_request=bool(triage_llm and triage_llm.get("is_feature_request")),
+        is_device_related=bool(triage_llm and triage_llm.get("is_device_related")),
+        has_screenshots=has_screenshots,
+        suggested_docs=[
+            doc for doc in (triage_llm.get("suggested_docs", []) if triage_llm else []) if isinstance(doc, dict)
+        ],
+        similar_items=similar_items,
     )
 
+    comment_body = format_comment(triage)
+
     # Only post if there's something useful to say
-    version_issue = analysis.get("version_issue", {})
-    has_version_issue = version_issue.get("has_issue") and version_issue.get("severity") in (
-        "critical",
-        "warning",
-    )
-    # attachment_info / missing_required_info were computed earlier for label maintenance.
     has_useful_feedback = (
-        has_version_issue
+        version_check.status in ("outdated", "unknown", "missing")
         or missing_required_info
-        or analysis.get("missing_information")
-        or analysis.get("terminology_issues")
-        or attachment_info.get("findings")
-        or analysis.get("suggested_docs")
-        or similar_items
         or ai_detection["detected"]
+        or triage.is_feature_request
+        or (triage.is_device_related and not has_screenshots)
+        or bool(triage.suggested_docs)
+        or bool(similar_items)
     )
 
     if has_useful_feedback:
         try:
             issue.create_comment(comment_body)
             print("Comment posted successfully")
-        except Exception as e:
+        except GithubException as e:
             print(f"Error posting comment: {e}")
             sys.exit(1)
     else:

--- a/.github/workflows/ISSUE_ANALYZER_README.md
+++ b/.github/workflows/ISSUE_ANALYZER_README.md
@@ -1,28 +1,53 @@
 # Issue Analyzer Workflow
 
-This GitHub Actions workflow automatically analyzes newly created issues and provides helpful feedback.
+This GitHub Actions workflow automatically **triages** newly created issues. It deliberately
+does **not** diagnose root causes: an audit of 181 bot-commented issues (2026-07) showed that
+LLM root-cause analyses were fully correct in only 18% of cases and outright wrong in 24%,
+while the data-collection parts (missing diagnostics/log requests) were the reliably useful
+ones. The bot therefore focuses on deterministic checks; do not re-add diagnosis sections.
 
-## Features
+## What the bot does
 
-The workflow uses Claude AI to:
+1. **Checks required raw data (deterministic)**
+   - Detects attached integration diagnostics (.json) and log files (including inline log
+     excerpts in fenced code blocks)
+   - Requests missing data and maintains the `needs-raw-data` triage label
 
-1. **Identify missing information**
-   - Checks if all required fields from the issue template have been filled out
-   - Requests missing information (version, installation type, backend type, etc.)
+2. **Validates the reported version (deterministic)**
+   - Parses the version from the issue-form field (not from free text)
+   - Compares it against the actually published releases of
+     [homematicip_local](https://github.com/sukramj/homematicip_local/releases)
+   - Posts a *neutral* notice when the version is outdated or matches no published release —
+     never a "critical" banner
 
-2. **Suggest relevant documentation**
-   - References appropriate documentation pages in both repositories:
-     - AioHomematic README and Docs
-     - Homematic(IP) Local README
-   - Considers troubleshooting guides and FAQs
+3. **Detects pasted AI analyses (deterministic)**
+   - Flags reports that contain an AI-generated interpretation instead of raw data and
+     redirects the reporter to attach the underlying files
 
-3. **Find similar issues and discussions**
-   - Searches for similar issues (both open and closed)
-   - Helps avoid duplicates and find existing solutions
+4. **Searches for similar issues (GitHub search API)**
+   - Uses the device model (extracted deterministically) plus LLM-suggested search terms
+   - Queries the real GitHub search API (the previous implementation listed the most
+     recently updated issues regardless of relevance)
 
-4. **Multilingual support**
-   - Automatically detects the language (German/English)
-   - Responds in the detected language
+5. **Uses Claude only for triage, not diagnosis**
+   - A short summary (max. 2 sentences), 0-2 documentation links, search terms, and
+     routing flags (device-related, feature request)
+   - The prompt contains the current date and forbids root-cause claims
+   - If the Claude call fails, the deterministic triage comment is still posted
+
+6. **Multilingual support**
+   - Detects the template language (German/English) and responds in it
+
+## Companion workflow: Close Issue - Insufficient Information
+
+`close-insufficient-info.yml` closes an issue that lacks the required data. It is triggered
+manually (`workflow_dispatch`) and protects against premature closes with guardrails:
+
+- refuses to close when the issue contains attachments, screenshots, or inline log excerpts
+- refuses to close issues labeled as feature requests (`enhancement`/`feature`)
+- enforces a minimum waiting period of **72 hours** after the `needs-raw-data` label was
+  applied (or after issue creation), giving reporters time to supply the data
+- `force: true` input overrides all guardrails
 
 ## Setup
 
@@ -41,88 +66,46 @@ To activate the workflow, you need an Anthropic API key:
    - Name: `ANTHROPIC_API_KEY`
    - Value: Your Anthropic API key
 
-2. **Activate workflow**
+2. **Optional: pin the Claude model**
+   - Repository variable `ANALYZER_MODEL` overrides the default model used for the
+     triage summary (no code change needed when a model is renamed)
+
+3. **Activate workflow**
    - The workflow is automatically active after adding the secret
-   - It will run on every newly created issue
+   - It runs on every newly created or edited issue (a comment is only posted once)
 
 ### Permissions
 
 The workflow requires the following permissions (already configured):
-- `issues: write` - To post comments
+
+- `issues: write` - To post comments and maintain labels
 - `contents: read` - To read the repository
 
-## How it works
+## Comment structure
 
-1. **Trigger**: When a new issue is created
-2. **Analysis**: Claude AI analyzes:
-   - Title and content of the issue
-   - Compliance with template requirements
-   - Relevant topics and keywords
-3. **Search**: Searches for similar issues in the repository
-4. **Comment**: Posts a helpful comment with:
-   - Summary
-   - List of missing information (if any)
-   - Relevant documentation links
-   - Similar issues/discussions
+A posted comment can contain (only sections with content are rendered):
 
-## Example Comment
+- Summary (LLM, descriptive only)
+- Version notice (deterministic: outdated / unknown version)
+- Missing required information (diagnostics / log / version field)
+- Raw-data redirect when a pasted AI analysis was detected
+- Feature-request routing hint (pointing to the discussions)
+- Screenshot hint for device-related issues
+- Helpful documentation (max. 2 links)
+- Similar issues (search-API results)
 
-```markdown
-## Automatic Issue Analysis
-
-**Summary:** Connection problem with CCU3 via HTTPS
-
-### Missing Information
-
-To help you better, the following information is missing:
-
-- **Diagnostics data**: Please upload the diagnostics data for the affected device
-- **Protocol file**: The complete log helps with troubleshooting
-
-### Helpful Documentation
-
-The following documentation pages might be helpful:
-
-- [troubleshooting](https://sukramj.github.io/aiohomematic/user/troubleshooting/homeassistant_troubleshooting/)
-  _Contains solutions for common connection problems_
-
-### Similar Issues and Discussions
-
-The following issues or discussions might be relevant:
-
-- ✅ #1234: [HTTPS connection fails with self-signed certificate](https://github.com/...)
-- 🔄 #1456: [CCU3 connection timeout](https://github.com/...)
-
----
-_This analysis was generated automatically. For questions or problems, please use the discussions._
-```
+If none of the sections has content, no comment is posted.
 
 ## Customization
 
-### Customize documentation links
-
-The available documentation links are defined in `.github/scripts/analyze_issue.py`.
-
-> **Note:** These links point to the deployed documentation site at `sukramj.github.io/aiohomematic/` which is built from the `main` branch.
-
-```python
-DOCS_LINKS = {
-    "main_readme": "https://sukramj.github.io/aiohomematic/",
-    "homematicip_local_readme": "https://github.com/sukramj/homematicip_local#homematicip_local",
-    "troubleshooting": "https://sukramj.github.io/aiohomematic/user/troubleshooting/homeassistant_troubleshooting/",
-    # ... more links
-}
-```
-
-### Customize analysis prompt
-
-The analysis prompt can be customized in the variable `CLAUDE_ANALYSIS_PROMPT` in `analyze_issue.py`.
+- **Documentation links**: `DOCS_LINKS` in `.github/scripts/analyze_issue.py`
+- **Triage prompt**: `CLAUDE_TRIAGE_PROMPT` in `analyze_issue.py` (keep the no-diagnosis rules!)
+- **Version-field markers**: `VERSION_FIELD_MARKERS` (update when the issue-template labels change)
 
 ## Costs
 
-- The workflow uses Claude 3.5 Sonnet
-- Estimated costs: ~$0.01-0.03 per issue analysis
-- Depends on issue length and complexity
+- One Claude call per issue with a small output budget (max. 600 tokens)
+- Estimated costs: well below $0.01-0.03 per issue
 
 ## Troubleshooting
 
@@ -133,20 +116,22 @@ The analysis prompt can be customized in the variable `CLAUDE_ANALYSIS_PROMPT` i
 
 ### Comment is not posted
 
-- Workflow only posts if there is helpful information to provide
+- The workflow only posts when at least one section has content
 - Check the logs for error messages
 
 ### API errors
 
 - Make sure the API key is valid
 - Check your Anthropic account for sufficient credits
+- The deterministic checks still run and post when the Claude call fails
 
 ## Deactivation
 
 To deactivate the workflow:
+
 1. Delete or rename the file `.github/workflows/issue-analyzer.yml`
 2. Or add at the beginning:
    ```yaml
    on:
-     workflow_dispatch:  # Only manually executable
+     workflow_dispatch: # Only manually executable
    ```

--- a/.github/workflows/close-insufficient-info.yml
+++ b/.github/workflows/close-insufficient-info.yml
@@ -8,6 +8,11 @@ on:
         description: 'Issue number to close'
         required: true
         type: number
+      force:
+        description: 'Skip the safety guardrails (min. age, attached data, feature-request label)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   issues: write
@@ -24,6 +29,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const issueNumber = ${{ github.event.inputs.issue_number }};
+            const force = ${{ github.event.inputs.force }} === true || '${{ github.event.inputs.force }}' === 'true';
 
             // Fetch the issue to get its body
             const { data: issue } = await github.rest.issues.get({
@@ -31,6 +37,73 @@ jobs:
               repo: context.repo.repo,
               issue_number: issueNumber
             });
+
+            // ---------------------------------------------------------------
+            // Guardrails: closing for "insufficient information" is refused
+            // when the issue plausibly DOES contain data, is a feature request,
+            // or the reporter has not had enough time to supply the data.
+            // Override with the "force" input.
+            // ---------------------------------------------------------------
+            if (issue.state === 'closed') {
+              core.setFailed(`Issue #${issueNumber} is already closed.`);
+              return;
+            }
+
+            if (!force) {
+              const body = issue.body || '';
+              const labels = issue.labels.map((label) => (typeof label === 'string' ? label : label.name));
+
+              // 1. Never close feature requests as "insufficient information".
+              const featureLabels = labels.filter((name) => /enhancement|feature/i.test(name || ''));
+              if (featureLabels.length > 0) {
+                core.setFailed(
+                  `Refusing to close #${issueNumber}: it carries the label(s) ${featureLabels.join(', ')} ` +
+                  '(feature requests must not be closed as "insufficient information"). Use force=true to override.'
+                );
+                return;
+              }
+
+              // 2. Never close when attachments, screenshots or inline logs are present.
+              const hasAttachment = /user-attachments\/(files|assets)\//.test(body);
+              const fencedBlocks = body.match(/```[^\n]*\n[\s\S]*?```/g) || [];
+              const logLine = /\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}|\b(ERROR|WARNING|DEBUG|INFO|Traceback)\b/;
+              const hasInlineLog = fencedBlocks.some(
+                (block) => block.split('\n').filter((line) => logLine.test(line)).length >= 5
+              );
+              if (hasAttachment || hasInlineLog) {
+                core.setFailed(
+                  `Refusing to close #${issueNumber}: the issue contains ` +
+                  `${hasAttachment ? 'attached files/screenshots' : 'an inline log excerpt'}. ` +
+                  'It may not actually lack information. Use force=true to override.'
+                );
+                return;
+              }
+
+              // 3. Minimum waiting period: 72h since the needs-raw-data label was applied
+              //    (or since issue creation when the label was never applied).
+              const MIN_WAIT_MS = 72 * 60 * 60 * 1000;
+              let referenceTime = new Date(issue.created_at).getTime();
+              const events = await github.paginate(github.rest.issues.listEvents, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100
+              });
+              for (const event of events) {
+                if (event.event === 'labeled' && event.label && event.label.name === 'needs-raw-data') {
+                  referenceTime = Math.max(referenceTime, new Date(event.created_at).getTime());
+                }
+              }
+              const elapsed = Date.now() - referenceTime;
+              if (elapsed < MIN_WAIT_MS) {
+                const earliest = new Date(referenceTime + MIN_WAIT_MS).toISOString();
+                core.setFailed(
+                  `Refusing to close #${issueNumber}: the reporter has had less than 72h to supply the data ` +
+                  `(earliest close: ${earliest}). Use force=true to override.`
+                );
+                return;
+              }
+            }
 
             // Detect language based on German-specific labels in the issue body
             const isGerman = issue.body &&

--- a/.github/workflows/issue-analyzer.yml
+++ b/.github/workflows/issue-analyzer.yml
@@ -30,12 +30,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install anthropic PyGithub requests
+          pip install anthropic PyGithub
 
       - name: Analyze issue and post comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANALYZER_MODEL: ${{ vars.ANALYZER_MODEL }}
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
           ISSUE_TITLE: ${{ github.event.issue.title || '' }}
           ISSUE_BODY: ${{ github.event.issue.body || '' }}

--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.7.7"
+VERSION: Final = "2026.7.8"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,42 @@
+# Version 2026.7.8 (2026-07-18)
+
+## What's Changed
+
+### Changed
+
+- **Issue-Analyzer bot refocused from diagnosis to triage.** An audit of all 181
+  bot-commented issues showed the LLM root-cause analyses were fully correct in
+  only 18% of cases and outright wrong in 24% (16% correct on issues that turned
+  out to be real, code-fixed bugs), while the data-collection parts were the
+  reliably useful ones. `.github/scripts/analyze_issue.py` no longer posts
+  attachment-analysis findings, LLM version judgments, or "critical" banners.
+  What remains is deterministic: template-field parsing (the version is read from
+  the issue-form field instead of a body-wide regex), a version check against the
+  actually published releases (neutral wording, tolerant of shortened versions),
+  attachment/screenshot/inline-log detection, AI-paste detection, and the
+  `needs-raw-data` label maintenance. Claude is only asked for a 2-sentence
+  summary, up to 2 documentation links, duplicate-search terms, and routing flags
+  (device-related, feature request) — with the current date in the prompt and an
+  explicit no-diagnosis rule. The model is overridable via the `ANALYZER_MODEL`
+  repository variable.
+
+### Fixed
+
+- **"Similar issues" section actually searches now.** `search_similar_issues()`
+  listed the 5 most recently updated issues and never applied the search term
+  (2 of 169 audited lists were topically relevant). It now queries the GitHub
+  search API with a deterministically extracted device model plus LLM-suggested
+  terms.
+
+### Added
+
+- **Guardrails for the insufficient-information close workflow.**
+  `close-insufficient-info.yml` now refuses to close an issue when attachments,
+  screenshots or inline log excerpts are present, when the issue carries a
+  feature-request label, or when the reporter has had less than 72 hours since
+  the `needs-raw-data` label was applied (or issue creation). A `force` input
+  overrides the guardrails.
+
 # Version 2026.7.7 (2026-07-16)
 
 ## What's Changed

--- a/tests/github_scripts/test_analyze_issue.py
+++ b/tests/github_scripts/test_analyze_issue.py
@@ -1,4 +1,4 @@
-"""Tests for the GitHub issue-analyzer helper ``detect_ai_generated_analysis``."""
+"""Tests for the GitHub issue-analyzer triage helpers."""
 
 from __future__ import annotations
 
@@ -236,3 +236,366 @@ def test_remove_needs_raw_data_label_noop_when_absent() -> None:
     issue = _FakeIssue()
     analyze_issue.remove_needs_raw_data_label(issue)
     assert issue.removed == []
+
+
+# ---------------------------------------------------------------------------
+# Issue-form parsing
+# ---------------------------------------------------------------------------
+
+_EN_FORM_BODY = """### The problem
+
+The light entity is missing after the update.
+
+### What version of Homematic(IP) Local for OpenCCU has the issue?
+
+2.8.3
+
+### What was the last working version of Homematic(IP) Local for OpenCCU?
+
+_No response_
+
+### What type of installation are you running?
+
+Home Assistant OS
+"""
+
+_DE_FORM_BODY = """### Das Problem
+
+Nach dem Update fehlt die Entität.
+
+### Bei welcher Version von HomematicIP (lokal) tritt das Problem auf?
+
+2.8.1
+
+### Welche war die letzte funktionierende Version von Homematic(IP) Local for OpenCCU?
+
+2.7.3
+"""
+
+
+def test_parse_form_fields_english_template() -> None:
+    """Parse labels and values from an English issue-form body."""
+    fields = analyze_issue.parse_form_fields(_EN_FORM_BODY)
+    assert fields["What version of Homematic(IP) Local for OpenCCU has the issue?"] == "2.8.3"
+    assert fields["What type of installation are you running?"] == "Home Assistant OS"
+
+
+def test_parse_form_fields_normalizes_no_response() -> None:
+    """Normalize the GitHub placeholder for empty fields to an empty string."""
+    fields = analyze_issue.parse_form_fields(_EN_FORM_BODY)
+    assert fields["What was the last working version of Homematic(IP) Local for OpenCCU?"] == ""
+
+
+def test_parse_form_fields_empty_body() -> None:
+    """Return an empty mapping for an empty or template-free body."""
+    assert analyze_issue.parse_form_fields("") == {}
+    assert analyze_issue.parse_form_fields("just some free text") == {}
+
+
+def test_get_form_field_version_english() -> None:
+    """Find the integration-version field in the English template."""
+    fields = analyze_issue.parse_form_fields(_EN_FORM_BODY)
+    value = analyze_issue.get_form_field(fields, markers=analyze_issue.VERSION_FIELD_MARKERS)
+    assert value == "2.8.3"
+
+
+def test_get_form_field_version_german_does_not_match_last_working() -> None:
+    """Find the German version field and never the "last working version" field."""
+    fields = analyze_issue.parse_form_fields(_DE_FORM_BODY)
+    value = analyze_issue.get_form_field(fields, markers=analyze_issue.VERSION_FIELD_MARKERS)
+    assert value == "2.8.1"
+
+
+def test_get_form_field_missing() -> None:
+    """Return None when the field does not exist at all."""
+    assert analyze_issue.get_form_field({}, markers=analyze_issue.VERSION_FIELD_MARKERS) is None
+
+
+# ---------------------------------------------------------------------------
+# Deterministic version check
+# ---------------------------------------------------------------------------
+
+_RELEASES = analyze_issue.ReleaseInfo(
+    stable="2.8.3",
+    prerelease="2.9.0b1",
+    all_versions=frozenset({"2.8.3", "2.8.2", "2.8.1", "2.9.0b1", "2.0.0"}),
+)
+
+
+def test_check_reported_version_ok() -> None:
+    """Accept the current stable version."""
+    check = analyze_issue.check_reported_version("2.8.3", releases=_RELEASES)
+    assert check.status == "ok"
+
+
+def test_check_reported_version_ok_prerelease() -> None:
+    """Accept a newer pre-release without flagging it."""
+    check = analyze_issue.check_reported_version("2.9.0b1", releases=_RELEASES)
+    assert check.status == "ok"
+
+
+def test_check_reported_version_outdated() -> None:
+    """Flag a known but outdated release."""
+    check = analyze_issue.check_reported_version("2.8.1", releases=_RELEASES)
+    assert check.status == "outdated"
+    assert check.stable == "2.8.3"
+
+
+def test_check_reported_version_unknown() -> None:
+    """Flag a version that matches no published release (e.g. HA or CCU version)."""
+    for reported in ("2026.7.2", "3.79.6", "core-2026.7.2"):
+        check = analyze_issue.check_reported_version(reported, releases=_RELEASES)
+        assert check.status == "unknown", reported
+
+
+def test_check_reported_version_prefix_tolerance() -> None:
+    """Accept a shortened version like "2.8" when a matching release exists."""
+    check = analyze_issue.check_reported_version("2.8", releases=_RELEASES)
+    assert check.status == "ok"
+
+
+def test_check_reported_version_strips_v_prefix() -> None:
+    """Normalize a leading "v" before comparing against the release set."""
+    check = analyze_issue.check_reported_version("v2.8.3", releases=_RELEASES)
+    assert check.status == "ok"
+
+
+def test_check_reported_version_missing() -> None:
+    """Report a missing version for empty or absent field values."""
+    assert analyze_issue.check_reported_version(None, releases=_RELEASES).status == "missing"
+    assert analyze_issue.check_reported_version("  ", releases=_RELEASES).status == "missing"
+
+
+def test_check_reported_version_no_data() -> None:
+    """Make no validity statement when the release list could not be fetched."""
+    empty = analyze_issue.ReleaseInfo()
+    check = analyze_issue.check_reported_version("9.9.9", releases=empty)
+    assert check.status == "no_data"
+
+
+# ---------------------------------------------------------------------------
+# Attachment / screenshot detection
+# ---------------------------------------------------------------------------
+
+
+def test_detect_attachments_urls() -> None:
+    """Detect diagnostics and log attachments from uploaded file URLs."""
+    body = (
+        "Diagnostics: https://github.com/user-attachments/files/1/config_entry-diagnostics.json\n"
+        "Log: https://github.com/user-attachments/files/2/home-assistant.log"
+    )
+    has_diagnostics, has_logs = analyze_issue.detect_attachments(body)
+    assert has_diagnostics is True
+    assert has_logs is True
+
+
+def test_detect_attachments_inline_log_counts_as_log() -> None:
+    """Count a fenced code block full of log lines as provided log data."""
+    log_lines = "\n".join(f"2026-07-18 12:00:0{i} ERROR (MainThread) something failed" for i in range(6))
+    body = f"It fails:\n```\n{log_lines}\n```"
+    has_diagnostics, has_logs = analyze_issue.detect_attachments(body)
+    assert has_diagnostics is False
+    assert has_logs is True
+
+
+def test_detect_attachments_short_code_block_is_not_a_log() -> None:
+    """Do not count a short code snippet as log data."""
+    body = "```\nyaml: value\n```"
+    _, has_logs = analyze_issue.detect_attachments(body)
+    assert has_logs is False
+
+
+def test_detect_screenshots() -> None:
+    """Detect screenshots via asset URLs and markdown images."""
+    assert analyze_issue.detect_screenshots("![img](https://github.com/user-attachments/assets/abc)") is True
+    assert analyze_issue.detect_screenshots("see https://example.com/foo.png") is True
+    assert analyze_issue.detect_screenshots("no images here") is False
+
+
+# ---------------------------------------------------------------------------
+# Device-model extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_device_model() -> None:
+    """Extract the first device-model designation from text."""
+    assert analyze_issue.extract_device_model("HmIP-eTRV-2 fehlender window_state") == "HmIP-eTRV-2"
+    assert analyze_issue.extract_device_model("HM-PB-2-WM55 funktioniert nicht") == "HM-PB-2-WM55"
+    assert analyze_issue.extract_device_model("no device mentioned") is None
+
+
+def test_extract_device_model_skips_interface_names() -> None:
+    """Skip interface designations that are useless as duplicate-search terms."""
+    assert analyze_issue.extract_device_model("HmIP-RF disconnects, HmIP-SWDO-2 affected") == "HmIP-SWDO-2"
+
+
+# ---------------------------------------------------------------------------
+# Similar-issue search (search API, not recently-updated listing)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSearchResultIssue:
+    """Minimal stand-in for a PyGithub issue returned by the search API."""
+
+    def __init__(self, number: int, title: str = "title", state: str = "open") -> None:
+        """Store the search-result fields."""
+        self.number = number
+        self.title = title
+        self.html_url = f"https://github.com/x/y/issues/{number}"
+        self.state = state
+
+
+class _FakeGithub:
+    """Minimal stand-in for a PyGithub client capturing search queries."""
+
+    def __init__(self, results: list[_FakeSearchResultIssue]) -> None:
+        """Store the canned search results."""
+        self._results = results
+        self.queries: list[str] = []
+
+    def search_issues(self, query: str) -> list[_FakeSearchResultIssue]:
+        """Record the query and return the canned results."""
+        self.queries.append(query)
+        return self._results
+
+
+def test_search_similar_issues_uses_search_api_with_term() -> None:
+    """Pass the search term to the search API query."""
+    gh = _FakeGithub([_FakeSearchResultIssue(11), _FakeSearchResultIssue(12)])
+    items = analyze_issue.search_similar_issues(
+        gh,  # type: ignore[arg-type]
+        repo_full_name="SukramJ/aiohomematic",
+        search_terms=["HmIP-eTRV-2"],
+        current_issue_number=99,
+    )
+    assert gh.queries == ["repo:SukramJ/aiohomematic is:issue HmIP-eTRV-2"]
+    assert [item["number"] for item in items] == [11, 12]
+
+
+def test_search_similar_issues_excludes_current_and_dedupes() -> None:
+    """Exclude the current issue and deduplicate results across terms."""
+    gh = _FakeGithub([_FakeSearchResultIssue(99), _FakeSearchResultIssue(11), _FakeSearchResultIssue(11)])
+    items = analyze_issue.search_similar_issues(
+        gh,  # type: ignore[arg-type]
+        repo_full_name="SukramJ/aiohomematic",
+        search_terms=["term-a", "term-b"],
+        current_issue_number=99,
+    )
+    assert [item["number"] for item in items] == [11]
+
+
+def test_search_similar_issues_sanitizes_query_syntax() -> None:
+    """Strip search-syntax characters from terms so they cannot break the query."""
+    gh = _FakeGithub([])
+    analyze_issue.search_similar_issues(
+        gh,  # type: ignore[arg-type]
+        repo_full_name="SukramJ/aiohomematic",
+        search_terms=['error: "Parameter not found"'],
+        current_issue_number=1,
+    )
+    assert gh.queries == ["repo:SukramJ/aiohomematic is:issue error   Parameter not found"]
+
+
+# ---------------------------------------------------------------------------
+# Comment formatting (triage only - no diagnosis sections, no critical banners)
+# ---------------------------------------------------------------------------
+
+
+def _make_triage(**overrides: object) -> object:
+    """Build a TriageResult with sensible defaults for formatting tests."""
+    defaults: dict[str, object] = {
+        "language": "de",
+        "summary": "Entität fehlt nach Update.",
+        "version_check": analyze_issue.VersionCheck(status="ok", reported="2.8.3", stable="2.8.3"),
+        "has_diagnostics": True,
+        "has_logs": True,
+        "ai_detection": {"detected": False, "strong": False, "markers": []},
+        "is_feature_request": False,
+        "is_device_related": False,
+        "has_screenshots": False,
+        "suggested_docs": [],
+        "similar_items": [],
+    }
+    defaults.update(overrides)
+    return analyze_issue.TriageResult(**defaults)  # type: ignore[arg-type]
+
+
+def test_format_comment_contains_no_diagnosis_sections() -> None:
+    """Never render diagnosis sections or critical banners."""
+    triage = _make_triage(
+        version_check=analyze_issue.VersionCheck(status="unknown", reported="3.79.6", stable="2.8.3"),
+        has_diagnostics=False,
+        has_logs=False,
+    )
+    comment = analyze_issue.format_comment(triage)
+    assert "KRITISCH" not in comment
+    assert "CRITICAL" not in comment
+    assert "Analyse der angehängten Daten" not in comment
+    assert "Attachment Analysis" not in comment
+
+
+def test_format_comment_version_notice_outdated_is_neutral() -> None:
+    """Render a neutral update hint for a known but outdated version."""
+    triage = _make_triage(
+        version_check=analyze_issue.VersionCheck(status="outdated", reported="2.8.1", stable="2.8.3"),
+    )
+    comment = analyze_issue.format_comment(triage)  # type: ignore[arg-type]
+    assert "Versionshinweis" in comment
+    assert "2.8.1" in comment
+    assert "2.8.3" in comment
+    assert "🚨" not in comment
+
+
+def test_format_comment_version_notice_absent_when_ok_or_no_data() -> None:
+    """Render no version notice when the version is fine or no release data exists."""
+    for status in ("ok", "no_data"):
+        triage = _make_triage(version_check=analyze_issue.VersionCheck(status=status, reported="x", stable="2.8.3"))
+        comment = analyze_issue.format_comment(triage)  # type: ignore[arg-type]
+        assert "Versionshinweis" not in comment
+
+
+def test_format_comment_missing_info_lists_version_field() -> None:
+    """List an empty version field in the missing-information section."""
+    triage = _make_triage(
+        version_check=analyze_issue.VersionCheck(status="missing", stable="2.8.3"),
+        has_diagnostics=False,
+        has_logs=True,
+    )
+    comment = analyze_issue.format_comment(triage)  # type: ignore[arg-type]
+    assert "Fehlende Pflichtinformationen" in comment
+    assert "Integrationsdiagnose" in comment
+    assert "Version der Integration" in comment
+    assert "❌ **Protokolldatei**" not in comment
+
+
+def test_format_comment_feature_request_hint() -> None:
+    """Point feature requests to the discussions."""
+    triage = _make_triage(is_feature_request=True)
+    comment = analyze_issue.format_comment(triage)  # type: ignore[arg-type]
+    assert "Feature-Wunsch" in comment
+    assert "Diskussionen" in comment
+
+
+def test_format_comment_header_is_stable_for_duplicate_detection() -> None:
+    """Keep the header text that has_bot_comment relies on."""
+    de_comment = analyze_issue.format_comment(_make_triage())  # type: ignore[arg-type]
+    en_comment = analyze_issue.format_comment(_make_triage(language="en"))  # type: ignore[arg-type]
+    assert "Automatische Issue-Analyse" in de_comment
+    assert "Automatic Issue Analysis" in en_comment
+
+
+def test_format_comment_limits_suggested_docs_to_two() -> None:
+    """Render at most two documentation links and drop unknown doc keys."""
+    triage = _make_triage(
+        suggested_docs=[
+            {"doc_key": "troubleshooting", "reason": "r1"},
+            {"doc_key": "unignore", "reason": "r2"},
+            {"doc_key": "glossary", "reason": "r3"},
+            {"doc_key": "nonexistent", "reason": "r4"},
+        ],
+    )
+    comment = analyze_issue.format_comment(triage)  # type: ignore[arg-type]
+    assert "troubleshooting" in comment
+    assert "unignore" in comment
+    assert "glossary" not in comment.split("Hilfreiche Dokumentation")[1]
+    assert "nonexistent" not in comment


### PR DESCRIPTION
## Summary

An audit of all 181 bot-commented issues (#2489–#3297, bot live since 2025-11-16) showed that the analyzer's LLM root-cause analyses were fully correct in only **18%** of cases and outright wrong in **24%** — on issues that turned out to be real, code-fixed bugs only 16% correct. The "similar issues" section was topically relevant in **2 of 169** cases, and 52 of 152 missing-info requests were unjustified. The reliably useful parts were the data-collection ones. This PR refocuses the bot from *diagnosis* to *deterministic triage*.

### 1. Diagnosis sections removed from the public comment
- No more attachment-analysis findings, LLM version judgments, or "🚨 KRITISCH" banners
- Removes the regex log-pattern "deep analysis" (`LOG_PATTERNS`) whose matches the prompt declared "VERIFIED data"

### 2. Remaining checks are deterministic (Python, no LLM judgment)
- **Version check**: the version is parsed from the issue-form field (`VERSION_FIELD_MARKERS`) instead of a body-wide regex that grabbed the first version-like string (frequent false "CRITICAL" alerts from HA/CalVer versions, e.g. #2622, #2962, #2984). It is compared against the **actually published releases** of homematicip_local — this kills the "Version 2.0.0 existiert nicht" failure mode (#2662, #2666–#2668, #2673, #2680, #2684, #2690, #2693). Wording is neutral, shortened versions ("2.8") are tolerated, and no statement is made when the release list cannot be fetched
- **Attachment detection**: diagnostics/log URLs plus inline log excerpts in fenced code blocks (reduces pointless "log missing" requests, cf. #3052)
- AI-paste detection, template-language detection and `needs-raw-data` label maintenance are unchanged
- Claude is only asked for a 2-sentence summary, up to 2 doc links, duplicate-search terms and routing flags (device-related / feature request). The prompt contains the **current date** (ends the "2026 = Systemzeitproblem" hallucination, #2661, #2860, #3295) and an explicit no-diagnosis rule. If the call fails, the deterministic comment is still posted. Model overridable via the `ANALYZER_MODEL` repository variable (4 past commits were model-name fixes)

### 3. Similar-issues section actually searches now
`search_similar_issues()` called `repo.get_issues(sort="updated")` and **never applied the search term** — it listed the 5 most recently updated issues. It now queries the GitHub search API with a deterministically extracted device model plus the LLM-suggested terms.

### 4. Guardrails for the insufficient-info close workflow
`close-insufficient-info.yml` refuses to close (cf. #3272 "Böser auto close", #3276 reopened same day) when:
- the issue contains attachments, screenshots or inline log excerpts
- the issue carries an `enhancement`/`feature` label
- less than **72 h** have passed since the `needs-raw-data` label was applied (or issue creation)

A `force: true` input overrides all guardrails.

## Test plan

- `tests/github_scripts/test_analyze_issue.py` extended from 16 to 49 tests: form-field parsing (EN/DE, `_No response_`), version check (ok/outdated/unknown/missing/no_data, prefix and `v` tolerance), attachment/inline-log/screenshot detection, device-model extraction, search-API query construction (term applied, current issue excluded, dedupe, syntax sanitizing), comment formatting (no diagnosis sections, no critical banners, stable header for duplicate detection, doc-link cap)
- Full suite: 3905 passed, 1 skipped
- `prek run --all-files` passes