### PR TITLE
chore(release): 2026.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         files: ^(docs/.+\.md|aiohomematic/central/events/.+\.py)$
         pass_filenames: false
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.16.0
+    rev: v0.16.1
     hooks:
       - id: ruff
         args:

--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.7.11"
+VERSION: Final = "2026.8.0"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,28 @@
+# Version 2026.8.0 (2026-08-01)
+
+## What's Changed
+
+### Added
+
+- `AI_POLICY.md` documenting the project's policy on AI-assisted contributions,
+  linked from `docs/contributor/contributing.md`.
+
+### Changed
+
+- **Minimum `openccu-data` raised to 2026.7.2**, picking up the current CCU
+  translation and easymode artifacts. The package is pulled in transitively, so
+  upgrading aiohomematic is sufficient.
+- **`_GenericProperty.__init__` now takes `cached` and `log_context` as
+  keyword-only arguments**, in line with the project-wide keyword-only
+  convention. All in-tree call sites already pass them by keyword; only code
+  that constructs `_GenericProperty` with more than four positional arguments is
+  affected.
+- Unhandled task exceptions are logged via `_LOGGER.error(..., exc_info=exc)`
+  instead of `_LOGGER.exception()`. `_log_task_exception` runs from a task
+  done-callback, i.e. outside an active exception handler, where `exception()`
+  has no ambient `sys.exc_info()` to draw on. Log level and traceback output are
+  unchanged.
+
 # Version 2026.7.11 (2026-07-24)
 
 ## What's Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.12.0",
-    "openccu-data>=2026.7.1",
+    "openccu-data>=2026.7.2",
     "pydantic>=2.10.0",
     "python-slugify>=8.0.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.14.3
-openccu-data>=2026.7.1
+openccu-data>=2026.7.2
 pydantic>=2.13.4
 python-slugify>=8.0.4
 # orjson is optional - see pyproject.toml [project.optional-dependencies]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,7 +5,7 @@
 coverage==7.15.2
 freezegun==1.5.5
 mypy==2.3.0
-pip==26.1.2
+pip==26.2
 prek==0.4.11
 pur==7.4.0
 pydevccu==0.2.5
@@ -23,4 +23,4 @@ pytest-timeout==2.4.0
 pytest-xdist==3.8.0
 pytest==9.1.1
 types-python-slugify==8.0.2.20240310
-uv==0.11.33
+uv==0.12.1

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 bandit==1.9.4
 codespell==2.4.3
 python-typing-update==v0.8.1
-ruff==0.16.0
+ruff==0.16.1
 yamllint==1.38.0


### PR DESCRIPTION
## Summary

Cuts the `2026.8.0` release and updates dependencies. No functional library changes beyond the two internal cleanups noted below.

## Changes

**Dependencies**

- `openccu-data` minimum raised to `>=2026.7.2` (runtime)
- `ruff` 0.16.1 (also in `.pre-commit-config.yaml`), `pip` 26.2, `uv` 0.12.1 (development)

**Release**

- New `changelog.md` entry for 2026.8.0
- `aiohomematic/const.py:VERSION` bumped to `2026.8.0` (in sync with the changelog)

## Changelog entry content

Besides the `openccu-data` floor, the entry documents two changes that landed since `2026.7.11` and were not yet in the changelog:

- `_GenericProperty.__init__` now takes `cached` / `log_context` as keyword-only arguments (the symbol is exported via `__all__`; all in-tree call sites already used keywords)
- `_log_task_exception` logs via `_LOGGER.error(..., exc_info=exc)` instead of `_LOGGER.exception()` — it runs from a task done-callback, outside an active exception handler. Level and traceback output unchanged.
- `AI_POLICY.md` is listed under Added.

Pure development-dependency bumps are not listed in the changelog, matching previous entries.

## Verification

- `prek` hooks pass on the commit (ruff, ruff format, mypy, pylint, bandit, codespell, kwonly-lint, i18n checks, …)
- Version sync verified: `head -1 changelog.md` and `grep "^VERSION" aiohomematic/const.py` both report `2026.8.0`
- `git tag --list` confirms no existing `2026.8.*` tag; month numbering starts at `.0` per `2026.4.0` / `2026.5.0` / `2026.6.0`
- Full test suite not run locally — relying on CI