### PR TITLE
feat(const): let an inbox entry say it is awaiting release

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.8.5"
+VERSION: Final = "2026.8.6"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -2185,6 +2185,20 @@ class InboxDeviceData:
     name: str
     device_type: str
     interface: str
+    # True when the device is already accepted and fully materialised — it has
+    # its ise_id, its channels and its data points, and can be renamed and
+    # assigned rooms — but is deliberately still withheld from the ecosystems
+    # until an operator finishes onboarding it.
+    #
+    # A consumer must not offer *accept* for such an entry: it is accepted
+    # already, and what it needs is a release. Both states arrive in the same
+    # inbox listing, so without this flag they are indistinguishable and the
+    # only action on offer is the wrong one.
+    #
+    # Only the openccu-loom backend has this middle state; a CCU reached
+    # directly goes straight from "waiting" to "in service", which is why the
+    # default is False and the field is optional for every existing caller.
+    awaiting_release: bool = False
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)

--- a/changelog.md
+++ b/changelog.md
@@ -17,7 +17,7 @@
 
   Between those steps the device appears in the same inbox listing as one that
   is genuinely waiting for a decision, where the only action on offer is
-  *accept* — and for this entry that is exactly wrong: it is accepted already,
+  _accept_ — and for this entry that is exactly wrong: it is accepted already,
   and what it needs is a release.
 
   `InboxDeviceData.awaiting_release` carries the distinction. It defaults to

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,30 @@
+# Version 2026.8.6 (2026-08-28)
+
+## What's Changed
+
+### Added
+
+- **An inbox entry can say that it is awaiting release.** A device can sit in
+  the inbox in two different states, and a consumer that cannot tell them apart
+  offers the wrong action for one of them.
+
+  The `openccu-loom` backend onboards a device in two steps: it is **accepted**
+  first — gaining its ise_id, its channels and its data points, so it can be
+  renamed and assigned rooms — and **released** to the ecosystems only
+  afterwards. The order is the point: an ecosystem that sees a device first and
+  is corrected afterwards keeps the identity it saw, so Home Assistant would
+  mint entity ids from the still-unnamed device.
+
+  Between those steps the device appears in the same inbox listing as one that
+  is genuinely waiting for a decision, where the only action on offer is
+  *accept* — and for this entry that is exactly wrong: it is accepted already,
+  and what it needs is a release.
+
+  `InboxDeviceData.awaiting_release` carries the distinction. It defaults to
+  `False` and is optional for every existing caller, because a CCU reached
+  directly has no such middle state — it goes straight from waiting to in
+  service, so the default is the truth there rather than a placeholder.
+
 # Version 2026.8.5 (2026-08-23)
 
 ## What's Changed


### PR DESCRIPTION
A device can sit in the inbox in two different states, and a consumer that cannot tell them apart offers the wrong action for one of them.

## The state that has no name yet

The `openccu-loom` backend gained an onboarding wizard. A device is **accepted** first — it gets its ise_id, its channels and its data points, and can be renamed and assigned rooms — and only **released** to the ecosystems afterwards. The order is the point: an ecosystem that sees a device first and is corrected afterwards keeps the identity it saw, so Home Assistant would mint entity ids from the unnamed device.

Between those two steps the device is listed in the same inbox as one still waiting for a decision. The only action a consumer can offer is *accept*, and for this entry that is exactly wrong — it is accepted already; what it needs is a release.

## The change

One optional field, `awaiting_release: bool = False`.

It defaults to `False` and is optional for every existing caller, because a CCU reached directly has no such middle state: it goes straight from waiting to in service. So the default is the truth on that path rather than a placeholder — nothing needs to start passing it.

`dataclasses.asdict()` picks it up automatically, which is how `homematicip_local` serialises these records to its frontend.

## Verification

3949 tests pass, 1 skipped. ruff check / ruff format / mypy clean on the touched file.

## Follow-ups elsewhere

`openccu-loom-client` will populate it from the daemon's inbox payload (which already carries `awaiting_release`), and `homematicip_local` can then offer *release* instead of *accept* for those entries. Neither can be done without this field, which is why it goes first.