### PR TITLE
fix(climate): don't let rarely reported values invalidate classic RF thermostats

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.8.4"
+VERSION: Final = "2026.8.5"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/model/custom/climate.py
+++ b/aiohomematic/model/custom/climate.py
@@ -475,9 +475,13 @@ class CustomDpRfThermostat(BaseCustomDpClimate):
     _dp_temperature_offset: Final = DataPointField(field=Field.TEMPERATURE_OFFSET, dpt=DpSelect)
     _dp_valve_state: Final = DataPointField(field=Field.VALVE_STATE, dpt=DpSensor[int | None])
     _dp_week_program_pointer: Final = DataPointField(field=Field.WEEK_PROGRAM_POINTER, dpt=DpSelect)
-    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset(
-        {Field.TEMPERATURE, Field.SETPOINT, Field.CONTROL_MODE}
-    )
+    # CONTROL_MODE is only reported when the operating mode actually changes, while
+    # temperature and setpoint keep arriving every few minutes. After a CCU restart it can
+    # therefore stay unrefreshed for as long as nobody switches the mode, which would keep
+    # Home Assistant at value_state=restored and freeze the live values. Validity follows
+    # the two continuously reported values; mode falls back to AUTO until CONTROL_MODE
+    # arrives.
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.TEMPERATURE, Field.SETPOINT})
 
     @property
     def _current_profile_name(self) -> ClimateProfile | None:

--- a/aiohomematic/model/custom/climate.py
+++ b/aiohomematic/model/custom/climate.py
@@ -448,6 +448,14 @@ class CustomDpSimpleRfThermostat(BaseCustomDpClimate):
 
     __slots__ = ()
 
+    # HM-CC-TC reports SETPOINT only when the wheel is turned on the device, never
+    # periodically. The ReGa bulk fetch skips data points without a timestamp and
+    # BidCos-RF has no per-parameter getValue fallback, so a device that has not been
+    # touched since the last CCU restart would keep the whole climate data point
+    # invalid - freezing Home Assistant at value_state=restored while TEMPERATURE
+    # events keep arriving. Validity therefore follows TEMPERATURE alone.
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.TEMPERATURE})
+
     def _manu_temp_changed(self) -> None:
         """Handle device state changes."""
 

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,16 @@
   arrives instead of reporting a stale restored value. Same pattern as the earlier
   heating-group fixes (#3255, #3279). A regression test covers a thermostat that only ever
   receives `TEMPERATURE` events, and the validity contract test is updated.
+- **Classic RF thermostats no longer hang at the restored state when the operating mode
+  stays untouched.** Same failure class as above: `CustomDpRfThermostat` (`HM-CC-RT-DN`,
+  `HM-TC-IT-WM-W-EU`, `HM-CC-VG-1`, `BC-RT-TRX-*`, `BC-TC-C-WM`) also gated its validity on
+  `CONTROL_MODE`. Unlike `ACTUAL_TEMPERATURE` and `SET_TEMPERATURE`, which these devices
+  report every few minutes, `CONTROL_MODE` is only sent when the operating mode actually
+  changes — so after a CCU restart it can stay unrefreshed for as long as nobody switches
+  between AUTO and MANU, keeping the climate entity at `value_state=restored` with frozen
+  live values. Validity now follows `TEMPERATURE` and `SETPOINT`; until `CONTROL_MODE`
+  arrives, `mode` reports its existing `AUTO` fallback. A regression test covers a wall
+  thermostat that reports temperature, setpoint and humidity but never `CONTROL_MODE`.
 
 # Version 2026.8.4 (2026-08-22)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,25 @@
+# Version 2026.8.5 (2026-08-23)
+
+## What's Changed
+
+### Fixed
+
+- **`HM-CC-TC` climate no longer freezes at the restored Home Assistant state.**
+  `CustomDpSimpleRfThermostat` gated its validity on `TEMPERATURE` **and** `SETPOINT`, but
+  `HM-CC-TC` reports `SETPOINT` (channel 2, `CLIMATECONTROL_REGULATOR`) only when the wheel
+  is turned on the device — never periodically. The ReGa bulk fetch skips data points
+  without a timestamp, and since the BidCos-RF interface no longer falls back to a
+  per-parameter `getValue` during init, `SETPOINT` stayed unrefreshed forever on a device
+  that had not been touched since the last CCU restart. That dragged the whole custom
+  climate data point to `is_valid=False`, so Home Assistant kept the entity in
+  `value_state=restored` and froze `current_temperature`/`target_temperature`/`hvac_mode` at
+  the last (re)start value — while the sibling `sensor.*` entities (gated on their own data
+  point) kept updating from the very same `TEMPERATURE` events. Validity now follows
+  `TEMPERATURE` alone; `target_temperature` stays `None` until the first real `SETPOINT`
+  arrives instead of reporting a stale restored value. Same pattern as the earlier
+  heating-group fixes (#3255, #3279). A regression test covers a thermostat that only ever
+  receives `TEMPERATURE` events, and the validity contract test is updated.
+
 # Version 2026.8.4 (2026-08-22)
 
 ## What's Changed

--- a/tests/contract/test_cdp_validity_contract.py
+++ b/tests/contract/test_cdp_validity_contract.py
@@ -49,7 +49,7 @@ EXPECTED_VALIDITY_RELEVANT_FIELDS: dict[str, frozenset[Field]] = {
     "CustomDpIpSirenSmoke": frozenset({Field.SMOKE_DETECTOR_ALARM_STATUS}),
     "CustomDpIpThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT, Field.SET_POINT_MODE}),
     "CustomDpRfLock": frozenset({Field.STATE}),
-    "CustomDpRfThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT, Field.CONTROL_MODE}),
+    "CustomDpRfThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT}),
     "CustomDpSimpleRfThermostat": frozenset({Field.TEMPERATURE}),
     "CustomDpSoundPlayer": frozenset({Field.DIRECTION}),
     "CustomDpSoundPlayerLed": frozenset({Field.LEVEL}),

--- a/tests/contract/test_cdp_validity_contract.py
+++ b/tests/contract/test_cdp_validity_contract.py
@@ -50,7 +50,7 @@ EXPECTED_VALIDITY_RELEVANT_FIELDS: dict[str, frozenset[Field]] = {
     "CustomDpIpThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT, Field.SET_POINT_MODE}),
     "CustomDpRfLock": frozenset({Field.STATE}),
     "CustomDpRfThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT, Field.CONTROL_MODE}),
-    "CustomDpSimpleRfThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT}),
+    "CustomDpSimpleRfThermostat": frozenset({Field.TEMPERATURE}),
     "CustomDpSoundPlayer": frozenset({Field.DIRECTION}),
     "CustomDpSoundPlayerLed": frozenset({Field.LEVEL}),
     "CustomDpSwitch": frozenset({Field.STATE}),

--- a/tests/test_model_climate.py
+++ b/tests/test_model_climate.py
@@ -2783,3 +2783,38 @@ class TestClimateValidityIrrelevantDataPoints:
                 dp._set_refreshed_at(refreshed_at=datetime.now())
         assert climate._dp_valve_state.is_refreshed is False
         assert climate.is_valid is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_simple_rf_thermostat_setpoint_excluded_from_validity(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """SETPOINT must not block is_valid for a simple RF thermostat."""
+        central, _mock_client, _ = central_client_factory_with_homegear_client
+        climate = cast(CustomDpSimpleRfThermostat, get_prepared_custom_data_point(central, "VCU0000054", 1))
+        # Precondition: SETPOINT is a real, readable data point on the regulator channel.
+        assert climate._dp_setpoint.is_readable
+        assert climate._dp_setpoint not in climate._relevant_data_points
+        # HM-CC-TC only reports SETPOINT when the wheel is turned on the device, so after a
+        # restart the regulator channel stays silent while the weather channel keeps sending.
+        await central.event_coordinator.data_point_event(
+            interface_id=const.INTERFACE_ID,
+            channel_address="VCU0000054:1",
+            parameter="TEMPERATURE",
+            value=26.0,
+        )
+        assert climate._dp_setpoint.is_refreshed is False
+        # The climate must be valid so Home Assistant leaves the restored state behind.
+        assert climate.is_valid is True
+        assert climate.current_temperature == 26.0

--- a/tests/test_model_climate.py
+++ b/tests/test_model_climate.py
@@ -2767,6 +2767,47 @@ class TestClimateValidityIrrelevantDataPoints:
             (TEST_DEVICES, True, None, None),
         ],
     )
+    async def test_rf_thermostat_control_mode_excluded_from_validity(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """CONTROL_MODE must not block is_valid for an RF thermostat."""
+        central, _mock_client, _ = central_client_factory_with_homegear_client
+        climate = cast(CustomDpRfThermostat, get_prepared_custom_data_point(central, "VCU0000341", 2))
+        # Precondition: CONTROL_MODE is a real, readable data point on the thermal control channel.
+        assert climate._dp_control_mode.is_readable
+        assert climate._dp_control_mode not in climate._relevant_data_points
+        # A wall thermostat reports temperature, setpoint and humidity every few minutes, but
+        # CONTROL_MODE only when the operating mode actually changes.
+        for parameter, value in (
+            ("ACTUAL_TEMPERATURE", 22.5),
+            ("SET_TEMPERATURE", 21.0),
+            ("ACTUAL_HUMIDITY", 48),
+        ):
+            await central.event_coordinator.data_point_event(
+                interface_id=const.INTERFACE_ID,
+                channel_address="VCU0000341:2",
+                parameter=parameter,
+                value=value,
+            )
+        assert climate._dp_control_mode.is_refreshed is False
+        # The climate must be valid so Home Assistant leaves the restored state behind.
+        assert climate.is_valid is True
+        assert climate.current_temperature == 22.5
+        assert climate.target_temperature == 21.0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
     async def test_rf_thermostat_valve_state_excluded_from_validity(
         self,
         central_client_factory_with_homegear_client,


### PR DESCRIPTION
## Problem

Two classic BidCos-RF climate classes gated their validity on values the devices report only on demand, not periodically.

`fetch_all_device_data.fn` only returns data points that carry a timestamp, and `BidCos-RF` is in `INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK`, so there is no per-parameter `getValue` fallback during init either. A value that has not been reported since the last CCU restart therefore stays unrefreshed indefinitely — and drags the whole custom climate data point to `is_valid=False`. Home Assistant then falls back to the restored state for `current_temperature`, `target_temperature` and `hvac_mode`, so the `climate` entity freezes at the last (re)start value, while the sibling `sensor.*` entities keep updating from the very same events.

Same failure class as the earlier heating-group fixes for `LEVEL`/`STATE`/`VALVE_STATE` and `HUMIDITY`/`HEATING_COOLING`.

### 1. `CustomDpSimpleRfThermostat` — `SETPOINT`

`HM-CC-TC` reports `SETPOINT` (channel 2, `CLIMATECONTROL_REGULATOR`) only when the wheel is turned on the device. On a thermostat nobody has touched since the last CCU restart, the climate entity is permanently stuck:

```
_relevant_data_points:   [(':1', 'TEMPERATURE'), (':2', 'SETPOINT')]
after TEMPERATURE event: current_temperature = 26.0, SETPOINT refreshed = False
                         -> is_refreshed = False -> is_valid = False
```

### 2. `CustomDpRfThermostat` — `CONTROL_MODE`

`HM-CC-RT-DN`, `HM-TC-IT-WM-W-EU`, `HM-CC-VG-1`, `BC-RT-TRX-*`, `BC-TC-C-WM`.

These devices report `ACTUAL_TEMPERATURE`, `SET_TEMPERATURE` and `ACTUAL_HUMIDITY` every few minutes, but `CONTROL_MODE` only when the operating mode actually changes. A debug log of a wall thermostat over 17 minutes shows the asymmetry clearly — 7 events each for the continuously reported values, none for `CONTROL_MODE`:

```
7 <addr> 2 ACTUAL_HUMIDITY
7 <addr> 2 ACTUAL_TEMPERATURE
7 <addr> 2 SET_TEMPERATURE
0 <addr> 2 CONTROL_MODE
```

After a CCU restart, `CONTROL_MODE` can stay unrefreshed for as long as nobody switches between AUTO and MANU.

## Change

| Class | before | after |
|---|---|---|
| `CustomDpSimpleRfThermostat` | `{TEMPERATURE, SETPOINT}` | `{TEMPERATURE}` |
| `CustomDpRfThermostat` | `{TEMPERATURE, SETPOINT, CONTROL_MODE}` | `{TEMPERATURE, SETPOINT}` |

Trade-offs, both preferring live values over a stale restored state:

- `HM-CC-TC`: `target_temperature` stays `None` until the first real `SETPOINT` arrives, instead of reporting a stale restored value. Writing a setpoint is unaffected.
- RF thermostats: until `CONTROL_MODE` arrives, `mode` reports its existing `AUTO` fallback.

## Tests

- Regression test: `HM-CC-TC` receiving only `TEMPERATURE` events must be valid.
- Regression test: a wall thermostat reporting temperature, setpoint and humidity but never `CONTROL_MODE` must be valid.
- Validity contract test updated for both classes.
- Full suite: 3949 passed, 1 skipped. `prek run --all-files` green.