### PR TITLE
fix(model): scope CUxD addresses by central in generate_unique_id

### DIFF
--- a/aiohomematic/model/support.py
+++ b/aiohomematic/model/support.py
@@ -59,6 +59,17 @@ __all__ = [
 
 _LOGGER: Final = logging.getLogger(__name__)
 
+# Address prefix of CCU-internal addresses (e.g. INT0001234). They repeat verbatim on
+# every CCU, so their parameter-level unique_id is namespaced by the central.
+_INTERNAL_ADDRESS_PREFIX: Final = "INT000"
+
+# Address prefix of CUxD devices (e.g. CUX2801001). CUxD hands out the same synthetic
+# addresses on every CCU it runs on, so - like the internal and virtual-remote families -
+# their parameter-level unique_id is namespaced by the central. Without it, two CCUs
+# bridged into one Home Assistant declare identical unique_ids and Home Assistant drops
+# one CCU's entities, permanently once the payload is retained.
+_CUXD_ADDRESS_PREFIX: Final = "CUX"
+
 # dict with binary_sensor relevant value lists and the corresponding TRUE value
 _BINARY_SENSOR_TRUE_VALUE_DICT_FOR_VALUE_LIST: Final[Mapping[tuple[str, ...], str]] = {
     ("CLOSED", "OPEN"): "OPEN",
@@ -491,7 +502,8 @@ def generate_unique_id(
     """
     Build unique identifier from address and parameter.
 
-    Central id is additionally used for heating groups.
+    The central id is prepended for every address family that repeats verbatim across
+    CCUs: the hub pseudo-addresses, internal addresses, virtual remotes and CUxD.
     Prefix is used for events and buttons.
     """
     unique_id = address.replace(ADDRESS_SEPARATOR, "_").replace("-", "_")
@@ -502,7 +514,7 @@ def generate_unique_id(
         unique_id = f"{prefix}_{unique_id}"
     if (
         address in (HUB_ADDRESS, INSTALL_MODE_ADDRESS, PROGRAM_ADDRESS, SYSVAR_ADDRESS)
-        or address.startswith("INT000")
+        or address.startswith((_INTERNAL_ADDRESS_PREFIX, _CUXD_ADDRESS_PREFIX))
         or address.split(ADDRESS_SEPARATOR, maxsplit=1)[0] in VIRTUAL_REMOTE_ADDRESSES
     ):
         return f"{config_provider.config.central_id}_{unique_id}".lower()

--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,34 @@
   The change is purely additive. The concrete classes gain a protocol base and
   keep every member they had.
 
+### Fixed
+
+- **CUxD addresses are scoped by the central in `generate_unique_id`.**
+  ⚠️ **Breaking:** this re-keys the CUxD entities of every installation on
+  upgrade, including direct-CCU installations. See the migration guide
+  `docs/migrations/cuxd_unique_id_scoping_migration_2026_08.md`.
+
+  `generate_unique_id` namespaces a key with the central id for the hub
+  pseudo-addresses, for `INT000*` and for the virtual-remote roots — every
+  address family that repeats verbatim from CCU to CCU. CUxD is such a family
+  and was missing from the list.
+
+  CUxD hands out the same synthetic addresses on every CCU it runs on;
+  `CUX2801001` exists on practically every installation that runs it. Two CCUs
+  bridged into one Home Assistant therefore declared identical CUxD
+  `unique_id`s, and Home Assistant keeps whichever arrived first and drops the
+  other CCU's entities — permanently, once the payload is retained. The
+  `openccu-loom` backend already scoped CUxD and carried the gap as a declared
+  divergence from this library, with a retirement condition pointing here.
+
+  `generate_channel_unique_id` is deliberately unchanged: it namespaces the
+  virtual-remote roots only, on both sides. Scoping channel ids as well would
+  break parity in the other direction.
+
+  A new contract test pins the full cross-implementation golden set — the
+  address fold, the parameter append, the prefix order, the lowercasing, and
+  exactly which address families are scoped at parameter and at channel level.
+
 # Version 2026.8.6 (2026-08-28)
 
 ## What's Changed

--- a/docs/migrations/cuxd_unique_id_scoping_migration_2026_08.md
+++ b/docs/migrations/cuxd_unique_id_scoping_migration_2026_08.md
@@ -1,0 +1,118 @@
+# CUxD unique_id Scoping Migration Guide (2026.08)
+
+## Overview
+
+`generate_unique_id` now namespaces CUxD addresses with the central id, the same way
+it already namespaced the hub pseudo-addresses, the `INT000*` internal addresses and
+the virtual-remote roots.
+
+CUxD hands out the same synthetic addresses on every CCU it runs on — `CUX2801001`
+exists on practically every installation that runs CUxD. Two CCUs bridged into one
+Home Assistant therefore declared identical CUxD `unique_id`s. Home Assistant keeps
+whichever entity arrived first and drops the other CCU's entities, permanently once
+the payload is retained.
+
+This is **not** an additive change. It re-keys the CUxD entities of every installation
+on upgrade, including direct-CCU installations.
+
+Only the **parameter-level** key changes. `generate_channel_unique_id` is unchanged:
+it namespaces the virtual-remote roots only, and did so for CUxD neither before nor
+after this change.
+
+## Breaking Changes
+
+### `generate_unique_id` prepends the central id for `CUX*` addresses
+
+**Before:**
+
+```python
+generate_unique_id(config_provider=central, address="CUX2801001:1", parameter="STATE")
+# "cux2801001_1_state"
+```
+
+**After:**
+
+```python
+generate_unique_id(config_provider=central, address="CUX2801001:1", parameter="STATE")
+# "<central_id>_cux2801001_1_state"
+```
+
+The prefix argument keeps its position — the central id is prepended last:
+
+```python
+generate_unique_id(
+    config_provider=central, address="CUX2801001:1", parameter="STATE", prefix="calculated"
+)
+# "<central_id>_calculated_cux2801001_1_state"
+```
+
+### Unchanged: `generate_channel_unique_id`
+
+```python
+generate_channel_unique_id(config_provider=central, address="CUX2801001:1")
+# "cux2801001_1"   (before and after)
+```
+
+## Migration Steps
+
+### Consumers that persist `unique_id` (Home Assistant integrations)
+
+A registry migration pass is required. Without it, CUxD entities are orphaned together
+with their history and every automation that references them.
+
+`homematicip_local` already runs two `async_migrate_entries` passes
+(`_async_migrate_loom_unique_ids`, `_async_migrate_aiohomematic_hub_unique_ids`).
+Neither covers the direct-CCU CUxD path; a third pass is needed. It must be
+idempotent, because the migration runs on every config-entry load.
+
+Shape of the rewrite:
+
+| Old `unique_id`                 | New `unique_id`                              |
+| ------------------------------- | -------------------------------------------- |
+| `cux2801001_1_state`            | `<central_id>_cux2801001_1_state`            |
+| `calculated_cux2801001_1_state` | `<central_id>_calculated_cux2801001_1_state` |
+
+Guard the pass so an id that already carries the central prefix is left alone.
+
+### Consumers that only route events
+
+No action. The routing key is recomputed from the address on both ends, so it stays
+consistent as long as every implementation ships the same rule in the same release
+wave.
+
+### Other implementations of the routing key
+
+The rule is rebuilt independently in several places. All of them must ship this change
+together, or events route to entities that no longer exist:
+
+- `openccu-loom` (Go) — already scopes CUxD; it pinned the difference as a declared
+  divergence in `notes/parity/by_design.md` (`BD-Identity-CUxDCentralScoping`) with
+  fixtures that fail once the divergence disappears. Its CUxD cases have to be folded
+  into the shared fixtures and the divergence entry deleted.
+- `aiohomematic-contract` — the shared golden fixtures and the reference algorithm
+  (`unique_id.py`, `data/unique_id_golden.json`) still encode the unscoped rule.
+- `py-openccu-loom-client` — consumes the contract package.
+
+## Search-and-Replace Patterns
+
+There is no source-level pattern to replace: the change is entirely inside
+`generate_unique_id`. What has to be found instead are **persisted** ids.
+
+```bash
+# Home Assistant entity registry: CUxD ids that are not yet central-scoped.
+grep -o '"unique_id": "[^"]*cux[0-9]\{7\}[^"]*"' .storage/core.entity_registry
+
+# Test fixtures / recorded sessions carrying CUxD unique ids.
+grep -rn "cux[0-9]\{7\}_" tests/
+```
+
+## Compatibility Notes
+
+- `aiohomematic/model/support.py:generate_unique_id` is the only changed function.
+- The channel-level key, the address fold (`:` and `-` → `_`), the parameter append,
+  the prefix prepend and the final lowercasing are all unchanged.
+- The full cross-implementation golden set — including the newly scoped CUxD cases —
+  is pinned by `tests/contract/test_unique_id_routing_key_contract.py`.
+- ⚠️ Unmeasured: whether CUxD devices occur in production installations at all, and in
+  what numbers. The divergence between the implementations is verified in the source
+  trees; its practical blast radius is not.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -18,8 +18,9 @@ aiohomematic follows these principles for breaking changes:
 
 ### 2026.x
 
-| Version | Change | Migration |
-| ------- | ------ | --------- |
+| Version  | Change                                     | Migration                                                             |
+| -------- | ------------------------------------------ | --------------------------------------------------------------------- |
+| 2026.8.7 | CUxD `unique_id`s are scoped by central id | [CUxD unique_id scoping](cuxd_unique_id_scoping_migration_2026_08.md) |
 
 ### 2025.x
 

--- a/tests/contract/test_unique_id_routing_key_contract.py
+++ b/tests/contract/test_unique_id_routing_key_contract.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""
+Contract tests for the unique_id routing key.
+
+STABILITY GUARANTEE
+-------------------
+The ``unique_id`` is the routing key for every Home Assistant value-change
+subscription. Several implementations rebuild it independently -- ``aiohomematic``,
+``py-openccu-loom-client`` and the Go ``openccu-loom`` daemon -- and they MUST produce
+bit-identical output, otherwise events route to the wrong entity (or to no entity) and
+Home Assistant loses entity history on cutover.
+
+The cases below are the cross-implementation golden set. Any change to them re-keys
+existing Home Assistant entities and therefore requires a coordinated release across
+every implementation plus a registry migration in the integration.
+
+Rules pinned here:
+1. ``:`` and ``-`` fold to ``_`` in the *address*; a ``-`` inside a *parameter*
+   survives (hub slugs).
+2. An optional parameter is appended, an optional prefix is prepended, and the
+   central id is prepended last.
+3. The parameter-level key is namespaced by the central for every address family
+   that repeats verbatim across CCUs: the hub pseudo-addresses, ``INT000*``,
+   the virtual-remote roots, and CUxD (``CUX*``).
+4. The channel-level key is namespaced by the central for the virtual-remote roots
+   **only** -- not for hub, internal or CUxD addresses.
+5. The whole result is lowercased.
+
+See ADR-0018 for architectural context.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from aiohomematic.model.support import generate_channel_unique_id, generate_unique_id
+
+# (central_id, address, parameter, prefix, expected)
+UNIQUE_ID_CASES: tuple[tuple[str, str, str | None, str | None, str], ...] = (
+    # Plain device addresses are not namespaced.
+    ("1234", "VCU1234567:1", "STATE", None, "vcu1234567_1_state"),
+    ("1234", "VCU1234567:1", None, None, "vcu1234567_1"),
+    ("1234", "VCU1234567:0", None, None, "vcu1234567_0"),
+    ("1234", "VCU1234567:3", None, None, "vcu1234567_3"),
+    ("1234", "ABC-DEF:2", "LEVEL", None, "abc_def_2_level"),
+    # Internal addresses are namespaced.
+    ("1234", "INT0001234:1", "LEVEL", None, "1234_int0001234_1_level"),
+    ("1234", "INT0001234:2", "LEVEL", None, "1234_int0001234_2_level"),
+    ("1234", "INT0001234:1", "X", "event", "1234_event_int0001234_1_x"),
+    # Hub pseudo-addresses are namespaced.
+    ("ccu3", "hub", "STATUS", None, "ccu3_hub_status"),
+    ("ccu3", "install_mode", "ACTIVE", None, "ccu3_install_mode_active"),
+    ("ccu3", "program", "RUN", None, "ccu3_program_run"),
+    ("ccu3", "program", "my_prog", None, "ccu3_program_my_prog"),
+    ("ccu3", "sysvar", "VALUE", None, "ccu3_sysvar_value"),
+    ("ccu3", "sysvar", "my_var", None, "ccu3_sysvar_my_var"),
+    # A "-" inside the parameter survives the fold.
+    ("ccu3", "sysvar", "aussen-temperatur", None, "ccu3_sysvar_aussen-temperatur"),
+    # Virtual remotes are namespaced.
+    ("ccu3", "BidCoS-RF:1", "PRESS_SHORT", None, "ccu3_bidcos_rf_1_press_short"),
+    ("ccu3", "HmIP-RCV-1:2", "PRESS_LONG", None, "ccu3_hmip_rcv_1_2_press_long"),
+    # Prefixes.
+    ("1234", "VCU1234567:1", "PRESS_SHORT", "event", "event_vcu1234567_1_press_short"),
+    ("1234", "VCU1234567:0", "BUTTON", "btn", "btn_vcu1234567_0_button"),
+    ("1234", "VCU1234567", "WEEK_PROFILE", "week_profile", "week_profile_vcu1234567_week_profile"),
+    (
+        "1234",
+        "VCU1234567",
+        "SCHEDULE_CHANNEL_LOCK_1_1",
+        "schedule_channel_switch",
+        "schedule_channel_switch_vcu1234567_schedule_channel_lock_1_1",
+    ),
+    # CUxD hands out the same synthetic addresses on every CCU, so it is namespaced.
+    ("1234", "CUX2801001:1", "STATE", None, "1234_cux2801001_1_state"),
+    ("ccu3", "CUX0300001:2", "LEVEL", None, "ccu3_cux0300001_2_level"),
+    ("1234", "CUX2801001:1", "STATE", "calculated", "1234_calculated_cux2801001_1_state"),
+    ("1234", "CUX2801001", None, None, "1234_cux2801001"),
+)
+
+# (central_id, address, expected)
+CHANNEL_UNIQUE_ID_CASES: tuple[tuple[str, str, str], ...] = (
+    ("ccu3", "VCU1234567:1", "vcu1234567_1"),
+    ("ccu3", "VCU1234567:0", "vcu1234567_0"),
+    ("ccu3", "VCU1234567", "vcu1234567"),
+    ("ccu3", "ABC-DEF:2", "abc_def_2"),
+    # Virtual remotes are the only family namespaced at channel level.
+    ("ccu3", "BidCoS-RF:1", "ccu3_bidcos_rf_1"),
+    ("ccu3", "HmIP-RCV-1:2", "ccu3_hmip_rcv_1_2"),
+    # Hub, internal and CUxD channel ids stay unscoped.
+    ("ccu3", "INT0001234:1", "int0001234_1"),
+    ("1234", "CUX2801001:1", "cux2801001_1"),
+    ("1234", "CUX2801001", "cux2801001"),
+)
+
+
+def _config_provider(*, central_id: str) -> SimpleNamespace:
+    """Return a minimal config provider carrying only the central id."""
+    return SimpleNamespace(config=SimpleNamespace(central_id=central_id))
+
+
+# =============================================================================
+# Contract: parameter-level routing key
+# =============================================================================
+
+
+class TestUniqueIdRoutingKeyContract:
+    """Contract: generate_unique_id matches the cross-implementation golden set."""
+
+    @pytest.mark.parametrize(
+        ("central_id", "address", "parameter", "prefix", "expected"),
+        UNIQUE_ID_CASES,
+        ids=[f"{case[1]}|{case[2]}|{case[3]}" for case in UNIQUE_ID_CASES],
+    )
+    def test_unique_id_matches_golden(
+        self, central_id: str, address: str, parameter: str | None, prefix: str | None, expected: str
+    ) -> None:
+        """Contract: The parameter-level routing key is byte-identical to the golden set."""
+        assert (
+            generate_unique_id(
+                config_provider=_config_provider(central_id=central_id),  # type: ignore[arg-type]
+                address=address,
+                parameter=parameter,
+                prefix=prefix,
+            )
+            == expected
+        )
+
+
+# =============================================================================
+# Contract: channel-level routing key
+# =============================================================================
+
+
+class TestChannelUniqueIdRoutingKeyContract:
+    """Contract: generate_channel_unique_id matches the cross-implementation golden set."""
+
+    @pytest.mark.parametrize(
+        ("central_id", "address", "expected"),
+        CHANNEL_UNIQUE_ID_CASES,
+        ids=[case[1] for case in CHANNEL_UNIQUE_ID_CASES],
+    )
+    def test_channel_unique_id_matches_golden(self, central_id: str, address: str, expected: str) -> None:
+        """Contract: The channel-level routing key is byte-identical to the golden set."""
+        assert (
+            generate_channel_unique_id(
+                config_provider=_config_provider(central_id=central_id),  # type: ignore[arg-type]
+                address=address,
+            )
+            == expected
+        )
+
+
+# =============================================================================
+# Contract: central scoping families
+# =============================================================================
+
+
+class TestCentralScopingFamiliesContract:
+    """Contract: Exactly the repeating address families are namespaced by the central."""
+
+    @pytest.mark.parametrize("address", ["hub", "install_mode", "program", "sysvar", "INT0001234:1", "CUX2801001:1"])
+    def test_only_virtual_remotes_are_scoped_at_channel_level(self, address: str) -> None:
+        """Contract: Channel-level keys carry the central id for virtual remotes only."""
+        channel_unique_id = generate_channel_unique_id(
+            config_provider=_config_provider(central_id="ccu3"),  # type: ignore[arg-type]
+            address=address,
+        )
+        assert not channel_unique_id.startswith("ccu3_"), address
+
+    @pytest.mark.parametrize(
+        "address",
+        ["hub", "install_mode", "program", "sysvar", "INT0001234:1", "BidCoS-RF:1", "HmIP-RCV-1:2", "CUX2801001:1"],
+    )
+    def test_scoped_families_carry_the_central_id(self, address: str) -> None:
+        """Contract: Repeating address families carry the central id at parameter level."""
+        unique_id = generate_unique_id(
+            config_provider=_config_provider(central_id="ccu3"),  # type: ignore[arg-type]
+            address=address,
+            parameter="X",
+        )
+        assert unique_id.startswith("ccu3_"), address
+
+    @pytest.mark.parametrize("address", ["VCU1234567:1", "ABC-DEF:2", "OEQ1860891:1"])
+    def test_unscoped_families_do_not_carry_the_central_id(self, address: str) -> None:
+        """Contract: Real device addresses are unique per CCU and stay unscoped."""
+        unique_id = generate_unique_id(
+            config_provider=_config_provider(central_id="ccu3"),  # type: ignore[arg-type]
+            address=address,
+            parameter="X",
+        )
+        assert not unique_id.startswith("ccu3_"), address

--- a/tests/test_naming_and_unique_id.py
+++ b/tests/test_naming_and_unique_id.py
@@ -91,6 +91,40 @@ class TestUniqueIdPatterns:
         ("address_device_translation", "do_mock_client", "ignore_devices_on_create", "un_ignore_list"),
         [({}, True, None, None)],
     )
+    async def test_unique_id_pattern_cuxd_addresses(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """
+        Test unique_id pattern for CUxD addresses: {central_id}_{address}_{parameter}.
+
+        CUxD hands out the same synthetic addresses on every CCU it runs on, so two
+        bridged CCUs would otherwise declare identical unique_ids.
+        """
+        central, _, _ = central_client_factory_with_homegear_client
+        central_id = central.config.central_id
+
+        uid = generate_unique_id(config_provider=central, address="CUX2801001", parameter="STATE")
+        assert uid == f"{central_id}_cux2801001_state"
+
+        uid = generate_unique_id(config_provider=central, address="CUX2801001:1", parameter="STATE")
+        assert uid == f"{central_id}_cux2801001_1_state"
+
+        uid = generate_unique_id(
+            config_provider=central, address="CUX2801001:1", parameter="PRESS_SHORT", prefix="event"
+        )
+        assert uid == f"{central_id}_event_cux2801001_1_press_short"
+
+        # Channel unique_ids stay unscoped - the Go reference scopes CUxD only at
+        # parameter level (GenerateChannelUniqueID namespaces virtual remotes only).
+        uid = generate_channel_unique_id(config_provider=central, address="CUX2801001:1")
+        assert uid == "cux2801001_1"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("address_device_translation", "do_mock_client", "ignore_devices_on_create", "un_ignore_list"),
+        [({}, True, None, None)],
+    )
     async def test_unique_id_pattern_internal_addresses(
         self,
         central_client_factory_with_homegear_client,


### PR DESCRIPTION
Closes #3369.

> ⚠️ **This is not an additive change.** It re-keys the CUxD entities of every installation on upgrade, including **direct-CCU** installations. See *Follow-up required* below.

## Why

`generate_unique_id` (`aiohomematic/model/support.py`) namespaces a key with the central id for every address family that repeats verbatim from CCU to CCU — the hub pseudo-addresses, `INT000*`, and the virtual-remote roots. CUxD is such a family and was missing from the list.

CUxD hands out the same synthetic addresses on every CCU it runs on; `CUX2801001` exists on practically every installation that runs it. Two CCUs bridged into one Home Assistant therefore declared identical CUxD `unique_id`s — Home Assistant keeps whichever arrived first and drops the other CCU's entities, permanently once the payload is retained.

`openccu-loom` already scopes CUxD and carried the gap as a declared divergence from this library (`notes/parity/by_design.md` → `BD-Identity-CUxDCentralScoping`) with a retirement condition pointing here.

## What

One condition in `generate_unique_id`. The `INT000` literal and the new `CUX` prefix are lifted to module-private `Final` constants carrying the reason:

```python
if (
    address in (HUB_ADDRESS, INSTALL_MODE_ADDRESS, PROGRAM_ADDRESS, SYSVAR_ADDRESS)
    or address.startswith((_INTERNAL_ADDRESS_PREFIX, _CUXD_ADDRESS_PREFIX))
    or address.split(ADDRESS_SEPARATOR, maxsplit=1)[0] in VIRTUAL_REMOTE_ADDRESSES
):
```

`generate_channel_unique_id` is deliberately **unchanged**: the Go side scopes CUxD in `needsCentralPrefix` (the parameter-level key), while `GenerateChannelUniqueID` namespaces virtual remotes only — exactly as this library does. Scoping channel ids as well would break parity in the other direction.

Every expected value in this PR was read out of the source of record rather than derived: `openccu-loom/internal/routingkey/uniqueid.go` (`cuxdAddressPrefix = "CUX"`, `needsCentralPrefix`, `GenerateUniqueID`) and the golden fixtures under `openccu-loom/tests/contract/testdata/routing_key/`.

## Acceptance

| Call | Result |
| --- | --- |
| `generate_unique_id(address="CUX2801001", parameter="STATE")` | `<central_id>_cux2801001_state` |
| `generate_unique_id(address="CUX2801001:1", parameter="STATE")` | `<central_id>_cux2801001_1_state` |
| `generate_unique_id(address="CUX2801001:1", parameter="STATE", prefix="calculated")` | `<central_id>_calculated_cux2801001_1_state` |
| `generate_channel_unique_id(address="CUX2801001:1")` | `cux2801001_1` (unchanged) |

These match `cuxd_scoping_golden.json`'s `expected` column byte for byte.

## Tests

Test-first: the reproducer in `tests/test_naming_and_unique_id.py` was written before the fix and failed with `assert 'cux2801001_state' == 'test1234_cux2801001_state'`.

New `tests/contract/test_unique_id_routing_key_contract.py` pins the full cross-implementation golden set — all 21 shared cases from `unique_id_golden.json`, all 6 from `channel_unique_id_golden.json`, plus the 4 CUxD cases in their now-scoped form — and asserts which address families are scoped at parameter level and at channel level.

Negative control: reverting only the `startswith` change makes exactly the 5 CUxD-related cases fail and nothing else.

- `pytest tests/` — 4031 passed, 1 skipped
- `prek run --all-files` — all hooks pass

## Follow-up required (outside this repository)

The routing key is rebuilt independently in several places. They must ship in the same release wave, or events route to entities that no longer exist:

1. **`homematicip_local`** — a third `async_migrate_entries` pass. The two existing passes (`_async_migrate_loom_unique_ids`, `_async_migrate_aiohomematic_hub_unique_ids`) do not cover the direct-CCU CUxD path. Without it, CUxD entities are orphaned with their history and every automation referencing them. Tracked in SukramJ/openccu-loom-client#126.
2. **`openccu-loom`** — fold the CUxD cases into the shared fixtures and delete the `BD-Identity-CUxDCentralScoping` entry. Its guards fail on the same run once the divergence disappears, so `make routing-key-parity` goes red the moment this lands without a companion PR.
3. **`aiohomematic-contract`** *(not listed in the issue)* — the published package `aiohomematic-contract` (github.com/sukramj/aiohomematic-contract, seen at 2026.6.1) holds the shared golden fixtures and a reference implementation `unique_id.py` whose docstring still states *"internal addresses (`INT000*`) and virtual-remote addresses are prefixed with the `central_id`; all other addresses are not"*, and `data/unique_id_golden.json` encodes that. `py-openccu-loom-client` consumes it. It is **not** a dependency of this repo, so nothing here breaks — but it becomes a third source of drift.

Migration guide: `docs/migrations/cuxd_unique_id_scoping_migration_2026_08.md`.

## Version

`changelog.md` extends the existing, untagged `2026.8.7` entry; `VERSION` stays `2026.8.7`.

## Unmeasured

Whether CUxD devices occur in production installations at all, and in what numbers. The divergence between the implementations is verified in both source trees; its practical blast radius is not.