### PR TITLE
docs: add HA events reference (EN + DE)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,28 @@
+# Version 2026.8.1 (2026-08-02)
+
+## What's Changed
+
+### Documentation
+
+- **Events reference for the Home Assistant integration**
+  (`docs/user/features/homeassistant_events.md`, EN + DE): Documents all seven
+  events the integration fires on the HA event bus — `homematic.keypress`,
+  `homematic.impulse`, `homematic.device_error`,
+  `homematic.device_availability`, `homematicip_local.optimistic_rollback`,
+  `homematicip_local.central_state_changed` and
+  `homematicip_local.interface_connection_changed` — with their triggering
+  parameters and complete payloads. The user guide's `Events` section previously
+  described three of them in one sentence each and named neither the triggering
+  parameters nor any payload field, so which parameter surfaces as which event
+  was not answerable from the docs (aiohomematic#3333). It now carries an
+  overview table and links to the new page.
+- **Service messages are explicitly documented as non-events**: CCU service
+  messages (`CONFIG_PENDING`, `UPDATE_PENDING`, `STICKY_UNREACH`) never produce
+  a `device_error` event, and their parameters are hidden, so they yield no
+  entity either. The new page points to the `hub_service_messages` sensor as the
+  supported way to consume them, including an example automation. This was the
+  concrete misunderstanding behind aiohomematic#3333.
+
 # Version 2026.8.0 (2026-08-01)
 
 ## What's Changed

--- a/docs/user/features/homeassistant_events.de.md
+++ b/docs/user/features/homeassistant_events.de.md
@@ -1,0 +1,243 @@
+---
+translation_source: docs/user/features/homeassistant_events.md
+translation_date: 2026-08-02
+translation_source_hash: d144149088e1
+---
+
+# Ereignis-Referenz
+
+Diese Seite dokumentiert alle Ereignisse, die die Integration Homematic(IP) Local für OpenCCU
+auf dem Home Assistant-Event-Bus auslöst, einschließlich der jeweiligen Nutzdaten.
+
+Über **Entwicklerwerkzeuge → Ereignisse** in Home Assistant lassen sich alle Ereignistypen live
+mitlesen.
+
+!!! info "Auf der Suche nach dem Bibliotheks-Event-Bus?"
+Diese Seite beschreibt die Ereignisse, auf die eine Automation triggern kann. Der interne
+aiohomematic-EventBus für Entwickler ist unter [Event Reference](../../architecture/events/event_reference.md)
+dokumentiert.
+
+---
+
+## Überblick
+
+| Ereignistyp                                      | Wird ausgelöst, wenn                                  |
+| ------------------------------------------------ | ----------------------------------------------------- |
+| `homematic.keypress`                             | eine Taste an einem Gerät gedrückt wird               |
+| `homematic.impulse`                              | ein Gerät einen Impuls meldet                         |
+| `homematic.device_error`                         | sich ein `ERROR*`- / `SENSOR_ERROR*`-Parameter ändert |
+| `homematic.device_availability`                  | ein Gerät erreichbar oder unerreichbar wird           |
+| `homematicip_local.optimistic_rollback`          | ein optimistisch gesetzter Wert zurückgenommen wurde  |
+| `homematicip_local.central_state_changed`        | die Zentrale ihren Zustand ändert                     |
+| `homematicip_local.interface_connection_changed` | sich eine Schnittstelle verbindet oder trennt         |
+
+Geräteparameter außerhalb dieser Liste lösen niemals ein Ereignis aus. Insbesondere sind
+CCU-Servicemeldungen wie `CONFIG_PENDING`, `UPDATE_PENDING`, `STICKY_UNREACH`, `LOW_BAT` und
+`SABOTAGE` **keine** Ereignisse — siehe [Servicemeldungen sind keine Ereignisse](#servicemeldungen-sind-keine-ereignisse).
+
+---
+
+## homematic.keypress
+
+Wird ausgelöst, wenn ein Gerät einen Tastendruck meldet. Dieses Ereignis liegt den
+Fernbedienungs-Blueprints und den Geräte-Triggern in der Automations-Oberfläche zugrunde.
+
+**Auslösende Parameter:** `PRESS`, `PRESS_CONT`, `PRESS_LOCK`, `PRESS_LONG`,
+`PRESS_LONG_RELEASE`, `PRESS_LONG_START`, `PRESS_SHORT`, `PRESS_UNLOCK`
+
+| Feld           | Typ   | Beschreibung                                                  |
+| -------------- | ----- | ------------------------------------------------------------- |
+| `device_id`    | `str` | ID im Geräteregister von Home Assistant                       |
+| `name`         | `str` | Gerätename (ein selbst vergebener Name hat Vorrang)           |
+| `address`      | `str` | Geräteadresse, z. B. `0001D8A9B12C34`                         |
+| `model`        | `str` | Gerätemodell, z. B. `HmIP-WRC2`                               |
+| `interface_id` | `str` | Schnittstelle, z. B. `openccu-HmIP-RF`                        |
+| `type`         | `str` | auslösender Parameter in Kleinschreibung, z. B. `press_short` |
+| `subtype`      | `int` | Kanalnummer, von der der Tastendruck stammt                   |
+
+!!! note
+Der Parametername wird als `type` geliefert, der Kanal als `subtype`. Dieses Ereignis hat keine
+separaten Felder `parameter`, `channel_no` oder `value`.
+
+---
+
+## homematic.impulse
+
+Wird ausgelöst, wenn ein Gerät einen Impuls meldet. Einziger auslösender Parameter ist
+`SEQUENCE_OK`.
+
+Die Nutzdaten entsprechen [homematic.keypress](#homematickeypress), wobei `type` den Wert
+`sequence_ok` hat.
+
+---
+
+## homematic.device_error
+
+Wird ausgelöst, wenn ein Gerät einen Fehlerzustand meldet.
+
+**Auslösende Parameter:** alle Parameter, deren Name mit `ERROR` oder `SENSOR_ERROR`
+**beginnt** — zum Beispiel `ERROR_OVERHEAT`, `ERROR_OVERLOAD`, `ERROR_JAMMED`,
+`ERROR_NON_FLAT_POSITIONING`, `ERROR_SABOTAGE` oder `SENSOR_ERROR`.
+
+`ERROR_CODE` ist bewusst ausgenommen: Es handelt sich um einen rohen Zahlencode, dessen
+Bedeutung je Gerät unterschiedlich ist und der in einer Benachrichtigung keinen verwertbaren
+Inhalt hat.
+
+Das Ereignis wird bei jeder Änderung des Fehlerzustands ausgelöst, also sowohl beim Auftreten
+als auch beim Verschwinden eines Fehlers. Bei booleschen Parametern wird zusätzlich beim
+Übergang von unbekannt auf `true` ausgelöst, bei numerischen Parametern beim Übergang von
+unbekannt auf einen Wert größer null.
+
+| Feld           | Typ           | Beschreibung                                                         |
+| -------------- | ------------- | -------------------------------------------------------------------- |
+| `device_id`    | `str`         | ID im Geräteregister von Home Assistant                              |
+| `name`         | `str`         | Gerätename (ein selbst vergebener Name hat Vorrang)                  |
+| `address`      | `str`         | Geräteadresse                                                        |
+| `channel_no`   | `int`         | Kanalnummer, die den Fehler meldet                                   |
+| `model`        | `str`         | Gerätemodell                                                         |
+| `interface_id` | `str`         | Schnittstelle                                                        |
+| `parameter`    | `str`         | Name des Fehlerparameters, z. B. `ERROR_OVERHEAT`                    |
+| `value`        | `bool \| int` | Rohwert des Parameters                                               |
+| `error_value`  | `bool \| int` | identisch mit `value`                                                |
+| `error`        | `bool`        | `true`, solange der Fehler aktiv ist, `false` beim Abklingen         |
+| `identifier`   | `str`         | stabile ID `<adresse>_<parameter>`, als Benachrichtigungs-ID nutzbar |
+| `title`        | `str`         | fertiger Benachrichtigungstitel                                      |
+| `message`      | `str`         | fertiger Benachrichtigungstext                                       |
+
+Über `error` wird entschieden, ob eine Benachrichtigung erzeugt oder geschlossen wird, über
+`identifier` wird in beiden Fällen dieselbe Benachrichtigung adressiert. Genau so arbeitet der
+Blueprint `Show device error`.
+
+---
+
+## homematic.device_availability
+
+Wird ausgelöst, wenn ein Gerät zwischen erreichbar und unerreichbar wechselt.
+
+Die Erreichbarkeit wird aus dem Parameter `UN_REACH` auf Kanal `0` abgeleitet. Nur wenn ein
+Gerät überhaupt keinen `UN_REACH`-Parameter besitzt, dient `STICKY_UNREACH` als Rückfallebene.
+Da HmIP- und BidCos-Geräte beide Parameter bereitstellen, entscheidet praktisch immer
+`UN_REACH`; `STICKY_UNREACH` beeinflusst die Verfügbarkeit nicht. Die Action
+`force_device_availability` überschreibt das Ergebnis und löst dieses Ereignis ebenfalls aus.
+
+| Feld           | Typ    | Beschreibung                                            |
+| -------------- | ------ | ------------------------------------------------------- |
+| `device_id`    | `str`  | ID im Geräteregister von Home Assistant                 |
+| `name`         | `str`  | Gerätename (ein selbst vergebener Name hat Vorrang)     |
+| `address`      | `str`  | Geräteadresse                                           |
+| `channel_no`   | `int`  | immer `0` — Verfügbarkeit gilt je Gerät, nicht je Kanal |
+| `model`        | `str`  | Gerätemodell                                            |
+| `interface_id` | `str`  | Schnittstelle                                           |
+| `parameter`    | `str`  | immer die Zeichenkette `AVAILABILITY`                   |
+| `unavailable`  | `bool` | `true`, wenn das Gerät unerreichbar wurde               |
+| `identifier`   | `str`  | stabile ID `<adresse>_availability`                     |
+| `title`        | `str`  | fertiger Benachrichtigungstitel                         |
+| `message`      | `str`  | fertiger Benachrichtigungstext                          |
+
+!!! note
+`parameter` ist ein von der Integration gesetzter fester Platzhalter, kein CCU-Parameter —
+Geräte haben keinen Parameter `AVAILABILITY`.
+
+---
+
+## homematicip_local.optimistic_rollback
+
+Wird ausgelöst, wenn ein in Home Assistant optimistisch übernommener Wert zurückgenommen werden
+musste, weil die CCU ihn nicht bestätigt hat. Setzt voraus, dass **Systembenachrichtigungen** in
+den erweiterten Optionen der Integration aktiviert sind. Hintergründe unter
+[Optimistische Aktualisierungen](optimistic_updates.md).
+
+| Feld                | Typ     | Beschreibung                                                        |
+| ------------------- | ------- | ------------------------------------------------------------------- |
+| `device_id`         | `str`   | ID im Geräteregister von Home Assistant (entfällt, wenn unbekannt)  |
+| `name`              | `str`   | Gerätename (entfällt, wenn unbekannt)                               |
+| `address`           | `str`   | Geräteadresse                                                       |
+| `interface_id`      | `str`   | Schnittstelle                                                       |
+| `parameter`         | `str`   | betroffener Parameter                                               |
+| `reason`            | `str`   | `timeout`, `send_error` oder `mismatch`                             |
+| `rolled_back_value` | `Any`   | der fehlgeschlagene optimistische Wert                              |
+| `restored_value`    | `Any`   | der zuvor bestätigte, wiederhergestellte Wert                       |
+| `age_seconds`       | `float` | wie lange der optimistische Wert gehalten wurde                     |
+| `error`             | `str`   | Fehlermeldung, nur vorhanden, wenn `reason` gleich `send_error` ist |
+
+Die drei Gründe bedeuten: Die CCU hat nicht innerhalb des Zeitlimits für optimistische
+Aktualisierungen geantwortet (`timeout`), beim Senden ist eine Ausnahme aufgetreten
+(`send_error`), oder die CCU hat einen anderen als den gesendeten Wert bestätigt (`mismatch`).
+
+---
+
+## homematicip_local.central_state_changed
+
+Wird ausgelöst, wenn die Zentrale ihren Gesamtzustand ändert.
+
+| Feld            | Typ   | Beschreibung                                      |
+| --------------- | ----- | ------------------------------------------------- |
+| `instance_name` | `str` | Name der Zentralen-Instanz                        |
+| `new_state`     | `str` | `degraded`, `failed`, `recovering` oder `running` |
+
+`degraded` bedeutet, dass mindestens eine Schnittstelle nicht verbunden ist, `failed`, dass ein
+manueller Eingriff nötig ist, `recovering`, dass ein Verbindungsaufbau läuft, und `running`, dass
+alle Schnittstellen verbunden sind. Beruht ein Zustand `degraded` oder `failed` auf einem
+Authentifizierungsproblem, wird statt dieses Ereignisses eine erneute Anmeldung angestoßen.
+
+---
+
+## homematicip_local.interface_connection_changed
+
+Wird ausgelöst, wenn sich eine einzelne Schnittstelle verbindet oder trennt.
+
+| Feld            | Typ    | Beschreibung                                          |
+| --------------- | ------ | ----------------------------------------------------- |
+| `instance_name` | `str`  | Name der Zentralen-Instanz                            |
+| `interface_id`  | `str`  | betroffene Schnittstelle, z. B. `openccu-HmIP-RF`     |
+| `connected`     | `bool` | `true`, wenn die Schnittstelle (wieder) verbunden ist |
+
+---
+
+## Servicemeldungen sind keine Ereignisse
+
+Die CCU führt eine eigene Liste von Servicemeldungen — die Einträge, die in der OpenCCU-Weboberfläche
+sichtbar sind. Diese werden **nicht** als Ereignisse ausgeliefert, und die dahinterliegenden
+Parameter (`CONFIG_PENDING`, `UPDATE_PENDING`, `STICKY_UNREACH`, `UN_REACH`) erzeugen auch keine
+Entities in Home Assistant.
+
+Stattdessen stellt die Integration die vollständige Liste über den Hub-Sensor
+`sensor.<instanz>_hub_service_messages` bereit:
+
+- **Zustand**: die Anzahl der aktuell aktiven Servicemeldungen
+- **Attribute**: `message_1`, `message_2`, … — je Meldung ein Attribut mit Gerätename und
+  Meldungstext
+
+Der Sensor ist standardmäßig aktiviert und wird im Abfrageintervall für Systemvariablen
+aktualisiert (standardmäßig 30 Sekunden). Automationen sollten daher einen **Zustands-Trigger**
+auf diesen Sensor verwenden statt eines Ereignis-Triggers.
+
+**Beispiel — benachrichtigen, sobald eine Servicemeldung auftritt:**
+
+```yaml
+triggers:
+  - trigger: numeric_state
+    entity_id: sensor.openccu_hub_service_messages
+    above: 0
+actions:
+  - action: persistent_notification.create
+    data:
+      title: CCU-Servicemeldungen
+      message: >
+        {{ state_attr('sensor.openccu_hub_service_messages', 'message_1') }}
+```
+
+Ein entsprechender Sensor `sensor.<instanz>_hub_alarm_messages` stellt die Alarmmeldungen der CCU
+auf dieselbe Weise bereit.
+
+!!! note "LOW_BAT und SABOTAGE"
+Diese beiden sind ein Sonderfall: Sie sind reguläre Binärsensoren am Gerät und sollten als
+Entities verwendet werden, statt sie unter den Ereignissen zu suchen.
+
+---
+
+## Siehe auch
+
+- [Actions-Referenz](homeassistant_actions.md) — alle Actions der Integration
+- [Optimistische Aktualisierungen](optimistic_updates.md) — Hintergründe zu optimistischen Werten und Rollbacks
+- [Event Reference](../../architecture/events/event_reference.md) — interner aiohomematic-EventBus (Entwickler)

--- a/docs/user/features/homeassistant_events.md
+++ b/docs/user/features/homeassistant_events.md
@@ -1,0 +1,231 @@
+# Events Reference
+
+This page documents all events that the Homematic(IP) Local for OpenCCU integration fires
+on the Home Assistant event bus, including the payload of each event.
+
+Use **Developer Tools → Events** in Home Assistant to listen to any of these event types live.
+
+!!! info "Looking for the library event bus?"
+This page covers the events an automation can trigger on. For the internal aiohomematic
+EventBus used by developers, see [Event Reference](../../architecture/events/event_reference.md).
+
+---
+
+## Overview
+
+| Event type                                       | Fired when                                      |
+| ------------------------------------------------ | ----------------------------------------------- |
+| `homematic.keypress`                             | A button on a device is pressed                 |
+| `homematic.impulse`                              | A device reports an impulse                     |
+| `homematic.device_error`                         | An `ERROR*` / `SENSOR_ERROR*` parameter changes |
+| `homematic.device_availability`                  | A device becomes reachable or unreachable       |
+| `homematicip_local.optimistic_rollback`          | An optimistic value was rolled back             |
+| `homematicip_local.central_state_changed`        | The central changes its health state            |
+| `homematicip_local.interface_connection_changed` | An interface connects or disconnects            |
+
+Device parameters outside this list never produce an event. In particular, CCU service
+messages such as `CONFIG_PENDING`, `UPDATE_PENDING`, `STICKY_UNREACH`, `LOW_BAT` and
+`SABOTAGE` are **not** events — see [Service messages are not events](#service-messages-are-not-events).
+
+---
+
+## homematic.keypress
+
+Fired when a device reports a button press. This is the event behind the remote control
+blueprints and the device triggers offered in the automation UI.
+
+**Triggering parameters:** `PRESS`, `PRESS_CONT`, `PRESS_LOCK`, `PRESS_LONG`,
+`PRESS_LONG_RELEASE`, `PRESS_LONG_START`, `PRESS_SHORT`, `PRESS_UNLOCK`
+
+| Field          | Type  | Description                                            |
+| -------------- | ----- | ------------------------------------------------------ |
+| `device_id`    | `str` | Home Assistant device registry ID                      |
+| `name`         | `str` | Device name (a user-assigned name takes priority)      |
+| `address`      | `str` | Device address, e.g. `0001D8A9B12C34`                  |
+| `model`        | `str` | Device model, e.g. `HmIP-WRC2`                         |
+| `interface_id` | `str` | Interface, e.g. `openccu-HmIP-RF`                      |
+| `type`         | `str` | Triggering parameter in lower case, e.g. `press_short` |
+| `subtype`      | `int` | Channel number the press came from                     |
+
+!!! note
+The parameter name is delivered as `type` and the channel as `subtype`. This event has no
+separate `parameter`, `channel_no` or `value` field.
+
+---
+
+## homematic.impulse
+
+Fired when a device reports an impulse. The only triggering parameter is `SEQUENCE_OK`.
+
+The payload is identical to [homematic.keypress](#homematickeypress), with `type` set to
+`sequence_ok`.
+
+---
+
+## homematic.device_error
+
+Fired when a device reports an error condition.
+
+**Triggering parameters:** every parameter whose name **starts with** `ERROR` or
+`SENSOR_ERROR` — for example `ERROR_OVERHEAT`, `ERROR_OVERLOAD`, `ERROR_JAMMED`,
+`ERROR_NON_FLAT_POSITIONING`, `ERROR_SABOTAGE` or `SENSOR_ERROR`.
+
+`ERROR_CODE` is deliberately excluded: it is a raw numeric code whose meaning differs per
+device and carries no usable information in a notification.
+
+The event fires on every change of the error state, so both the arrival and the clearing of
+an error produce an event. For boolean parameters an event is also fired when the value
+transitions from unknown to `true`; for numeric parameters, from unknown to a value greater
+than zero.
+
+| Field          | Type          | Description                                                  |
+| -------------- | ------------- | ------------------------------------------------------------ |
+| `device_id`    | `str`         | Home Assistant device registry ID                            |
+| `name`         | `str`         | Device name (a user-assigned name takes priority)            |
+| `address`      | `str`         | Device address                                               |
+| `channel_no`   | `int`         | Channel number reporting the error                           |
+| `model`        | `str`         | Device model                                                 |
+| `interface_id` | `str`         | Interface                                                    |
+| `parameter`    | `str`         | Error parameter name, e.g. `ERROR_OVERHEAT`                  |
+| `value`        | `bool \| int` | Raw parameter value                                          |
+| `error_value`  | `bool \| int` | Same as `value`                                              |
+| `error`        | `bool`        | `true` while the error is active, `false` once it clears     |
+| `identifier`   | `str`         | Stable ID `<address>_<parameter>`, usable as notification ID |
+| `title`        | `str`         | Ready-made notification title                                |
+| `message`      | `str`         | Ready-made notification message                              |
+
+Use `error` to decide whether to raise or dismiss a notification, and `identifier` to address
+the same notification in both cases. The `Show device error` blueprint does exactly this.
+
+---
+
+## homematic.device_availability
+
+Fired when a device changes between reachable and unreachable.
+
+Reachability is derived from the `UN_REACH` parameter on channel `0`. Only if a device has no
+`UN_REACH` parameter at all does `STICKY_UNREACH` act as a fallback. Since HmIP and BidCos
+devices provide both, `UN_REACH` is what decides in practice, and `STICKY_UNREACH` does not
+affect availability. The `force_device_availability` action overrides the result and also
+fires this event.
+
+| Field          | Type   | Description                                              |
+| -------------- | ------ | -------------------------------------------------------- |
+| `device_id`    | `str`  | Home Assistant device registry ID                        |
+| `name`         | `str`  | Device name (a user-assigned name takes priority)        |
+| `address`      | `str`  | Device address                                           |
+| `channel_no`   | `int`  | Always `0` — availability is per device, not per channel |
+| `model`        | `str`  | Device model                                             |
+| `interface_id` | `str`  | Interface                                                |
+| `parameter`    | `str`  | Always the literal `AVAILABILITY`                        |
+| `unavailable`  | `bool` | `true` when the device became unreachable                |
+| `identifier`   | `str`  | Stable ID `<address>_availability`                       |
+| `title`        | `str`  | Ready-made notification title                            |
+| `message`      | `str`  | Ready-made notification message                          |
+
+!!! note
+`parameter` is a fixed placeholder set by the integration, not a CCU parameter — devices have
+no `AVAILABILITY` parameter.
+
+---
+
+## homematicip_local.optimistic_rollback
+
+Fired when a value that was optimistically applied in Home Assistant had to be reverted
+because the CCU did not confirm it. Requires **system notifications** to be enabled in the
+integration's advanced options. See [Optimistic Updates](optimistic_updates.md) for background.
+
+| Field               | Type    | Description                                               |
+| ------------------- | ------- | --------------------------------------------------------- |
+| `device_id`         | `str`   | Home Assistant device registry ID (omitted if unknown)    |
+| `name`              | `str`   | Device name (omitted if unknown)                          |
+| `address`           | `str`   | Device address                                            |
+| `interface_id`      | `str`   | Interface                                                 |
+| `parameter`         | `str`   | Affected parameter                                        |
+| `reason`            | `str`   | `timeout`, `send_error` or `mismatch`                     |
+| `rolled_back_value` | `Any`   | The optimistic value that failed                          |
+| `restored_value`    | `Any`   | The previously confirmed value that was restored          |
+| `age_seconds`       | `float` | How long the optimistic value was held                    |
+| `error`             | `str`   | Error message, only present when `reason` is `send_error` |
+
+The three reasons mean: the CCU did not respond within the optimistic update timeout
+(`timeout`), sending raised an exception (`send_error`), or the CCU confirmed a different
+value than the one sent (`mismatch`).
+
+---
+
+## homematicip_local.central_state_changed
+
+Fired when the central changes its overall health state.
+
+| Field           | Type  | Description                                     |
+| --------------- | ----- | ----------------------------------------------- |
+| `instance_name` | `str` | Name of the central instance                    |
+| `new_state`     | `str` | `degraded`, `failed`, `recovering` or `running` |
+
+`degraded` means at least one interface is not connected, `failed` means manual intervention
+is required, `recovering` means a reconnect is in progress and `running` means all interfaces
+are connected. When a degraded or failed state is caused by an authentication problem, a
+reauthentication flow is started instead of firing this event.
+
+---
+
+## homematicip_local.interface_connection_changed
+
+Fired when a single interface connects or disconnects.
+
+| Field           | Type   | Description                                |
+| --------------- | ------ | ------------------------------------------ |
+| `instance_name` | `str`  | Name of the central instance               |
+| `interface_id`  | `str`  | Affected interface, e.g. `openccu-HmIP-RF` |
+| `connected`     | `bool` | `true` when the interface (re-)connected   |
+
+---
+
+## Service messages are not events
+
+The CCU maintains its own list of service messages (Servicemeldungen) — the entries visible in
+the OpenCCU web UI. These are **not** delivered as events, and the parameters behind them
+(`CONFIG_PENDING`, `UPDATE_PENDING`, `STICKY_UNREACH`, `UN_REACH`) do not produce Home
+Assistant entities either.
+
+Instead, the integration exposes the complete list through the hub sensor
+`sensor.<instance>_hub_service_messages`:
+
+- **State**: the number of currently active service messages
+- **Attributes**: `message_1`, `message_2`, … — one per message, each containing the device
+  name and the message text
+
+The sensor is enabled by default and refreshes on the system variable scan interval (30 seconds
+by default), so automations should use a **state trigger** on this sensor rather than an event
+trigger.
+
+**Example — notify when a service message appears:**
+
+```yaml
+triggers:
+  - trigger: numeric_state
+    entity_id: sensor.openccu_hub_service_messages
+    above: 0
+actions:
+  - action: persistent_notification.create
+    data:
+      title: CCU service messages
+      message: >
+        {{ state_attr('sensor.openccu_hub_service_messages', 'message_1') }}
+```
+
+A matching sensor `sensor.<instance>_hub_alarm_messages` exposes CCU alarm messages
+(Alarmmeldungen) the same way.
+
+!!! note "LOW_BAT and SABOTAGE"
+These two are a separate case: they are regular binary sensors on the device and should be
+used as entities, not looked for among the events.
+
+---
+
+## See Also
+
+- [Actions Reference](homeassistant_actions.md) — all custom actions of the integration
+- [Optimistic Updates](optimistic_updates.md) — background on optimistic values and rollbacks
+- [Event Reference](../../architecture/events/event_reference.md) — internal aiohomematic EventBus (developers)

--- a/docs/user/homeassistant_integration.de.md
+++ b/docs/user/homeassistant_integration.de.md
@@ -337,17 +337,26 @@ target:
 
 ## Ereignisse
 
-### homematic.keypress
+Die Integration löst auf dem Home Assistant-Event-Bus Ereignisse aus, auf die Automationen
+triggern können:
 
-Wird bei einem Tastendruck ausgelöst. Mit Device-Triggern oder Event-Entities verwenden.
+| Ereignistyp                                      | Wird ausgelöst, wenn                                  |
+| ------------------------------------------------ | ----------------------------------------------------- |
+| `homematic.keypress`                             | eine Taste an einem Gerät gedrückt wird               |
+| `homematic.impulse`                              | ein Gerät einen Impuls meldet                         |
+| `homematic.device_error`                         | sich ein `ERROR*`- / `SENSOR_ERROR*`-Parameter ändert |
+| `homematic.device_availability`                  | ein Gerät erreichbar oder unerreichbar wird           |
+| `homematicip_local.optimistic_rollback`          | ein optimistisch gesetzter Wert zurückgenommen wurde  |
+| `homematicip_local.central_state_changed`        | die Zentrale ihren Zustand ändert                     |
+| `homematicip_local.interface_connection_changed` | sich eine Schnittstelle verbindet oder trennt         |
 
-### homematic.device_availability
+!!! note "Servicemeldungen sind keine Ereignisse"
+CCU-Servicemeldungen wie `CONFIG_PENDING`, `UPDATE_PENDING` oder `STICKY_UNREACH` werden **nicht**
+als Ereignis ausgeliefert. Dafür steht der Hub-Sensor `sensor.<instanz>_hub_service_messages`
+bereit.
 
-Wird ausgelöst, wenn ein Gerät nicht mehr erreichbar ist oder wieder erreichbar wird. Nützlich mit dem Blueprint für persistente Benachrichtigungen.
-
-### homematic.device_error
-
-Wird ausgelöst, wenn sich ein Gerät in einem Fehlerzustand befindet.
+Die auslösenden Parameter und die vollständigen Nutzdaten aller Ereignisse sind in der
+[Ereignis-Referenz](features/homeassistant_events.md) dokumentiert.
 
 ---
 

--- a/docs/user/homeassistant_integration.md
+++ b/docs/user/homeassistant_integration.md
@@ -331,17 +331,24 @@ target:
 
 ## Events
 
-### homematic.keypress
+The integration fires events on the Home Assistant event bus that automations can trigger on:
 
-Fired when a key is pressed. Use with device triggers or event entities.
+| Event type                                       | Fired when                                      |
+| ------------------------------------------------ | ----------------------------------------------- |
+| `homematic.keypress`                             | A button on a device is pressed                 |
+| `homematic.impulse`                              | A device reports an impulse                     |
+| `homematic.device_error`                         | An `ERROR*` / `SENSOR_ERROR*` parameter changes |
+| `homematic.device_availability`                  | A device becomes reachable or unreachable       |
+| `homematicip_local.optimistic_rollback`          | An optimistic value was rolled back             |
+| `homematicip_local.central_state_changed`        | The central changes its health state            |
+| `homematicip_local.interface_connection_changed` | An interface connects or disconnects            |
 
-### homematic.device_availability
+!!! note "Service messages are not events"
+CCU service messages such as `CONFIG_PENDING`, `UPDATE_PENDING` or `STICKY_UNREACH` are **not**
+delivered as events. Use the hub sensor `sensor.<instance>_hub_service_messages` for those.
 
-Fired when a device becomes unavailable or available again. Useful with the persistent notification blueprint.
-
-### homematic.device_error
-
-Fired when a device is in an error state.
+See [Events Reference](features/homeassistant_events.md) for the triggering parameters and the
+full payload of every event.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - Device Support: user/device_support.md
       - Features:
           - Actions Reference: user/features/homeassistant_actions.md
+          - Events Reference: user/features/homeassistant_events.md
           - Week Profiles: user/features/week_profile.md
           - Device Configuration Panel: user/features/config_panel.md
           - Climate Schedule Card: user/features/climate_schedule_card.md


### PR DESCRIPTION
## Why

Discussion #3333: a user provoked `CONFIG_PENDING` deliberately, saw the message appear in the OpenCCU web UI and in the device configuration panel, but got no `homematic.device_error` event in Home Assistant. Their follow-up questions — which messages arrive via which event, with which payload, and is there a list anywhere — could not be answered from the docs.

The user guide's `Events` section described three events in one sentence each and named neither the triggering parameters nor a single payload field. Four of the seven events the integration fires were not documented at all.

## What

New page `docs/user/features/homeassistant_events.md` (+ `.de.md`), linked from the Features nav next to the Actions reference. It documents all seven events fired on the HA event bus with their triggering parameters and full payload tables:

- `homematic.keypress`
- `homematic.impulse`
- `homematic.device_error`
- `homematic.device_availability`
- `homematicip_local.optimistic_rollback`
- `homematicip_local.central_state_changed`
- `homematicip_local.interface_connection_changed`

Three points that the discussion showed to be genuinely unclear are now stated explicitly:

- **`device_error` scope**: only parameters whose name starts with `ERROR` or `SENSOR_ERROR` produce this event (`DEVICE_ERROR_EVENTS` + `startswith` in `model/event.py`); `ERROR_CODE` is filtered out by the integration.
- **Service messages are not events**: `CONFIG_PENDING`, `UPDATE_PENDING`, `STICKY_UNREACH` and `UN_REACH` are hidden parameters (`DataPointUsage.NO_CREATE`), so they produce neither an event nor an entity. The supported consumer is the `hub_service_messages` sensor — documented with an example automation, including the note that it polls on the sysvar scan interval and therefore needs a state trigger.
- **Availability derivation**: `UN_REACH` on channel 0 decides, with `STICKY_UNREACH` only as a fallback for devices that have no `UN_REACH` at all; the `AVAILABILITY` value in the payload is an integration-set placeholder, not a CCU parameter.

The user guide section keeps a compact overview table and links to the new page.

## Verification

- Pre-commit hooks pass (`check-docs-references`: no drift; prettier; codespell; yamllint)
- `translate_docs.py --check`: unchanged against `origin/main` (the 9 outdated translations listed there are pre-existing and untouched); the new DE page carries a current `translation_source_hash`
- `mkdocs build` produces the page in both languages, no warnings referencing it. The 4 warnings that abort `--strict` were verified to be identical on `origin/main` (README/index conflict, autorefs duplicates from the i18n build)

## Note for a separate PR

Prettier 3.1.0 strips the indentation under `!!! note` blocks, so admonition content falls out of the box — all 11 admonitions on `homeassistant_integration` render as empty boxes today. This PR follows the existing repo style rather than diverging in one file; the fix (a prettier exception for `docs/`) belongs in its own change.