### PR TITLE
feat(model): lift capabilities onto a category-specific protocol

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.8.6"
+VERSION: Final = "2026.8.7"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/interfaces/__init__.py
+++ b/aiohomematic/interfaces/__init__.py
@@ -123,6 +123,21 @@ Protocol Categories
         - `HubSensorDataPointProtocol`: Hub sensor data points
         - `HubBinarySensorDataPointProtocol`: Hub binary sensor data points
 
+    *Custom Category Protocols:*
+        Category-specific protocols carrying the ``capabilities`` dataclass of a custom
+        category, so consumers can dispatch on capability flags instead of on concrete
+        class identity. Sub-protocols exist wherever a capability flag gates an optional
+        method surface. See `aiohomematic.interfaces.custom`.
+
+        - `ClimateDataPointProtocol`: Climate data points (`ClimateCapabilities`)
+        - `CoverDataPointProtocol`: Cover data points (`CoverCapabilities`)
+        - `GarageDataPointProtocol`: Covers with a ventilation position (`capabilities.vent`)
+        - `TiltCoverDataPointProtocol`: Covers with tilt control (`capabilities.tilt`)
+        - `LightDataPointProtocol`: Light data points (`LightCapabilities`)
+        - `LockDataPointProtocol`: Lock data points (`LockCapabilities`)
+        - `SirenDataPointProtocol`: Siren data points (`SirenCapabilities`)
+        - `SoundPlayerDataPointProtocol`: Sirens with soundfiles (`capabilities.soundfiles`)
+
     *Other:*
         - `WeekProfileProtocol`: Weekly schedule management
 
@@ -143,6 +158,7 @@ For explicit imports, use the submodules:
 
 - ``aiohomematic.interfaces.central``: Central unit protocols
 - ``aiohomematic.interfaces.client``: Client-related protocols
+- ``aiohomematic.interfaces.custom``: Category-specific custom data point protocols
 - ``aiohomematic.interfaces.model``: Device, Channel, DataPoint protocols
 - ``aiohomematic.interfaces.operations``: Cache and visibility protocols
 - ``aiohomematic.interfaces.coordinators``: Coordinator-specific protocols
@@ -196,6 +212,16 @@ from aiohomematic.interfaces.client import (
     SessionRecorderProviderProtocol,
 )
 from aiohomematic.interfaces.coordinators import CoordinatorProviderProtocol
+from aiohomematic.interfaces.custom import (
+    ClimateDataPointProtocol,
+    CoverDataPointProtocol,
+    GarageDataPointProtocol,
+    LightDataPointProtocol,
+    LockDataPointProtocol,
+    SirenDataPointProtocol,
+    SoundPlayerDataPointProtocol,
+    TiltCoverDataPointProtocol,
+)
 from aiohomematic.interfaces.model import (
     BaseDataPointProtocol,
     BaseParameterDataPointProtocol,
@@ -294,6 +320,15 @@ __all__ = [
     # Model channel
     "ChannelEventGroupProtocol",
     "ChannelProtocol",
+    # Model custom category
+    "ClimateDataPointProtocol",
+    "CoverDataPointProtocol",
+    "GarageDataPointProtocol",
+    "LightDataPointProtocol",
+    "LockDataPointProtocol",
+    "SirenDataPointProtocol",
+    "SoundPlayerDataPointProtocol",
+    "TiltCoverDataPointProtocol",
     # Model data point
     "BaseDataPointProtocol",
     "BaseParameterDataPointProtocol",

--- a/aiohomematic/interfaces/custom.py
+++ b/aiohomematic/interfaces/custom.py
@@ -1,0 +1,528 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""
+Category-specific protocol interfaces for custom data points.
+
+While ``CustomDataPointProtocol`` describes what every custom data point has in
+common, consumers that dispatch on *capabilities* instead of on concrete class
+identity need a typed surface per category. This module provides that surface:
+one base protocol per custom category, each carrying the category's
+``capabilities`` dataclass plus the public API shared by every implementation of
+that category.
+
+Protocol Hierarchy
+------------------
+
+Categories whose capability flags gate an *optional* method surface get a
+sub-protocol for that surface, so a consumer can move from ``isinstance`` on a
+concrete class to a capability flag without losing its typing basis:
+
+- ``CoverDataPointProtocol``: position + stop (``CoverCapabilities``)
+    - ``TiltCoverDataPointProtocol``: adds the tilt surface (``capabilities.tilt``)
+    - ``GarageDataPointProtocol``: adds the ventilation surface (``capabilities.vent``)
+- ``SirenDataPointProtocol``: on/off, tones, lights (``SirenCapabilities``)
+    - ``SoundPlayerDataPointProtocol``: adds the soundfile surface (``capabilities.soundfiles``)
+- ``ClimateDataPointProtocol``: ``ClimateCapabilities``
+- ``LightDataPointProtocol``: ``LightCapabilities``
+- ``LockDataPointProtocol``: ``LockCapabilities``
+
+Climate, light and lock need no sub-protocol: every surface their capability
+flags gate is already declared on the category base class.
+
+All protocols are ``@runtime_checkable``, and every category declares members
+beyond ``capabilities``, so an ``isinstance`` check discriminates between
+categories rather than merely detecting the presence of a ``capabilities``
+attribute.
+"""
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Protocol, Unpack, runtime_checkable
+
+from aiohomematic.interfaces.model import CustomDataPointProtocol
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from aiohomematic.model.custom.capabilities import (
+        ClimateCapabilities,
+        CoverCapabilities,
+        LightCapabilities,
+        LockCapabilities,
+        SirenCapabilities,
+    )
+    from aiohomematic.model.custom.climate import ClimateActivity, ClimateMode, ClimateProfile
+    from aiohomematic.model.custom.light import LightOffArgs, LightOnArgs
+    from aiohomematic.model.custom.siren import PlaySoundArgs, SirenOnArgs
+    from aiohomematic.model.data_point import CallParameterCollector
+
+__all__ = [
+    "ClimateDataPointProtocol",
+    "CoverDataPointProtocol",
+    "GarageDataPointProtocol",
+    "LightDataPointProtocol",
+    "LockDataPointProtocol",
+    "SirenDataPointProtocol",
+    "SoundPlayerDataPointProtocol",
+    "TiltCoverDataPointProtocol",
+]
+
+
+# =============================================================================
+# Climate
+# =============================================================================
+
+
+@runtime_checkable
+class ClimateDataPointProtocol(CustomDataPointProtocol, Protocol):
+    """
+    Protocol for custom climate data points.
+
+    Carries ``ClimateCapabilities`` and the public API shared by all climate
+    implementations.
+    """
+
+    __slots__ = ()
+
+    @property
+    @abstractmethod
+    def activity(self) -> ClimateActivity | None:
+        """Return the current activity."""
+
+    @property
+    @abstractmethod
+    def capabilities(self) -> ClimateCapabilities:
+        """Return the climate capabilities."""
+
+    @property
+    @abstractmethod
+    def current_humidity(self) -> int | None:
+        """Return the current humidity."""
+
+    @property
+    @abstractmethod
+    def current_temperature(self) -> float | None:
+        """Return the current temperature."""
+
+    @property
+    @abstractmethod
+    def max_temp(self) -> float:
+        """Return the maximum temperature."""
+
+    @property
+    @abstractmethod
+    def min_max_value_not_relevant_for_manu_mode(self) -> bool:
+        """Return if the min/max value is not relevant for the manual mode."""
+
+    @property
+    @abstractmethod
+    def min_temp(self) -> float:
+        """Return the minimum temperature."""
+
+    @property
+    @abstractmethod
+    def mode(self) -> ClimateMode:
+        """Return the current mode."""
+
+    @property
+    @abstractmethod
+    def modes(self) -> tuple[ClimateMode, ...]:
+        """Return the available modes."""
+
+    @property
+    @abstractmethod
+    def profile(self) -> ClimateProfile:
+        """Return the current profile."""
+
+    @property
+    @abstractmethod
+    def profiles(self) -> tuple[ClimateProfile, ...]:
+        """Return the available profiles."""
+
+    @property
+    @abstractmethod
+    def target_temperature(self) -> float | None:
+        """Return the target temperature."""
+
+    @property
+    @abstractmethod
+    def target_temperature_step(self) -> float:
+        """Return the supported step of the target temperature."""
+
+    @property
+    @abstractmethod
+    def temperature_unit(self) -> str:
+        """Return the temperature unit."""
+
+    @abstractmethod
+    async def disable_away_mode(self) -> None:
+        """Disable the away mode."""
+
+    @abstractmethod
+    async def enable_away_mode_by_calendar(self, *, start: datetime, end: datetime, away_temperature: float) -> None:
+        """Enable the away mode by calendar."""
+
+    @abstractmethod
+    async def enable_away_mode_by_duration(self, *, hours: int, away_temperature: float) -> None:
+        """Enable the away mode by duration."""
+
+    @abstractmethod
+    async def set_mode(self, *, mode: ClimateMode, collector: CallParameterCollector | None = None) -> None:
+        """Set the mode."""
+
+    @abstractmethod
+    async def set_profile(self, *, profile: ClimateProfile, collector: CallParameterCollector | None = None) -> None:
+        """Set the profile."""
+
+    @abstractmethod
+    async def set_temperature(
+        self, *, temperature: float, collector: CallParameterCollector | None = None, do_validate: bool = True
+    ) -> None:
+        """Set the target temperature."""
+
+
+# =============================================================================
+# Cover
+# =============================================================================
+
+
+@runtime_checkable
+class CoverDataPointProtocol(CustomDataPointProtocol, Protocol):
+    """
+    Protocol for custom cover data points.
+
+    Carries ``CoverCapabilities`` and the position/stop surface shared by all
+    cover implementations. The tilt and ventilation surfaces live on
+    ``TiltCoverDataPointProtocol`` and ``GarageDataPointProtocol``.
+    """
+
+    __slots__ = ()
+
+    @property
+    @abstractmethod
+    def capabilities(self) -> CoverCapabilities:
+        """Return the cover capabilities."""
+
+    @property
+    @abstractmethod
+    def current_position(self) -> int | None:
+        """Return the current position of the cover."""
+
+    @property
+    @abstractmethod
+    def is_closed(self) -> bool | None:
+        """Return if the cover is closed."""
+
+    @property
+    @abstractmethod
+    def is_closing(self) -> bool | None:
+        """Return if the cover is closing."""
+
+    @property
+    @abstractmethod
+    def is_opening(self) -> bool | None:
+        """Return if the cover is opening."""
+
+    @abstractmethod
+    async def close(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Close the cover."""
+
+    @abstractmethod
+    async def open(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Open the cover."""
+
+    @abstractmethod
+    async def set_position(
+        self,
+        *,
+        position: int | None = None,
+        tilt_position: int | None = None,
+        collector: CallParameterCollector | None = None,
+    ) -> None:
+        """Move the cover to a specific position."""
+
+    @abstractmethod
+    async def stop(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Stop the cover if in motion."""
+
+
+@runtime_checkable
+class GarageDataPointProtocol(CoverDataPointProtocol, Protocol):
+    """
+    Protocol for cover data points that support a ventilation position.
+
+    Implemented by covers whose ``capabilities.vent`` is ``True``.
+    """
+
+    __slots__ = ()
+
+    @abstractmethod
+    async def vent(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Move the cover to the ventilation position."""
+
+
+@runtime_checkable
+class TiltCoverDataPointProtocol(CoverDataPointProtocol, Protocol):
+    """
+    Protocol for cover data points that support tilt control.
+
+    Implemented by covers whose ``capabilities.tilt`` is ``True``.
+    """
+
+    __slots__ = ()
+
+    @property
+    @abstractmethod
+    def current_channel_tilt_position(self) -> int:
+        """Return the current channel tilt position of the cover."""
+
+    @property
+    @abstractmethod
+    def current_tilt_position(self) -> int:
+        """Return the current group tilt position of the cover."""
+
+    @abstractmethod
+    async def close_tilt(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Close the tilt."""
+
+    @abstractmethod
+    async def open_tilt(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Open the tilt."""
+
+    @abstractmethod
+    async def stop_tilt(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Stop the tilt if in motion."""
+
+
+# =============================================================================
+# Light
+# =============================================================================
+
+
+@runtime_checkable
+class LightDataPointProtocol(CustomDataPointProtocol, Protocol):
+    """
+    Protocol for custom light data points.
+
+    Carries ``LightCapabilities`` and the public API shared by all light
+    implementations. The color and effect surfaces are always declared; whether
+    a concrete device exposes them is answered by ``capabilities`` (static) and
+    the ``has_*`` properties (runtime, for devices with an operation mode).
+    """
+
+    __slots__ = ()
+
+    @property
+    @abstractmethod
+    def brightness(self) -> int | None:
+        """Return the brightness of the light."""
+
+    @property
+    @abstractmethod
+    def brightness_pct(self) -> int | None:
+        """Return the brightness of the light in percent."""
+
+    @property
+    @abstractmethod
+    def capabilities(self) -> LightCapabilities:
+        """Return the light capabilities."""
+
+    @property
+    @abstractmethod
+    def color_temp_kelvin(self) -> int | None:
+        """Return the color temperature in kelvin."""
+
+    @property
+    @abstractmethod
+    def effect(self) -> str | None:
+        """Return the current effect."""
+
+    @property
+    @abstractmethod
+    def effects(self) -> tuple[str, ...] | None:
+        """Return the available effects."""
+
+    @property
+    @abstractmethod
+    def group_brightness(self) -> int | None:
+        """Return the group brightness of the light."""
+
+    @property
+    @abstractmethod
+    def group_brightness_pct(self) -> int | None:
+        """Return the group brightness of the light in percent."""
+
+    @property
+    @abstractmethod
+    def has_color_temperature(self) -> bool:
+        """Return if the light currently supports color temperature."""
+
+    @property
+    @abstractmethod
+    def has_effects(self) -> bool:
+        """Return if the light currently supports effects."""
+
+    @property
+    @abstractmethod
+    def has_hs_color(self) -> bool:
+        """Return if the light currently supports hue/saturation color."""
+
+    @property
+    @abstractmethod
+    def hs_color(self) -> tuple[float, float] | None:
+        """Return the hue and saturation color value."""
+
+    @property
+    @abstractmethod
+    def is_on(self) -> bool | None:
+        """Return if the light is on."""
+
+    @property
+    @abstractmethod
+    def last_level(self) -> float | None:
+        """Return the last level of the light."""
+
+    @abstractmethod
+    def set_last_level(self, *, value: float | None) -> None:
+        """Set the last level of the light."""
+
+    @abstractmethod
+    async def turn_off(
+        self, *, collector: CallParameterCollector | None = None, **kwargs: Unpack[LightOffArgs]
+    ) -> None:
+        """Turn the light off."""
+
+    @abstractmethod
+    async def turn_on(self, *, collector: CallParameterCollector | None = None, **kwargs: Unpack[LightOnArgs]) -> None:
+        """Turn the light on."""
+
+
+# =============================================================================
+# Lock
+# =============================================================================
+
+
+@runtime_checkable
+class LockDataPointProtocol(CustomDataPointProtocol, Protocol):
+    """
+    Protocol for custom lock data points.
+
+    Carries ``LockCapabilities`` and the public API shared by all lock
+    implementations. ``open`` is declared unconditionally; whether the device
+    actually supports it is answered by ``capabilities.open``.
+    """
+
+    __slots__ = ()
+
+    @property
+    @abstractmethod
+    def capabilities(self) -> LockCapabilities:
+        """Return the lock capabilities."""
+
+    @property
+    @abstractmethod
+    def is_jammed(self) -> bool:
+        """Return if the lock is jammed."""
+
+    @property
+    @abstractmethod
+    def is_locked(self) -> bool:
+        """Return if the lock is locked."""
+
+    @property
+    @abstractmethod
+    def is_locking(self) -> bool | None:
+        """Return if the lock is locking."""
+
+    @property
+    @abstractmethod
+    def is_unlocking(self) -> bool | None:
+        """Return if the lock is unlocking."""
+
+    @abstractmethod
+    async def lock(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Lock the lock."""
+
+    @abstractmethod
+    async def open(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Open the lock."""
+
+    @abstractmethod
+    async def unlock(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Unlock the lock."""
+
+
+# =============================================================================
+# Siren
+# =============================================================================
+
+
+@runtime_checkable
+class SirenDataPointProtocol(CustomDataPointProtocol, Protocol):
+    """
+    Protocol for custom siren data points.
+
+    Carries ``SirenCapabilities`` and the public API shared by all siren
+    implementations. The soundfile surface lives on
+    ``SoundPlayerDataPointProtocol``.
+    """
+
+    __slots__ = ()
+
+    @property
+    @abstractmethod
+    def available_lights(self) -> tuple[str, ...] | None:
+        """Return the available lights."""
+
+    @property
+    @abstractmethod
+    def available_tones(self) -> tuple[str, ...] | None:
+        """Return the available tones."""
+
+    @property
+    @abstractmethod
+    def capabilities(self) -> SirenCapabilities:
+        """Return the siren capabilities."""
+
+    @property
+    @abstractmethod
+    def is_on(self) -> bool:
+        """Return if the siren is on."""
+
+    @abstractmethod
+    async def turn_off(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Turn the siren off."""
+
+    @abstractmethod
+    async def turn_on(self, *, collector: CallParameterCollector | None = None, **kwargs: Unpack[SirenOnArgs]) -> None:
+        """Turn the siren on."""
+
+
+@runtime_checkable
+class SoundPlayerDataPointProtocol(SirenDataPointProtocol, Protocol):
+    """
+    Protocol for siren data points that support soundfile playback.
+
+    Implemented by sirens whose ``capabilities.soundfiles`` is ``True``.
+    """
+
+    __slots__ = ()
+
+    @property
+    @abstractmethod
+    def available_soundfiles(self) -> tuple[str, ...] | None:
+        """Return the available soundfiles."""
+
+    @property
+    @abstractmethod
+    def current_soundfile(self) -> str | None:
+        """Return the currently selected soundfile."""
+
+    @abstractmethod
+    async def play_sound(
+        self, *, collector: CallParameterCollector | None = None, **kwargs: Unpack[PlaySoundArgs]
+    ) -> None:
+        """Play a soundfile."""
+
+    @abstractmethod
+    async def stop_sound(self, *, collector: CallParameterCollector | None = None) -> None:
+        """Stop the soundfile playback."""

--- a/aiohomematic/model/custom/climate.py
+++ b/aiohomematic/model/custom/climate.py
@@ -26,6 +26,7 @@ from aiohomematic.const import (
 from aiohomematic.decorators import inspector
 from aiohomematic.exceptions import ValidationException
 from aiohomematic.interfaces import ChannelProtocol
+from aiohomematic.interfaces.custom import ClimateDataPointProtocol
 from aiohomematic.model.custom.capabilities.climate import (
     BASIC_CLIMATE_CAPABILITIES,
     IP_THERMOSTAT_CAPABILITIES,
@@ -151,7 +152,7 @@ _HM_WEEK_PROFILE_POINTERS_TO_NAMES: Final = {
 _HM_WEEK_PROFILE_POINTERS_TO_IDX: Final = {v: k for k, v in _HM_WEEK_PROFILE_POINTERS_TO_NAMES.items()}
 
 
-class BaseCustomDpClimate(CustomDataPoint):
+class BaseCustomDpClimate(CustomDataPoint, ClimateDataPointProtocol):
     """Base Homematic climate data_point."""
 
     __slots__ = (

--- a/aiohomematic/model/custom/cover.py
+++ b/aiohomematic/model/custom/cover.py
@@ -23,6 +23,7 @@ from aiohomematic.const import (
     Parameter,
 )
 from aiohomematic.converter import convert_hm_level_to_cpv
+from aiohomematic.interfaces.custom import CoverDataPointProtocol, GarageDataPointProtocol, TiltCoverDataPointProtocol
 from aiohomematic.model.combined import CombinedGarageDoorModeField
 from aiohomematic.model.custom.capabilities.cover import (
     BLIND_CAPABILITIES,
@@ -85,7 +86,7 @@ class _StateChangeArg(StrEnum):
     VENT = "vent"
 
 
-class CustomDpCover(PositionMixin, CustomDataPoint):
+class CustomDpCover(PositionMixin, CustomDataPoint, CoverDataPointProtocol):
     """Class for Homematic cover data point."""
 
     __slots__ = (
@@ -262,7 +263,7 @@ class CustomDpWindowDrive(CustomDpCover):
         await self._dp_level.send_value(value=wd_level, collector=collector, do_validate=False)
 
 
-class CustomDpBlind(CustomDpCover):
+class CustomDpBlind(CustomDpCover, TiltCoverDataPointProtocol):
     """Class for Homematic blind data point."""
 
     __slots__ = ()  # Required to prevent __dict__ creation (descriptors are class-level)
@@ -554,7 +555,7 @@ class CustomDpIpBlind(CustomDpBlind):
         return None
 
 
-class CustomDpGarage(PositionMixin, CustomDataPoint):
+class CustomDpGarage(PositionMixin, CustomDataPoint, GarageDataPointProtocol):
     """Class for Homematic garage data point."""
 
     __slots__ = ("_cached_capabilities",)

--- a/aiohomematic/model/custom/light.py
+++ b/aiohomematic/model/custom/light.py
@@ -12,6 +12,7 @@ import math
 from typing import ClassVar, Final, TypedDict, Unpack, override
 
 from aiohomematic.const import DataPointCategory, DataPointUsage, DeviceProfile, Field, Parameter
+from aiohomematic.interfaces.custom import LightDataPointProtocol
 from aiohomematic.model.combined.field import CombinedHsColorField, CombinedTimerField
 from aiohomematic.model.custom.capabilities.light import LightCapabilities
 from aiohomematic.model.custom.data_point import CustomDataPoint
@@ -216,7 +217,7 @@ class SoundPlayerLedOnArgs(LightOnArgs, total=False):
     flash_time: int  # Flash duration in milliseconds (converted to nearest VALUE_LIST entry)
 
 
-class CustomDpDimmer(StateChangeTimerMixin, BrightnessMixin, CustomDataPoint):
+class CustomDpDimmer(StateChangeTimerMixin, BrightnessMixin, CustomDataPoint, LightDataPointProtocol):
     """Base class for Homematic light data point."""
 
     __slots__ = ("_cached_capabilities",)

--- a/aiohomematic/model/custom/lock.py
+++ b/aiohomematic/model/custom/lock.py
@@ -12,6 +12,7 @@ from typing import ClassVar, Final
 
 from aiohomematic.client import CommandPriority
 from aiohomematic.const import DataPointCategory, DeviceProfile, Field, Parameter
+from aiohomematic.interfaces.custom import LockDataPointProtocol
 from aiohomematic.model.custom.capabilities.lock import BUTTON_LOCK_CAPABILITIES, IP_LOCK_CAPABILITIES, LockCapabilities
 from aiohomematic.model.custom.data_point import CustomDataPoint
 from aiohomematic.model.custom.field import DataPointField
@@ -56,7 +57,7 @@ class LockState(StrEnum):
     UNLOCKED = "UNLOCKED"
 
 
-class BaseCustomDpLock(CustomDataPoint):
+class BaseCustomDpLock(CustomDataPoint, LockDataPointProtocol):
     """Class for HomematicIP lock data point."""
 
     __slots__ = ("_cached_capabilities",)

--- a/aiohomematic/model/custom/siren.py
+++ b/aiohomematic/model/custom/siren.py
@@ -14,6 +14,7 @@ from aiohomematic import i18n
 from aiohomematic.client import CommandPriority
 from aiohomematic.const import DataPointCategory, DeviceProfile, Field
 from aiohomematic.exceptions import ValidationException
+from aiohomematic.interfaces.custom import SirenDataPointProtocol, SoundPlayerDataPointProtocol
 from aiohomematic.model.combined.field import CombinedTimerField
 from aiohomematic.model.custom.capabilities.siren import SMOKE_SENSOR_SIREN_CAPABILITIES, SirenCapabilities
 from aiohomematic.model.custom.data_point import CustomDataPoint
@@ -87,7 +88,7 @@ class PlaySoundArgs(TypedDict, total=False):
     repetitions: int  # 0=none, 1-18=count, -1=infinite (converted to VALUE_LIST entry)
 
 
-class BaseCustomDpSiren(CustomDataPoint):
+class BaseCustomDpSiren(CustomDataPoint, SirenDataPointProtocol):
     """Class for Homematic siren data point."""
 
     __slots__ = ("_cached_capabilities",)
@@ -269,7 +270,7 @@ class CustomDpIpSirenSmoke(BaseCustomDpSiren):
         return SMOKE_SENSOR_SIREN_CAPABILITIES
 
 
-class CustomDpSoundPlayer(BaseCustomDpSiren):
+class CustomDpSoundPlayer(BaseCustomDpSiren, SoundPlayerDataPointProtocol):
     """Class for HomematicIP sound player data point (HmIP-MP3P channel 2)."""
 
     __slots__ = ()  # Required to prevent __dict__ creation (descriptors are class-level)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,39 @@
+# Version 2026.8.7 (2026-08-28)
+
+## What's Changed
+
+### Added
+
+- **`capabilities` is reachable on a category-specific protocol.** Every custom
+  category already answers what it can do through a frozen capability dataclass —
+  `CoverCapabilities`, `SirenCapabilities`, `LockCapabilities`,
+  `ClimateCapabilities`, `LightCapabilities` — but that answer was only available
+  on the concrete classes. `aiohomematic/interfaces/` carried `BackendCapabilities`
+  on the client protocol and nothing per category.
+
+  A consumer that wants to dispatch on what a device _can do_ rather than on what
+  class it _is_ therefore had to keep importing the concrete classes, which ties
+  it to one backend's class identity. The new module
+  `aiohomematic.interfaces.custom` supplies the missing typing basis: one
+  `@runtime_checkable` protocol per category, carrying that category's
+  `capabilities` plus the public API every implementation of the category shares.
+
+  Where a capability flag gates an _optional_ method surface, that surface gets
+  its own sub-protocol, so the flag and the type stay in step:
+  `TiltCoverDataPointProtocol` for `capabilities.tilt`,
+  `GarageDataPointProtocol` for `capabilities.vent`, and
+  `SoundPlayerDataPointProtocol` for `capabilities.soundfiles`. Climate, light and
+  lock need none — every surface their flags gate is already on the category base
+  class.
+
+  Each category declares members beyond `capabilities`, so an `isinstance` check
+  discriminates between categories instead of merely finding a `capabilities`
+  attribute; a new contract test pins that, the explicit inheritance, and the
+  agreement between each flag and its sub-protocol.
+
+  The change is purely additive. The concrete classes gain a protocol base and
+  keep every member they had.
+
 # Version 2026.8.6 (2026-08-28)
 
 ## What's Changed

--- a/docs/developer/consumer_api.md
+++ b/docs/developer/consumer_api.md
@@ -389,8 +389,21 @@ from aiohomematic.interfaces import (
     GenericDataPointProtocol,
     CustomDataPointProtocol,
     DataPointProviderProtocol,
+
+    # Category capability access
+    CoverDataPointProtocol,
+    SirenDataPointProtocol,
+    TiltCoverDataPointProtocol,
 )
 ```
+
+Category protocols live in `aiohomematic.interfaces.custom` and are re-exported from
+`aiohomematic.interfaces`. They carry the category's `capabilities` dataclass plus the
+API every implementation of that category shares, so a consumer can branch on a
+capability flag rather than on a concrete class. Where a flag gates an optional method
+surface, a sub-protocol carries it: `TiltCoverDataPointProtocol` (`capabilities.tilt`),
+`GarageDataPointProtocol` (`capabilities.vent`) and `SoundPlayerDataPointProtocol`
+(`capabilities.soundfiles`).
 
 ### Example: Protocol-Based Component
 

--- a/docs/reference/api/public_api.md
+++ b/docs/reference/api/public_api.md
@@ -179,6 +179,32 @@ from aiohomematic.interfaces.model import (
 )
 ```
 
+### Category capability protocols
+
+Dispatch on what a device can do instead of on which class it is. Each protocol is
+`@runtime_checkable` and carries its category's `capabilities` dataclass.
+
+```python
+from aiohomematic.interfaces.custom import (
+    ClimateDataPointProtocol,
+    CoverDataPointProtocol,
+    GarageDataPointProtocol,       # capabilities.vent
+    LightDataPointProtocol,
+    LockDataPointProtocol,
+    SirenDataPointProtocol,
+    SoundPlayerDataPointProtocol,  # capabilities.soundfiles
+    TiltCoverDataPointProtocol,    # capabilities.tilt
+)
+
+
+async def open_cover(data_point: CoverDataPointProtocol) -> None:
+    """Open a cover, using the tilt surface when the device has it."""
+    if data_point.capabilities.tilt and isinstance(data_point, TiltCoverDataPointProtocol):
+        await data_point.open_tilt()
+        return
+    await data_point.open()
+```
+
 ### Device model
 
 ```python

--- a/tests/contract/test_capability_protocol_contract.py
+++ b/tests/contract/test_capability_protocol_contract.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""
+Contract tests for the category-specific capability protocols.
+
+STABILITY GUARANTEE
+-------------------
+``aiohomematic.interfaces.custom`` exposes one ``@runtime_checkable`` protocol per
+custom category, carrying that category's ``capabilities`` dataclass plus the public
+API shared by every implementation of the category. Consumers (notably the Home
+Assistant integration) dispatch on capability flags instead of on concrete class
+identity, so both the nominal inheritance and the structural surface are part of the
+public contract. Any change that breaks these tests requires a MAJOR version bump.
+
+The contract ensures that:
+1. Every category protocol is runtime checkable and carries ``capabilities``.
+2. Every concrete custom data point class explicitly inherits its category protocol
+   (structural subtyping alone is not enough — see ADR-0002/0003).
+3. The protocols discriminate: a class satisfies only its own category's protocols.
+4. A capability flag and its sub-protocol agree (``tilt``/``vent``/``soundfiles``).
+
+See ADR-0018 for architectural context.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Protocol, cast
+
+import pytest
+
+from aiohomematic.interfaces import (
+    ClimateDataPointProtocol,
+    CoverDataPointProtocol,
+    GarageDataPointProtocol,
+    LightDataPointProtocol,
+    LockDataPointProtocol,
+    SirenDataPointProtocol,
+    SoundPlayerDataPointProtocol,
+    TiltCoverDataPointProtocol,
+)
+from aiohomematic.model.custom import (
+    CustomDataPoint,
+    CustomDpBlind,
+    CustomDpCover,
+    CustomDpGarage,
+    CustomDpIpBlind,
+    CustomDpIpSiren,
+    CustomDpSoundPlayer,
+)
+from aiohomematic_test_support.helper import get_prepared_custom_data_point
+
+# pylint: disable=protected-access
+
+COVER_TEST_DEVICES: set[str] = {"VCU0000144", "VCU1223813", "VCU3574044", "VCU8537918"}
+SIREN_TEST_DEVICES: set[str] = {"VCU1543608", "VCU8249617"}
+
+# All category protocols, base protocols first.
+CATEGORY_PROTOCOLS: tuple[type, ...] = (
+    ClimateDataPointProtocol,
+    CoverDataPointProtocol,
+    LightDataPointProtocol,
+    LockDataPointProtocol,
+    SirenDataPointProtocol,
+    GarageDataPointProtocol,
+    SoundPlayerDataPointProtocol,
+    TiltCoverDataPointProtocol,
+)
+
+# Expected explicit protocol inheritance per concrete custom data point class.
+# A class listed with a sub-protocol implicitly also carries its base protocol.
+EXPECTED_CATEGORY_PROTOCOLS: dict[str, frozenset[type]] = {
+    "CustomDpBlind": frozenset({TiltCoverDataPointProtocol}),
+    "CustomDpButtonLock": frozenset({LockDataPointProtocol}),
+    "CustomDpColorDimmer": frozenset({LightDataPointProtocol}),
+    "CustomDpColorDimmerEffect": frozenset({LightDataPointProtocol}),
+    "CustomDpColorTempDimmer": frozenset({LightDataPointProtocol}),
+    "CustomDpCover": frozenset({CoverDataPointProtocol}),
+    "CustomDpDimmer": frozenset({LightDataPointProtocol}),
+    "CustomDpGarage": frozenset({GarageDataPointProtocol}),
+    "CustomDpIpAccessPermission": frozenset(),
+    "CustomDpIpBlind": frozenset({TiltCoverDataPointProtocol}),
+    "CustomDpIpDrgDaliLight": frozenset({LightDataPointProtocol}),
+    "CustomDpIpFixedColorLight": frozenset({LightDataPointProtocol}),
+    "CustomDpIpIrrigationValve": frozenset(),
+    "CustomDpIpLock": frozenset({LockDataPointProtocol}),
+    "CustomDpIpRGBWColorTempLight": frozenset({LightDataPointProtocol}),
+    "CustomDpIpRGBWLight": frozenset({LightDataPointProtocol}),
+    "CustomDpIpSiren": frozenset({SirenDataPointProtocol}),
+    "CustomDpIpSirenSmoke": frozenset({SirenDataPointProtocol}),
+    "CustomDpIpThermostat": frozenset({ClimateDataPointProtocol}),
+    "CustomDpRfLock": frozenset({LockDataPointProtocol}),
+    "CustomDpRfThermostat": frozenset({ClimateDataPointProtocol}),
+    "CustomDpSimpleRfThermostat": frozenset({ClimateDataPointProtocol}),
+    "CustomDpSoundPlayer": frozenset({SoundPlayerDataPointProtocol}),
+    "CustomDpSoundPlayerLed": frozenset({LightDataPointProtocol}),
+    "CustomDpSwitch": frozenset(),
+    "CustomDpTextDisplay": frozenset(),
+    "CustomDpWindowDrive": frozenset({CoverDataPointProtocol}),
+}
+
+
+def _concrete_cdp_classes() -> dict[str, type[CustomDataPoint]]:
+    """Return every concrete custom data point class by name."""
+    seen: dict[str, type[CustomDataPoint]] = {}
+
+    def _walk(cls: type[CustomDataPoint]) -> None:
+        for sub in cls.__subclasses__():
+            if not inspect.isabstract(sub) and not sub.__name__.startswith("_"):
+                seen[sub.__name__] = sub
+            _walk(sub)
+
+    _walk(CustomDataPoint)
+    return seen
+
+
+def _structurally_satisfies(*, cls: type, protocol: type) -> bool:
+    """Return whether a class carries every member a runtime_checkable protocol checks."""
+    return all(hasattr(cls, attr) for attr in protocol.__protocol_attrs__)  # type: ignore[attr-defined]
+
+
+def _expected_protocols(*, name: str) -> frozenset[type]:
+    """Return the declared protocols of a class, expanded by their protocol bases."""
+    expanded: set[type] = set()
+    for protocol in EXPECTED_CATEGORY_PROTOCOLS[name]:
+        expanded.add(protocol)
+        expanded.update(base for base in protocol.__mro__ if base in CATEGORY_PROTOCOLS)
+    return frozenset(expanded)
+
+
+# =============================================================================
+# Contract: Protocol shape
+# =============================================================================
+
+
+class TestCategoryProtocolShapeContract:
+    """Contract: Every category protocol is runtime checkable and carries capabilities."""
+
+    @pytest.mark.parametrize("protocol", CATEGORY_PROTOCOLS, ids=lambda p: cast(type, p).__name__)
+    def test_protocol_carries_capabilities(self, protocol: type) -> None:
+        """Contract: capabilities is reachable on every category protocol."""
+        assert "capabilities" in protocol.__protocol_attrs__  # type: ignore[attr-defined]
+
+    @pytest.mark.parametrize("protocol", CATEGORY_PROTOCOLS, ids=lambda p: cast(type, p).__name__)
+    def test_protocol_declares_more_than_capabilities(self, protocol: type) -> None:
+        """Contract: Category protocols discriminate, so they declare a category surface."""
+        own_members = {name for name in vars(protocol) if not name.startswith("_")}
+        assert own_members - {"capabilities"}, f"{protocol.__name__} would not discriminate"
+
+    @pytest.mark.parametrize("protocol", CATEGORY_PROTOCOLS, ids=lambda p: cast(type, p).__name__)
+    def test_protocol_is_runtime_checkable(self, protocol: type) -> None:
+        """Contract: Category protocols are runtime checkable."""
+        assert issubclass(protocol, Protocol)  # type: ignore[arg-type]
+        assert getattr(protocol, "_is_runtime_protocol", False) is True
+
+
+# =============================================================================
+# Contract: Explicit inheritance and structural completeness
+# =============================================================================
+
+
+class TestCategoryProtocolInheritanceContract:
+    """Contract: Concrete custom data points explicitly inherit their category protocol."""
+
+    def test_declared_protocols_are_structurally_complete(self) -> None:
+        """Contract: A declared protocol's every member exists on the implementing class."""
+        for name, cls in _concrete_cdp_classes().items():
+            for protocol in _expected_protocols(name=name):
+                missing = [attr for attr in protocol.__protocol_attrs__ if not hasattr(cls, attr)]  # type: ignore[attr-defined]
+                assert not missing, f"{name} misses {missing} of {protocol.__name__}"
+
+    def test_every_concrete_cdp_class_is_covered(self) -> None:
+        """Contract: The expectation table covers every concrete custom data point class."""
+        assert set(_concrete_cdp_classes()) == set(EXPECTED_CATEGORY_PROTOCOLS)
+
+    def test_explicit_inheritance_matches_contract(self) -> None:
+        """Contract: The protocols in the MRO are exactly the declared ones."""
+        for name, cls in _concrete_cdp_classes().items():
+            actual = frozenset(base for base in cls.__mro__ if base in CATEGORY_PROTOCOLS)
+            assert actual == _expected_protocols(name=name), f"{name}: unexpected category protocols"
+
+    def test_protocols_discriminate_between_categories(self) -> None:
+        """Contract: A class structurally satisfies only its own category's protocols."""
+        for name, cls in _concrete_cdp_classes().items():
+            declared = _expected_protocols(name=name)
+            for protocol in CATEGORY_PROTOCOLS:
+                satisfied = _structurally_satisfies(cls=cls, protocol=protocol)
+                assert satisfied is (protocol in declared), (
+                    f"{name} vs {protocol.__name__}: isinstance would return {satisfied}"
+                )
+
+
+# =============================================================================
+# Contract: Capability flag and sub-protocol agree
+# =============================================================================
+
+
+class TestCapabilityDispatchContract:
+    """Contract: Capability flags and their sub-protocols agree on live data points."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("address_device_translation", "do_mock_client", "ignore_devices_on_create", "un_ignore_list"),
+        [(COVER_TEST_DEVICES, True, None, None)],
+    )
+    async def test_cover_capability_matches_sub_protocol(
+        self,
+        central_client_factory_with_homegear_client: Any,
+    ) -> None:
+        """Contract: capabilities.tilt/vent agree with the tilt/garage protocol."""
+        central, _, _ = central_client_factory_with_homegear_client
+        data_points = (
+            get_prepared_custom_data_point(central, "VCU8537918", 4),  # CustomDpCover
+            get_prepared_custom_data_point(central, "VCU0000144", 1),  # CustomDpBlind
+            get_prepared_custom_data_point(central, "VCU1223813", 4),  # CustomDpIpBlind
+            get_prepared_custom_data_point(central, "VCU3574044", 1),  # CustomDpGarage
+        )
+
+        for data_point in data_points:
+            assert isinstance(data_point, CoverDataPointProtocol)
+            assert data_point.capabilities.tilt is isinstance(data_point, TiltCoverDataPointProtocol)
+            assert data_point.capabilities.vent is isinstance(data_point, GarageDataPointProtocol)
+            assert not isinstance(data_point, SirenDataPointProtocol)
+
+        assert isinstance(data_points[0], CustomDpCover)
+        assert isinstance(data_points[1], CustomDpBlind)
+        assert isinstance(data_points[2], CustomDpIpBlind)
+        assert isinstance(data_points[3], CustomDpGarage)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("address_device_translation", "do_mock_client", "ignore_devices_on_create", "un_ignore_list"),
+        [(SIREN_TEST_DEVICES, True, None, None)],
+    )
+    async def test_siren_capability_matches_sub_protocol(
+        self,
+        central_client_factory_with_homegear_client: Any,
+    ) -> None:
+        """Contract: capabilities.soundfiles agrees with the sound player protocol."""
+        central, _, _ = central_client_factory_with_homegear_client
+        data_points = (
+            get_prepared_custom_data_point(central, "VCU8249617", 3),  # CustomDpIpSiren
+            get_prepared_custom_data_point(central, "VCU1543608", 2),  # CustomDpSoundPlayer
+        )
+
+        for data_point in data_points:
+            assert isinstance(data_point, SirenDataPointProtocol)
+            assert data_point.capabilities.soundfiles is isinstance(data_point, SoundPlayerDataPointProtocol)
+            assert not isinstance(data_point, CoverDataPointProtocol)
+
+        assert isinstance(data_points[0], CustomDpIpSiren)
+        assert isinstance(data_points[1], CustomDpSoundPlayer)


### PR DESCRIPTION
Closes #3367.

## Why

`capabilities` exists today as a concrete property on the custom data-point classes (`cover.py`, `climate.py`, `light.py`, `lock.py`, `siren.py`), but `aiohomematic/interfaces/` only carries `BackendCapabilities` on the **client** protocol. There is no category-specific protocol carrying `capabilities`.

A consumer that wants to dispatch on what a device *can do* rather than on what class it *is* therefore has to keep importing the concrete classes — which ties it to one backend's class identity, and makes mypy lose its narrowing basis the moment `isinstance` is replaced by a capability flag.

## What

New module `aiohomematic/interfaces/custom.py` with one `@runtime_checkable` protocol per custom category, each carrying that category's `capabilities` dataclass plus the public API every implementation of the category shares:

| Protocol | Capabilities | Gated by |
| --- | --- | --- |
| `ClimateDataPointProtocol` | `ClimateCapabilities` | — |
| `CoverDataPointProtocol` | `CoverCapabilities` | — |
| `TiltCoverDataPointProtocol` | `CoverCapabilities` | `capabilities.tilt` |
| `GarageDataPointProtocol` | `CoverCapabilities` | `capabilities.vent` |
| `LightDataPointProtocol` | `LightCapabilities` | — |
| `LockDataPointProtocol` | `LockCapabilities` | — |
| `SirenDataPointProtocol` | `SirenCapabilities` | — |
| `SoundPlayerDataPointProtocol` | `SirenCapabilities` | `capabilities.soundfiles` |

Sub-protocols exist only where a capability flag gates an *optional* method surface. Climate, light and lock need none — every surface their flags gate is already declared on the category base class.

Each category declares members beyond `capabilities`, so an `isinstance` check discriminates between categories instead of merely finding a `capabilities` attribute.

The concrete classes inherit their protocol explicitly (ADR-0002/0003: structural subtyping alone is not enough here). All protocols are re-exported from `aiohomematic.interfaces`.

## Acceptance

`capabilities` is reachable on a `@runtime_checkable` protocol per category, and mypy narrows in a sample call without a `cast`:

```python
async def dispatch_cover(data_point: CoverDataPointProtocol) -> str:
    caps = data_point.capabilities
    if caps.vent and isinstance(data_point, GarageDataPointProtocol):
        await data_point.vent()
        return "garage"
    if caps.tilt and isinstance(data_point, TiltCoverDataPointProtocol):
        await data_point.open_tilt()
        return f"blind:{data_point.current_tilt_position}"
    await data_point.open()
    return "cover"
```

Verified with `mypy --config-file pyproject.toml` (strict): no issues, no `cast`.

## Tests

New contract test `tests/contract/test_capability_protocol_contract.py` pins:

1. every category protocol is runtime checkable, carries `capabilities`, and declares more than `capabilities` (so it discriminates);
2. every concrete custom data point class explicitly inherits exactly its declared category protocols — the expectation table is checked for completeness against all concrete `CustomDataPoint` subclasses;
3. a class structurally satisfies **only** its own category's protocols, i.e. `isinstance` does not confuse a cover with a siren;
4. on live data points, `capabilities.tilt` / `.vent` / `.soundfiles` agree with the corresponding sub-protocol.

The live-dispatch part was checked with a negative control (an inverted assertion fails as expected), so it is exercising real data points rather than passing vacuously.

## Compatibility

Purely additive. The concrete classes gain a protocol base and keep every member they had. No public API is renamed or removed.

## Verification

- `pytest tests/` — 3979 passed, 1 skipped
- `prek run --all-files` — all hooks pass (mypy strict, pylint, ruff, docs drift, export lint)
- `changelog.md` and `aiohomematic/const.py:VERSION` bumped to `2026.8.7`

Precondition for SukramJ/homematicip_local#1266.