### PR TITLE
Key system variables and programs on their id, not their name (2026.8.8)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         files: ^(docs/.+\.md|aiohomematic/central/events/.+\.py)$
         pass_filenames: false
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.16.1
+    rev: v0.16.5
     hooks:
       - id: ruff
         args:

--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.8.7"
+VERSION: Final = "2026.8.8"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/model/hub/data_point.py
+++ b/aiohomematic/model/hub/data_point.py
@@ -78,7 +78,7 @@ class GenericHubDataPoint(CallbackDataPoint, GenericHubDataPointProtocol):
         unique_id: Final = generate_unique_id(
             config_provider=config_provider,
             address=address,
-            parameter=slugify(data.legacy_name),
+            parameter=self._routing_key_parameter(data=data),
         )
         self._legacy_name = data.legacy_name
         self._channel = channel_lookup.identify_channel(text=data.legacy_name)
@@ -98,6 +98,22 @@ class GenericHubDataPoint(CallbackDataPoint, GenericHubDataPointProtocol):
         self._enabled_default: Final = data.enabled_default
         self._state_uncertain: bool = True
         self._primary_client_provider: Final = primary_client_provider
+
+    @staticmethod
+    def _routing_key_parameter(*, data: HubData) -> str:
+        """
+        Return the parameter slot of this data point's routing key.
+
+        The slug of the display name, which is right for the hub data points
+        whose name is a module constant — alarm and service messages, the
+        inbox, metrics, connectivity, install mode. None of those can be
+        renamed, so none of them can be re-keyed.
+
+        System variables and programs can be renamed in the CCU WebUI, and
+        both carry a stable id, so they override this. See
+        :meth:`GenericSysvarDataPoint._routing_key_parameter`.
+        """
+        return slugify(data.legacy_name)
 
     available = DelegatedProperty[bool](path="_central_info.available")
     channel: Final = DelegatedProperty[ChannelProtocol | None](path="_channel")
@@ -173,6 +189,22 @@ class GenericSysvarDataPoint(GenericHubDataPoint, GenericSysvarDataPointProtocol
         self._current_value: SYSVAR_TYPE = data.value
         self._previous_value: SYSVAR_TYPE = None
         self._unconfirmed_value: SYSVAR_TYPE = None
+
+    @staticmethod
+    def _routing_key_parameter(*, data: HubData) -> str:
+        """
+        Key a system variable on its CCU variable id, not on its name.
+
+        The id survives a rename in the CCU WebUI; the name does not, and a
+        key built from the name takes the entity's history, area,
+        customisations and every automation with it whenever somebody tidies
+        up their variable names.
+
+        Falls back to the slug when the id is empty, which is what a client
+        rebuilding the key must also do while an id is still unresolved.
+        """
+        vid = getattr(data, "vid", "")
+        return slugify(vid) if vid else slugify(data.legacy_name)
 
     is_extended: Final = DelegatedProperty[bool](path="_is_extended")
     max: Final = DelegatedProperty[float | int | None](path="_max")
@@ -313,6 +345,17 @@ class GenericProgramDataPoint(GenericHubDataPoint, GenericProgramDataPointProtoc
         self._last_execute_time: str = data.last_execute_time
         self._state_uncertain: bool = True
         self._hub_data_fetcher: Final = hub_data_fetcher
+
+    @staticmethod
+    def _routing_key_parameter(*, data: HubData) -> str:
+        """
+        Key a program on its CCU program id, not on its name.
+
+        Same reasoning as :meth:`GenericSysvarDataPoint._routing_key_parameter`
+        — a program is renameable in the WebUI and carries a stable id.
+        """
+        pid = getattr(data, "pid", "")
+        return slugify(pid) if pid else slugify(data.legacy_name)
 
     is_active: Final = DelegatedProperty[bool](path="_is_active")
     is_internal: Final = DelegatedProperty[bool](path="_is_internal")

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,44 @@
+# Version 2026.8.8 (2026-08-29)
+
+## What's Changed
+
+### Fixed
+
+- **System variables and programs are keyed on their id, not on their name.**
+  Renaming a system variable or a program in the CCU WebUI re-keyed its Home
+  Assistant entity, which took its history, its area, its customisations and
+  every automation built on it. The person who tidies up their variable names
+  was the one who lost.
+
+  `GenericHubDataPoint` built the routing key from `slugify(legacy_name)` for
+  every hub data point. That is right for the ones whose name is a module
+  constant — alarm and service messages, the inbox, metrics, connectivity,
+  install mode — because none of those can be renamed. It was wrong for the
+  two families that can be, and both already carried a stable id:
+  `SystemVariableData.vid` and `ProgramData.pid`.
+
+  The parameter slot is an overridable hook now, and those two subclasses
+  override it. Each falls back to the slug when the id is empty, so a backend
+  that has not resolved an id yet still produces a key, and a client rebuilding
+  one can accept both shapes during a rollover.
+
+  **Every system variable and program entity re-keys once on this upgrade.**
+  That is the price of ending a re-key that happened on every rename, and it
+  needs the matching registry migration in `homematicip_local` to ship
+  alongside — without it those entities orphan instead of moving.
+
+  The mapping had no test. The routing-key function was covered thoroughly;
+  nothing asserted which value a sysvar or a program put into it, which is how
+  a key built from a renameable name survived this long. Four cases cover it
+  now, including both fallbacks.
+
+### Changed
+
+- Routine dependency and tooling bumps: `pydantic>=2.13.5`, `coverage` 7.16.0,
+  `prek` 0.5.0, `pymdown-extensions` 11.0.2, `pytest-rerunfailures` 16.6,
+  `pytest-socket` 0.8.1, `uv` 0.12.7, and `ruff` 0.16.5 in both the pinned
+  requirements and the pre-commit revision.
+
 # Version 2026.8.7 (2026-08-28)
 
 ## What's Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.14.3
 openccu-data>=2026.7.2
-pydantic>=2.13.4
+pydantic>=2.13.5
 python-slugify>=8.0.4
 # orjson is optional - see pyproject.toml [project.optional-dependencies]
 # Install with: pip install aiohomematic[fast]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,25 +2,25 @@
 -r requirements_test_pre_commit.txt
 # Note: requirements_docs.txt excluded - not needed for tests
 
-coverage==7.15.4
+coverage==7.16.0
 freezegun==1.5.5
 mypy==2.3.1
 pip==26.2.1
-prek==0.4.13
+prek==0.5.0
 pur==7.4.0
 pydevccu==0.2.6
 pylint-per-file-ignores==3.2.1
 pylint-strict-informational==0.1
 pylint==4.0.7
-pymdown-extensions==11.0.1
+pymdown-extensions==11.0.2
 pyspelling==2.12.1
 pytest-aiohttp==1.1.1
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0
-pytest-rerunfailures==16.5
-pytest-socket==0.8.0
+pytest-rerunfailures==16.6
+pytest-socket==0.8.1
 pytest-timeout==2.4.0
 pytest-xdist==3.8.0
 pytest==9.1.1
 types-python-slugify==8.0.2.20240310
-uv==0.12.5
+uv==0.12.7

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 bandit==1.9.4
 codespell==2.4.3
 python-typing-update==v0.8.1
-ruff==0.16.3
+ruff==0.16.5
 yamllint==1.38.0

--- a/tests/test_naming_and_unique_id.py
+++ b/tests/test_naming_and_unique_id.py
@@ -11,7 +11,8 @@ This module verifies the exact patterns and rules for:
 
 import pytest
 
-from aiohomematic.const import ADDRESS_SEPARATOR
+from aiohomematic.const import ADDRESS_SEPARATOR, HubData, ProgramData, SystemVariableData
+from aiohomematic.model.hub import GenericHubDataPoint, GenericProgramDataPoint, GenericSysvarDataPoint
 from aiohomematic.model.support import (
     ChannelNameData,
     DataPointNameData,
@@ -674,3 +675,49 @@ class TestNamingWithMockedDeviceDetails:
             assert device_name in dp.full_name, (
                 f"DataPoint {dp.unique_id} full_name should contain device_name={device_name}, got {dp.full_name}"
             )
+
+
+class TestHubRoutingKeyParameter:
+    """
+    Which value a hub data point puts in the routing key's parameter slot.
+
+    The routing-key *function* was covered; this mapping was not, which is how
+    system variables and programs came to be keyed on a name the CCU WebUI can
+    change. A rename then took the entity's history, area, customisations and
+    every automation built on it — see #3371.
+    """
+
+    @staticmethod
+    def _program(*, legacy_name: str, pid: str) -> ProgramData:
+        return ProgramData(legacy_name=legacy_name, pid=pid, is_active=True, is_internal=False, last_execute_time="")
+
+    @staticmethod
+    def _sysvar(*, legacy_name: str, vid: str) -> SystemVariableData:
+        return SystemVariableData(legacy_name=legacy_name, vid=vid, value=True)
+
+    def test_program_key_survives_a_rename(self) -> None:
+        before = GenericProgramDataPoint._routing_key_parameter(data=self._program(legacy_name="My Prog", pid="4711"))
+        after = GenericProgramDataPoint._routing_key_parameter(
+            data=self._program(legacy_name="Renamed Prog", pid="4711")
+        )
+        assert before == after == "4711"
+
+    def test_synthetic_hub_data_points_keep_the_slug(self) -> None:
+        """Their names are module constants, so they cannot be renamed or re-keyed."""
+        assert GenericHubDataPoint._routing_key_parameter(data=HubData(legacy_name="Inbox")) == "inbox"
+
+    def test_sysvar_falls_back_to_the_slug_without_an_id(self) -> None:
+        """A backend that has not resolved the id yet must still produce a key."""
+        assert (
+            GenericSysvarDataPoint._routing_key_parameter(data=self._sysvar(legacy_name="Outside Temp", vid=""))
+            == "outside-temp"
+        )
+
+    def test_sysvar_key_survives_a_rename(self) -> None:
+        before = GenericSysvarDataPoint._routing_key_parameter(
+            data=self._sysvar(legacy_name="Outside Temp", vid="12345")
+        )
+        after = GenericSysvarDataPoint._routing_key_parameter(
+            data=self._sysvar(legacy_name="Outside Temp North", vid="12345")
+        )
+        assert before == after == "12345"


### PR DESCRIPTION
Closes #3371. Released as **2026.8.8**.

Renaming a system variable or a program in the CCU WebUI re-keyed its Home Assistant entity, taking its history, its area, its customisations and every automation built on it. The person who tidies up their variable names is the one who loses.

## Cause and shape of the fix

`GenericHubDataPoint.__init__` built the routing key from `slugify(data.legacy_name)` for **every** hub data point. That is right for the ones whose name is a module constant — alarm and service messages, the inbox, metrics, connectivity, install mode — because none of those can be renamed. It is wrong for the two families that can be, and both already carried a stable id: `SystemVariableData.vid` and `ProgramData.pid`, required on the dataclass in each case.

The parameter slot becomes an overridable hook instead of a fixed expression, and the two renameable subclasses override it. Each falls back to the slug when the id is empty — which is what a backend that has not resolved an id yet needs, and what a client rebuilding the key has to accept during a rollover.

## The mapping had no test

The routing-key *function* is covered thoroughly — `tests/contract/test_unique_id_routing_key_contract.py` replays it with an explicit parameter. Nothing asserted **which value** a sysvar or a program puts there. That is how a key built from a renameable name survived this long, and it is why the full suite stayed green when I first made the change.

Four cases now cover it: a sysvar key surviving a rename, a program key surviving a rename, and both fallbacks (empty id → slug; synthetic hub data points → slug).

## What this costs, and what has to follow

Every system variable and program entity **re-keys once** on the upgrade that lands this. That is the price of ending a re-key that currently happens every time somebody renames something, and it needs a registry migration in `homematicip_local` shipping in the same release — that integration already runs three such passes, so the shape is established. Without it those entities orphan instead of moving, which the changelog says in as many words.

`openccu-loom` stamps the same key by the same rule (`internal/model/hub/payload.go:102-107`, `:38-43`) and follows from here, so its golden fixtures move with it rather than declaring a divergence. Doing it the other way round would rebuild the CUxD construction that #3370 and its four-repository retirement just unwound. Tracked downstream as SukramJ/openccu-loom-client#126.

One asymmetry for whoever does the daemon side: its `SysvarSummary.vid` is **optional** in the OpenAPI schema where this library's is required, which is exactly why the fallback above exists.

## Release 2026.8.8

Version in `aiohomematic/const.py`, changelog entry leading with the re-key because that is what a user notices, and the routine dependency and tooling bumps that were sitting uncommitted in the tree.

Those bumps are not incidental here: **`ruff` 0.16.5 clears the three `BLE001` findings** in `central/coordinators/connection_recovery.py` that I had described as pre-existing when the first commit landed. They are gone rather than inherited, so `ruff check .` is clean on this branch without an exemption. Also `pydantic>=2.13.5`, `coverage` 7.16.0, `prek` 0.5.0, `pymdown-extensions` 11.0.2, `pytest-rerunfailures` 16.6, `pytest-socket` 0.8.1, `uv` 0.12.7.

4035 tests, ruff, mypy and pylint clean on the bumped toolchain.