### PR TITLE
fix(model): apply multi-channel name postfix only when channel name is ambiguous

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.7.9"
+VERSION: Final = "2026.7.10"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/interfaces/operations.py
+++ b/aiohomematic/interfaces/operations.py
@@ -145,6 +145,10 @@ class ParamsetDescriptionProviderProtocol(Protocol):
     """
 
     @abstractmethod
+    def get_channel_nos_for_parameter(self, *, channel_address: str, parameter: str) -> frozenset[int | None]:
+        """Get the channel numbers of the device that provide the parameter."""
+
+    @abstractmethod
     def get_channel_paramset_descriptions(
         self, *, interface_id: str, channel_address: str
     ) -> Mapping[ParamsetKey, Mapping[str, ParameterData]]:

--- a/aiohomematic/model/support.py
+++ b/aiohomematic/model/support.py
@@ -341,17 +341,21 @@ def get_data_point_name_data(
     """Get name for data_point."""
     if channel_name := _get_base_name_from_channel_or_device(channel=channel):
         p_name = parameter.title().replace("_", " ")
+        name_has_channel_no = _check_channel_name_with_channel_no(name=channel_name)
         c_postfix = ""
-        if channel.device.paramset_description_provider.is_in_multiple_channels(
-            channel_address=channel.address, parameter=parameter
+        if (
+            channel.no not in (0, None)
+            and channel.device.paramset_description_provider.is_in_multiple_channels(
+                channel_address=channel.address, parameter=parameter
+            )
+            and (
+                name_has_channel_no
+                or _is_channel_name_ambiguous(channel=channel, parameter=parameter, channel_name=channel_name)
+            )
         ):
-            c_postfix = "" if channel.no in (0, None) else f" ch{channel.no}"
+            c_postfix = f" ch{channel.no}"
 
-        c_name = (
-            channel_name.split(ADDRESS_SEPARATOR)[0]
-            if _check_channel_name_with_channel_no(name=channel_name)
-            else channel_name
-        )
+        c_name = channel_name.split(ADDRESS_SEPARATOR)[0] if name_has_channel_no else channel_name
         return DataPointNameData(
             device_name=channel.device.name,
             channel_name=c_name,
@@ -525,6 +529,18 @@ def _get_base_name_from_channel_or_device(*, channel: ChannelProtocol) -> str | 
     if name is None or name == default_channel_name:
         return channel.device.name if channel.no is None else f"{channel.device.name}:{channel.no}"
     return name
+
+
+def _is_channel_name_ambiguous(*, channel: ChannelProtocol, parameter: str, channel_name: str) -> bool:
+    """Check if another channel providing the same parameter resolves to the same channel name."""
+    channel_nos = channel.device.paramset_description_provider.get_channel_nos_for_parameter(
+        channel_address=channel.address, parameter=parameter
+    )
+    return any(
+        other.no in channel_nos and _get_base_name_from_channel_or_device(channel=other) == channel_name
+        for other in channel.device.channels.values()
+        if other.address != channel.address
+    )
 
 
 def _check_channel_name_with_channel_no(*, name: str) -> bool:

--- a/aiohomematic/store/persistent/paramset.py
+++ b/aiohomematic/store/persistent/paramset.py
@@ -158,6 +158,16 @@ class ParamsetDescriptionRegistry(
 
         return channel_addresses
 
+    def get_channel_nos_for_parameter(self, *, channel_address: str, parameter: str) -> frozenset[int | None]:
+        """Get the channel numbers of the device that provide the parameter."""
+        if ADDRESS_SEPARATOR not in channel_address:
+            return frozenset()
+        return frozenset(
+            self._address_parameter_cache.get(
+                (get_split_channel_address(channel_address=channel_address)[0], parameter), ()
+            )
+        )
+
     def get_channel_paramset_descriptions(
         self, *, interface_id: str, channel_address: str
     ) -> Mapping[ParamsetKey, Mapping[str, ParameterData]]:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,23 @@
+# Version 2026.7.10 (2026-07-20)
+
+## What's Changed
+
+### Fixed
+
+- **Multi-channel postfix no longer overrides unique custom channel names**: The
+  `ch<no>` postfix for parameters that exist on multiple channels of a device is
+  now only appended when the channel name alone does not identify the channel —
+  i.e. for device-derived names, names following the `<name>:<no>` scheme, or
+  when several channels providing the same parameter share the same custom name.
+  A channel with a unique custom name (e.g. a status channel named
+  `<sub device> Status`) keeps its clean data point name again.
+
+### Added
+
+- New `get_channel_nos_for_parameter()` on `ParamsetDescriptionProviderProtocol`
+  and `ParamsetDescriptionRegistry` returning the channel numbers of a device
+  that provide a parameter.
+
 # Version 2026.7.9 (2026-07-19)
 
 ## What's Changed

--- a/docs/contributor/coding/naming.md
+++ b/docs/contributor/coding/naming.md
@@ -54,16 +54,17 @@ Note about channel number detection:
 
 ## Data point names (regular)
 
-Function: `get_data_point_name_data(channel, parameter)`
+Function: `get_data_point_name_data(channel, parameter, parameter_translation=None)`
 Steps:
 
 1. Resolve a `channel_name` via `_get_base_name_from_channel_or_device` as described above. If there is none, we cannot construct a human-readable name and fall back to unique IDs elsewhere.
 2. Build a human-friendly parameter name: `parameter.title().replace("_", " ")` (e.g., `LEVEL` → `Level`, `WINDOW_STATE` → `Window State`).
-3. If the channel name includes a numeric channel suffix (`<something>:<int>`):
-   - Use the part before `:` as the channel base (`c_name`).
-   - When the same parameter exists on multiple channels of the device, append a channel marker to the parameter: `" ch<channel_no>"` (omitted for channel 0 or `None`). Determination uses `central.paramset_descriptions.is_in_multiple_channels(...)`.
+3. Determine the channel marker `" ch<channel_no>"` (always omitted for channel 0 or `None`). It is appended to the parameter name when the parameter exists on multiple channels of the device (checked via `paramset_description_provider.is_in_multiple_channels(...)`) and the channel name alone does not identify the channel, i.e. when either:
+   - the channel name includes a numeric channel suffix (`<something>:<int>`) — it is derived from the device name or follows the `<name>:<int>` scheme, or
+   - another channel providing the same parameter resolves to the same channel name (duplicate custom names).
+     A custom channel name that is unique among the channels carrying the parameter never gets a marker.
+4. If the channel name includes a numeric channel suffix, use the part before `:` as the channel base (`c_name`); otherwise use the entire channel name.
    - Example full name: `<device_name> <c_name> <Parameter>[ chX]`.
-4. Otherwise, use the entire channel name plus parameter.
 
 `DataPointNameData` contains:
 
@@ -157,6 +158,12 @@ Below are end-to-end examples showing inputs (model, addresses, CCU names, chann
   - DataPointNameData:
     - name: `Livingroom Blind Controller Level ch1`
     - full_name: `Livingroom Blind Controller Livingroom Blind Controller Level ch1` → effectively shown as `Livingroom Blind Controller Level ch1`
+- Input: channel 5 with unique custom name `Relay Status`, parameter `STATE`, parameter appears on multiple channels
+  - The custom name already identifies the channel → no ch marker
+  - DataPointNameData.name: `Relay Status State`
+- Input: channels 5 and 9 both custom-named `Status`, parameter `STATE` on both
+  - Duplicate custom names are ambiguous → ch marker is appended
+  - DataPointNameData.name: `Status State ch5` / `Status State ch9`
 
 4. Event names
 

--- a/tests/test_store_persistent.py
+++ b/tests/test_store_persistent.py
@@ -641,6 +641,29 @@ class TestParamsetDescriptionRegistry:
         )
 
     @pytest.mark.asyncio
+    async def test_get_channel_nos_for_parameter(self, tmp_path) -> None:
+        """Test the channel number lookup for a parameter."""
+        central = _CentralStub("C", str(tmp_path))
+        pdr = ParamsetDescriptionRegistry(
+            storage=central.create_paramset_storage(),
+            config_provider=central,
+        )
+
+        iface = "if1"
+        for ch_no in (1, 2):
+            pdr.add(
+                interface_id=iface,
+                channel_address=f"D1:{ch_no}",
+                paramset_key=ParamsetKey.VALUES,
+                paramset_description={"LEVEL": {"TYPE": "FLOAT"}},
+                device_type="TEST",
+            )
+
+        assert pdr.get_channel_nos_for_parameter(channel_address="D1:1", parameter="LEVEL") == frozenset({1, 2})
+        assert pdr.get_channel_nos_for_parameter(channel_address="D1:1", parameter="UNKNOWN") == frozenset()
+        assert pdr.get_channel_nos_for_parameter(channel_address="INVALID", parameter="LEVEL") == frozenset()
+
+    @pytest.mark.asyncio
     async def test_get_channel_paramset_descriptions(self, tmp_path) -> None:
         """Test getting all paramsets for a channel."""
         central = _CentralStub("C", str(tmp_path))

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -327,6 +327,55 @@ class TestNamingHelpers:
             (TEST_DEVICES, True, None, None),
         ],
     )
+    async def test_get_data_point_name_multi_channel_postfix(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """Test the ch<no> postfix for parameters that exist on multiple channels."""
+        central, _, _ = central_client_factory_with_homegear_client
+        device = central.device_coordinator.get_device(address="VCU2128127")
+        assert device
+        # STATE exists on channels 3, 4, 5 and 6 of the HmIP-BSM.
+        details = central.cache_coordinator.device_details
+
+        # Derived channel names keep the postfix.
+        channel4 = central.device_coordinator.get_channel(channel_address=f"{device.address}:4")
+        name_data = get_data_point_name_data(channel=channel4, parameter="STATE")
+        assert name_data.name == "State ch4"
+
+        # A unique custom channel name already identifies the channel: no postfix.
+        details.add_name(address=f"{device.address}:3", name="Relay Status")
+        channel3 = central.device_coordinator.get_channel(channel_address=f"{device.address}:3")
+        name_data = get_data_point_name_data(channel=channel3, parameter="STATE")
+        assert name_data.name == "Relay Status State"
+
+        # A custom name following the <name>:<no> scheme keeps the postfix.
+        details.add_name(address=f"{device.address}:5", name="Relay:1")
+        channel5 = central.device_coordinator.get_channel(channel_address=f"{device.address}:5")
+        name_data = get_data_point_name_data(channel=channel5, parameter="STATE")
+        assert name_data.name == "Relay State ch5"
+
+        # Identical custom names on channels sharing the parameter keep the postfix.
+        details.add_name(address=f"{device.address}:4", name="Relay Twin")
+        details.add_name(address=f"{device.address}:6", name="Relay Twin")
+        channel6 = central.device_coordinator.get_channel(channel_address=f"{device.address}:6")
+        name_data = get_data_point_name_data(channel=channel4, parameter="STATE")
+        assert name_data.name == "Relay Twin State ch4"
+        name_data = get_data_point_name_data(channel=channel6, parameter="STATE")
+        assert name_data.name == "Relay Twin State ch6"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
     async def test_get_device_name(
         self,
         central_client_factory_with_homegear_client,


### PR DESCRIPTION
## What

The `ch<no>` postfix for parameters that exist on multiple channels of a device is now only appended when the channel name alone does not identify the channel:

- device-derived channel names,
- names following the `<name>:<no>` scheme, or
- custom names shared by several channels providing the same parameter.

A channel with a unique custom name (e.g. a status channel named `<sub device> Status`) keeps its clean data point name again.

## Why

Since 2026.4.2 (#3101) the postfix was applied unconditionally whenever a parameter existed on multiple channels. That fixed missing disambiguation for identically named channels, but also added a redundant `ch<no>` suffix to channels whose custom name already uniquely identifies them.

## How

- `get_data_point_name_data()` now checks `_is_channel_name_ambiguous()` before applying the postfix: another channel of the device must provide the same parameter **and** resolve to the same channel name.
- New `get_channel_nos_for_parameter()` on `ParamsetDescriptionProviderProtocol` / `ParamsetDescriptionRegistry` returns the channel numbers of a device that provide a parameter.
- Naming documentation (`docs/contributor/coding/naming.md`) updated to match, including two new worked examples.
- Version bump to 2026.7.10 with changelog entry.

## Tests

- Test-first reproducer in `tests/test_support.py` using HmIP-BSM (`STATE` on channels 3–6): unique custom name → no postfix; derived name, `<name>:<no>` scheme and duplicate custom names → postfix kept.
- Unit test for `get_channel_nos_for_parameter()` in `tests/test_store_persistent.py`.
- Full suite: 3908 passed, prek hooks green.