### PR TITLE
feat: device_semantics module — curated doorbell models from openccu-data (2026.7.9)

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.7.8"
+VERSION: Final = "2026.7.9"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/device_semantics.py
+++ b/aiohomematic/device_semantics.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""
+Loader for curated device-semantics classifications.
+
+Small, hand-maintained device classifications shared across the stack.
+The data is shipped by the
+`openccu-data <https://github.com/sukramj/openccu-data>`_ package
+(``openccu_data/data/device_semantics.json``) and accessed via its
+``device_semantics`` module.
+
+First classification: ``DOORBELL_MODELS`` — devices whose press/ring
+channel is a doorbell rather than a generic button. Consumers map the
+ring press of these devices onto their platform's doorbell semantics
+(e.g. Home Assistant's standard ``ring`` event type).
+
+Public API of this module is defined by __all__.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from openccu_data.device_semantics import doorbell_models
+
+__all__ = ["DOORBELL_MODELS"]
+
+DOORBELL_MODELS: Final[frozenset[str]] = doorbell_models()

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,17 @@
+# Version 2026.7.9 (2026-07-19)
+
+## What's Changed
+
+### Added
+
+- New `aiohomematic.device_semantics` module exposing the curated
+  device-semantics classifications from openccu-data (>= 2026.7.0).
+  First classification: `DOORBELL_MODELS` (`HM-Sen-DB-PCB`,
+  `HmIP-DBB`, `HmIP-DSD-PCB`) — the shared source of truth for
+  consumers that map the ring press onto their platform's doorbell
+  semantics (homematicip_local's ring event type, openccu-loom's MQTT
+  HA discovery).
+
 # Version 2026.7.8 (2026-07-18)
 
 ## What's Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.12.0",
-    "openccu-data>=2026.5.0",
+    "openccu-data>=2026.7.0",
     "pydantic>=2.10.0",
     "python-slugify>=8.0.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.14.1
-openccu-data>=2026.6.1
+openccu-data>=2026.7.0
 pydantic>=2.13.4
 python-slugify>=8.0.4
 # orjson is optional - see pyproject.toml [project.optional-dependencies]


### PR DESCRIPTION
Exposes the curated device-semantics classifications from openccu-data (>= 2026.7.0, see SukramJ/openccu-data#19) as `aiohomematic.device_semantics.DOORBELL_MODELS` — `HM-Sen-DB-PCB`, `HmIP-DBB`, `HmIP-DSD-PCB`.

This is the shared source of truth for consumers mapping the ring press onto their platform's doorbell semantics: homematicip_local's ring-event rule (follow-up to SukramJ/homematicip_local#1213 — adds the classic HM-Sen-DB-PCB) and openccu-loom's MQTT HA discovery (same list, embedded Go-side).

⚠️ **Merge order:** requires the openccu-data **2026.7.0** release on PyPI first (requirement pins bumped to >= 2026.7.0) — CI will fail on dependency resolution until then.