### PR TITLE
fix(calculated): gate validity on source validity, not just refreshed state

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.8.0"
+VERSION: Final = "2026.8.1"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/model/calculated/data_point.py
+++ b/aiohomematic/model/calculated/data_point.py
@@ -119,7 +119,7 @@ class CalculatedDataPoint[ParameterT: ParamType](BaseDataPoint, CallbackDataPoin
         return False
 
     _relevant_data_points: Final = DelegatedProperty[tuple[GenericDataPointProtocolAny, ...]](
-        path="_readable_data_points"
+        path="_relevant_values_data_points"
     )
     default: Final = DelegatedProperty[ParameterT](path="_default")
     hmtype: Final = DelegatedProperty[ParameterType](path="_type")
@@ -140,7 +140,13 @@ class CalculatedDataPoint[ParameterT: ParamType](BaseDataPoint, CallbackDataPoin
 
     @property
     def _relevant_values_data_points(self) -> tuple[GenericDataPointProtocolAny, ...]:
-        """Returns the list of relevant VALUES data points. To be overridden by subclasses."""
+        """
+        Returns the list of relevant VALUES data points. To be overridden by subclasses.
+
+        These are the state carriers of a calculated data point and therefore gate its
+        validity. MASTER data points are configuration inputs (e.g. ``LOW_BAT_LIMIT``),
+        which a sleeping device may never deliver, and must not gate validity.
+        """
         return tuple(dp for dp in self._readable_data_points if dp.paramset_key == ParamsetKey.VALUES)
 
     @property
@@ -189,6 +195,24 @@ class CalculatedDataPoint[ParameterT: ParamType](BaseDataPoint, CallbackDataPoin
     def is_status_valid(self) -> bool:
         """Return if all relevant data points have valid status."""
         return all(dp.is_status_valid for dp in self._relevant_data_points)
+
+    @property
+    @override
+    def is_valid(self) -> bool:
+        """
+        Return if the calculated data point has a valid value.
+
+        A calculated value can only be as good as the values it derives from, so every
+        state-carrying source must carry a valid value itself. Checking ``is_refreshed``
+        alone is not enough: a source that was read at startup but returned no usable
+        value is refreshed, yet has nothing to calculate from.
+
+        Without any state-carrying source there is nothing to derive a value from, so the
+        data point is not valid.
+        """
+        return bool(relevant_data_points := self._relevant_data_points) and all(
+            dp.is_valid for dp in relevant_data_points
+        )
 
     @property
     def is_writable(self) -> bool:

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,26 @@
 
 ## What's Changed
 
+### Fixed
+
+- Fix calculated data points (`OPERATING_VOLTAGE_LEVEL`, `VAPOR_CONCENTRATION`,
+  `DEW_POINT`, …) reporting `is_valid=True` while their value is `None`, which left the
+  corresponding Home Assistant entities stuck at `unknown` after a restart instead of
+  restoring their previous state (#3332). `CalculatedDataPoint` inherited its validity
+  from `BaseDataPoint`, where `is_valid` only aggregates `is_refreshed` and
+  `is_status_valid` of the source data points. A source that was read at startup but
+  returned no usable value is refreshed, so the calculated data point claimed validity
+  with nothing to calculate from — and because Home Assistant only restores a previous
+  state for data points that report themselves as invalid, the restore path never ran.
+  Validity now requires every state-carrying source to be valid itself.
+- Calculated data point validity is no longer gated by MASTER sources. Applying the
+  ADR-0025 reasoning to calculated data points, only the readable VALUES sources
+  (`_relevant_values_data_points`) are state carriers; MASTER paramset entries such as
+  `LOW_BAT_LIMIT` are configuration inputs that a sleeping battery device may never
+  deliver, and previously blocked `is_valid`, `is_refreshed` and `state_uncertain` of the
+  whole calculated data point. A calculated data point without any readable VALUES source
+  is now invalid rather than valid-with-`None`.
+
 ### Documentation
 
 - **Events reference for the Home Assistant integration**

--- a/tests/test_model_calculated.py
+++ b/tests/test_model_calculated.py
@@ -135,6 +135,9 @@ class _FakeGenericDP:
         self.is_status_valid = True
         self.state_uncertain = False
         self.published_event_recently = True
+        # Mimics the extra type/range checks of GenericDataPoint.is_valid, which a
+        # refreshed data point without a usable value fails.
+        self.has_valid_value = True
         self._unsubscribed: list[bool] = []
         self.unique_id = f"fake_dp_{_FakeGenericDP._counter}"
 
@@ -144,7 +147,7 @@ class _FakeGenericDP:
 
     @property
     def is_valid(self) -> bool:
-        return self.is_refreshed and self.is_status_valid
+        return self.is_refreshed and self.is_status_valid and self.has_valid_value
 
     @property
     def modified_at(self) -> datetime:
@@ -322,6 +325,64 @@ class TestCalculatedDataPoint:
 
         # And then call unregister to iterate over both a callable and a None
         calc.unsubscribe_from_data_point_updated()
+
+
+class TestCalculatedDataPointValidity:
+    """Tests for the validity gating of CalculatedDataPoint."""
+
+    @staticmethod
+    def _build(*dps: _FakeGenericDP) -> _MyCalc:
+        """Return a calculated data point wired to the given source data points."""
+        ch = _FakeChannel()
+        for dp in dps:
+            ch.add_fake(dp)
+        calc = _MyCalc(channel=ch)
+        for dp in dps:
+            calc._add_data_point(parameter=dp.parameter, paramset_key=dp.paramset_key, dpt=_FakeGenericDP)  # type: ignore[arg-type]
+        return calc
+
+    def test_invalid_source_value_invalidates(self) -> None:
+        """Test a refreshed source data point without a usable value invalidates the calculated data point."""
+        dp = _FakeGenericDP(parameter="A", paramset_key=ParamsetKey.VALUES)
+        # The startup case: the source was read but returned no usable value.
+        dp.has_valid_value = False
+        calc = self._build(dp)
+
+        assert dp.is_refreshed is True
+        assert calc.is_refreshed is True
+        assert calc.is_valid is False
+
+    def test_master_source_does_not_gate_validity(self) -> None:
+        """Test a MASTER config source does not gate validity of the calculated data point."""
+        values_dp = _FakeGenericDP(parameter="A", paramset_key=ParamsetKey.VALUES, value=2.5)
+        master_dp = _FakeGenericDP(parameter="B", paramset_key=ParamsetKey.MASTER)
+        # A sleeping battery device may never deliver its MASTER paramset.
+        master_dp.is_refreshed = False
+        master_dp.has_valid_value = False
+        calc = self._build(values_dp, master_dp)
+
+        assert calc.is_valid is True
+        assert calc.is_refreshed is True
+        assert calc.state_uncertain is False
+
+    def test_no_subclass_overrides_relevant_data_points(self) -> None:
+        """Test validity gating stays with _relevant_values_data_points for every subclass."""
+
+        def _subclasses(cls: type) -> set[type]:
+            found = set(cls.__subclasses__())
+            for sub in tuple(found):
+                found |= _subclasses(sub)
+            return found
+
+        overriding = {sub.__name__ for sub in _subclasses(CalculatedDataPoint) if "_relevant_data_points" in vars(sub)}
+        assert not overriding
+
+    def test_without_relevant_sources_is_invalid(self) -> None:
+        """Test a calculated data point without readable VALUES sources is not valid."""
+        master_dp = _FakeGenericDP(parameter="B", paramset_key=ParamsetKey.MASTER)
+        calc = self._build(master_dp)
+
+        assert calc.is_valid is False
 
 
 class TestOperatingVoltageLevel:


### PR DESCRIPTION
Closes #3332

## Problem

Calculated data points (`OPERATING_VOLTAGE_LEVEL`, `VAPOR_CONCENTRATION`, `DEW_POINT`, …) stay at `unknown` in Home Assistant for a long time after a restart — until the physical device sends again — instead of restoring their previous value.

The Home Assistant integration already implements the restore path for these entities (`AioHomematicSensor` is a `RestoreSensor` and covers `CalculatedDataPointProtocol`), but it never runs: it is guarded by `not data_point.is_valid`, and the calculated data point wrongly reports `is_valid=True`.

`CalculatedDataPoint` inherited `is_valid` from `BaseDataPoint`, where it only aggregates `is_refreshed` and `is_status_valid` of the source data points — never their `is_valid`. A source that was read at startup but returned no usable value is `refreshed=True, valid=False`; `GenericDataPoint.is_valid` catches that via `has_valid_value_type` / `is_value_in_range`, the calculated data point did not.

Reproduced against the HA integration test harness (HmIP-SWDO-I, right after setup, no device event yet):

```
=== CALC Operating Voltage Level (OPERATING_VOLTAGE_LEVEL) ===
  is_valid       = True        <- although there is no value
  is_refreshed   = True
  value          = None
    src LOW_BAT_LIMIT      pset=MASTER  refreshed=True valid=True  value=2.2
    src OPERATING_VOLTAGE  pset=VALUES  refreshed=True valid=False value=None

sensor.…_operating_voltage:        unknown  value_state=not valid   <- generic, restore path runs
sensor.…_operating_voltage_level:  unknown  value_state=uncertain   <- calculated, restore path never runs
```

## Change

1. **`is_valid` is overridden on `CalculatedDataPoint`**: every state-carrying source must be valid itself. A calculated value can only be as good as the values it derives from.
2. **Only readable VALUES sources gate validity** (`_relevant_data_points` now delegates to `_relevant_values_data_points`). MASTER paramset entries such as `LOW_BAT_LIMIT` are configuration inputs that a sleeping battery device may never deliver — applying the ADR-0025 reasoning, they must not block `is_valid` / `is_refreshed` / `state_uncertain` of the whole calculated data point.

A calculated data point without any readable VALUES source is now invalid instead of valid-with-`None`. `modified_at`, `refreshed_at` and `load_data_point_value` keep operating on all readable sources.

## Tests

New `TestCalculatedDataPointValidity` in `tests/test_model_calculated.py`:

- an invalid source value invalidates the calculated data point
- a MASTER config source does not gate validity
- no readable VALUES source → invalid
- no subclass overrides `_relevant_data_points` (structural counterpart to the ADR-0025 contract test)

The first three fail without the fix. `_FakeGenericDP.is_valid` gained a `has_valid_value` flag so it mirrors the extra type/range checks of the real `GenericDataPoint`.

## Verification

- `pytest tests/`: 3914 passed, 1 skipped
- `prek run --all-files`: clean

End-to-end against the Home Assistant integration (HmIP-SWDO-I, restore cache holding 77.0, then an `OPERATING_VOLTAGE` event):

```
before:  unknown  value_state=uncertain   -> after event: unknown
after:   77.0     value_state=restored    -> after event: 87.5  value_state=valid
```

So the entity restores its previous value and is handed back to the live value as soon as the device reports — it does not get stuck in `value_state=restored`.

## Note

`aiohomematic/const.py:VERSION` was still at `2026.8.0` on `main` while `changelog.md` already carried a `2026.8.1` section (#3334). This PR syncs it to `2026.8.1`.