### PR TITLE
fix(client): give operational XML-RPC proxy a socket timeout

### DIFF
--- a/aiohomematic/client/client_factory.py
+++ b/aiohomematic/client/client_factory.py
@@ -133,6 +133,7 @@ class ClientConfig:
             session_recorder=self.client_deps.cache_coordinator.recorder,
             event_bus=self.client_deps.event_bus,
             incident_recorder=self.client_deps.cache_coordinator.incident_store,
+            timeout=config.timeout_config.rpc_timeout,
         )
         await xml_proxy.do_init()
         return xml_proxy

--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.7.10"
+VERSION: Final = "2026.7.11"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,23 @@
+# Version 2026.7.11 (2026-07-24)
+
+## What's Changed
+
+### Fixed
+
+- **XML-RPC commands no longer hang forever when a connection goes half-open**:
+  The operational XML-RPC proxy is now created with a socket timeout
+  (`timeout_config.rpc_timeout`, 60 s by default), matching backend detection.
+  Previously the proxy was created without a timeout, so a silently dropped or
+  half-open (TLS) keep-alive connection made a `setValue`/`putParamset` request
+  block indefinitely in the proxy's single worker thread. Because each interface
+  has exactly one worker, that wedged the interface's entire outgoing command
+  path — commands were neither sent nor failed, the only visible symptom being
+  the 30 s optimistic rollback — until Home Assistant was restarted. Incoming
+  events kept flowing the whole time, since they arrive over the separate
+  callback path. With the timeout in place, a stuck request now aborts as a
+  retryable `NoConnectionException`, freeing the worker thread and letting the
+  command retry handler react.
+
 # Version 2026.7.10 (2026-07-20)
 
 ## What's Changed

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -410,6 +410,39 @@ class TestClientConfigBasic:
         assert cfg.has_push_updates is True
 
 
+class TestRpcProxyTimeoutWiring:
+    """
+    Regression guard: the operational XML-RPC proxy must carry a socket timeout.
+
+    Without a socket timeout a half-open (TLS) connection makes an XML-RPC request
+    block forever inside the single proxy worker thread, wedging all outgoing
+    commands on the interface until Home Assistant is restarted. The factory must
+    therefore wire ``timeout_config.rpc_timeout`` onto the proxy transport.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_rpc_proxy_sets_socket_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """create_rpc_proxy must set the transport socket timeout to rpc_timeout."""
+        from aiohomematic.client.rpc_proxy import AioXmlRpcProxy
+
+        async def _noop_do_init(self) -> None:  # type: ignore[no-untyped-def]  # avoid real network in do_init
+            return None
+
+        monkeypatch.setattr(AioXmlRpcProxy, "do_init", _noop_do_init, raising=True)
+
+        central = _FakeCentral()
+        iface_cfg = InterfaceConfig(central_name="c", interface=Interface.BIDCOS_RF, port=32001)
+        cfg = ClientConfig(client_deps=central, interface_config=iface_cfg)
+
+        proxy = await cfg.create_rpc_proxy(interface=Interface.BIDCOS_RF, auth_enabled=False)
+        try:
+            transport = proxy._ServerProxy__transport  # type: ignore[attr-defined]  # concrete AioXmlRpcProxy
+            assert transport is not None
+            assert transport._timeout == central.config.timeout_config.rpc_timeout
+        finally:
+            await proxy.stop()
+
+
 class TestInterfaceClient:
     """Test InterfaceClient basic functionality."""
 

--- a/tests/test_client_xml_rpc_proxy.py
+++ b/tests/test_client_xml_rpc_proxy.py
@@ -323,6 +323,41 @@ class TestErrorHandling:
         await proxy.stop()
 
     @pytest.mark.asyncio
+    async def test_socket_timeout_raises_no_connection_and_records_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        A socket timeout on a blocking read must surface as NoConnectionException, not hang.
+
+        The configured socket timeout makes ``__request`` raise ``TimeoutError`` (a subclass of
+        ``OSError``) instead of blocking forever. ``_async_request`` must translate that into a
+        retryable ``NoConnectionException`` and record a circuit breaker failure, so the retry
+        handler reacts and the single proxy worker thread is freed instead of wedging the interface.
+        """
+
+        def raise_timeout(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            raise TimeoutError("timed out")
+
+        monkeypatch.setattr(xmlrpc.client.ServerProxy, "_ServerProxy__request", raise_timeout, raising=True)
+
+        conn_state = hmcu.CentralConnectionState()
+        proxy = AioXmlRpcProxy(
+            max_workers=1,
+            interface_id="test-if",
+            connection_state=conn_state,
+            uri="http://example/xmlrpc",
+            headers=[],
+            tls=False,
+        )
+
+        with pytest.raises(NoConnectionException):
+            await proxy._async_request("setValue", ("addr", "param", 1))
+
+        assert proxy.circuit_breaker._failure_count > 0
+
+        await proxy.stop()
+
+    @pytest.mark.asyncio
     async def test_typeerror_translates_to_client_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that TypeError from xmlrpc layer is mapped to ClientException."""
 


### PR DESCRIPTION
## Problem

The operational XML-RPC proxy was created **without a socket timeout**. When a keep-alive connection to the CCU went silently half-open (e.g. a dropped/reset TLS connection the client never noticed), a `setValue`/`putParamset` request would block **indefinitely** inside the proxy's request thread.

Because each interface's command proxy has exactly **one** worker thread (`DEFAULT_MAX_WORKERS = 1`), a single hung request wedged the interface's entire outgoing command path:

- Commands were **neither sent nor failed** — no exception, no retry.
- The only visible symptom was the 30 s optimistic rollback in the model layer.
- Incoming events kept flowing the whole time (separate callback path), so the connection looked healthy and no reconnect fired.
- Only a full Home Assistant restart recovered.

Debug-log evidence: a `COMMAND_RETRY: Superseding active retry` fired ~113 min after the original `__ASYNC_REQUEST`, proving `execute_with_retry`'s `finally` never ran — i.e. the operation never returned or raised. No `COMMAND_RETRY: Attempt` was logged, ruling out the recovery-wait path.

## Fix

Wire `timeout_config.rpc_timeout` (60 s default) onto the proxy transport in `ClientConfig._create_xml_rpc_proxy`, matching what backend detection already does. A stuck request now aborts as a retryable `NoConnectionException`, freeing the worker thread and letting the command retry handler react.

```python
 xml_proxy = AioXmlRpcProxy(
     ...
     incident_recorder=self.client_deps.cache_coordinator.incident_store,
+    timeout=config.timeout_config.rpc_timeout,
 )
```

`max_workers` is intentionally left unchanged — separate concern.

## Tests

- **Regression (reproducer):** `TestRpcProxyTimeoutWiring::test_create_rpc_proxy_sets_socket_timeout` asserts the transport carries `rpc_timeout`. Fails before the fix (`Transport` has no `_timeout`), passes after.
- **Behavior:** `test_socket_timeout_raises_no_connection_and_records_failure` asserts a socket `TimeoutError` is translated to `NoConnectionException` and records a circuit-breaker failure.

Affected suites + CUxD/CCU-Jack and capability contract tests green; `prek` (ruff, mypy, pylint, …) clean.

Fix #3316 