### PR TITLE
Guard prek revisions against the pinned tool versions (2026.9.1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,12 @@ repos:
         language: script
         files: ^(docs/.+\.md|aiohomematic/central/events/.+\.py)$
         pass_filenames: false
+      - id: check-pre-commit-pins
+        name: check-pre-commit-pins
+        entry: script/run-in-env.sh python script/check_pre_commit_pins.py
+        language: script
+        files: ^(\.pre-commit-config\.yaml|requirements_test_pre_commit\.txt)$
+        pass_filenames: false
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.16.5
     hooks:
@@ -52,7 +58,7 @@ repos:
       - id: ruff-format
         files: ^((aiohomematic|aiohomematic_test_support|pylint|script|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         args:
@@ -72,6 +78,7 @@ repos:
         # Tests and test-support contain intentional fixtures (fake tokens, short test passwords)
         # that bandit flags as B105/B106; ruff `S` rules already guard production code.
         files: ^(aiohomematic|script)/.+\.py$
+  # no-pin: hook-only repo, ships no tool the test env installs
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -83,9 +90,10 @@ repos:
         args:
           - --branch=main
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.37.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
+  # no-pin: node tool, prek installs it, not pip
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:
@@ -93,7 +101,7 @@ repos:
         files: ^.+\.(md|json|ya?ml)$
         exclude: ^(aiohomematic_storage/|tests/fixtures/|\.github/)
   - repo: https://github.com/cdce8p/python-typing-update
-    rev: v0.7.3
+    rev: v0.8.1
     hooks:
       # Run `python-typing-update` hook manually from time to time
       # to update python typing syntax.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -510,8 +510,8 @@ Release process (tagging, changelog rules): **`docs/contributor/release_process.
 - Feature branches: `feature/<desc>`; fixes: `fix/<desc>`; AI sessions: `claude/claude-md-<session>`.
 - Conventional-commit style: `<type>(<scope>): <subject>`.
 - Pre-commit hooks (prek): sort-class-members, check-i18n, lint-package-imports,
-  lint-all-exports, lint-delegated-property, lint-event-tiers, lint-kwonly, ruff, mypy, pylint,
-  codespell, bandit, yamllint. **Do not bypass hooks** (`--no-verify`) except when explicitly
+  lint-all-exports, lint-delegated-property, lint-event-tiers, lint-kwonly,
+  check-pre-commit-pins, ruff, mypy, pylint, codespell, bandit, yamllint. **Do not bypass hooks** (`--no-verify`) except when explicitly
   asked; fix the underlying issue.
 
 ---

--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.8.8"
+VERSION: Final = "2026.9.1"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,45 @@
+# Version 2026.9.1 (2026-09-03)
+
+## What's Changed
+
+### Added
+
+- **A guard keeps the prek hook revisions and the pinned tool versions from
+  drifting apart.** `.pre-commit-config.yaml` pins five tools in `rev:`, and
+  `requirements_test_pre_commit.txt` pins the very same five for the test
+  environment. Nothing linked the two files, so they were kept in sync by hand —
+  and at the previous commit they were not: `codespell` ran at `v2.4.2` from the
+  hook while the requirements installed `2.4.3`, `yamllint` at `v1.37.1` against
+  `1.38.0`, `python-typing-update` at `v0.7.3` against `v0.8.1`. A hook that
+  lints with a different release than CI installs reports different findings in
+  the two places, which is exactly the kind of difference nobody looks for.
+
+  `script/check_pre_commit_pins.py` closes that gap as the `check-pre-commit-pins`
+  hook. The link it checks is **declared in the two files, never inferred**: no
+  rule maps `charliermarsh/ruff-pre-commit` to the package `ruff`, so each pin
+  now names the hook repo it mirrors in a trailing `# pre-commit: <repo-url>`
+  comment (or `# pre-commit: local` for a tool behind a `repo: local` hook), and
+  each remote repo that deliberately carries no pin is marked `# no-pin: <reason>`
+  on the line above its `- repo:` entry. Guessing the mapping from names would
+  have produced a check that looks right and silently mismatches the day a repo
+  and its package stop sharing a name.
+
+  That marker sits on its own line for a reason worth recording: prettier
+  rewrites a YAML trailing comment down to a single leading space, and yamllint
+  then rejects it for having fewer than two — no trailing form passes both hooks.
+
+  Beyond version drift the guard also catches a hook repo added without a
+  matching pin, a pin naming a repo the config no longer has, a pin with no
+  mapping comment at all, and a repo that is both mapped and marked `# no-pin:`.
+  Twenty tests cover the parsers and each failure class, including a check that
+  the repository's own two files agree.
+
+### Changed
+
+- Routine tooling bumps: `prek` 0.5.2, `pylint` 4.0.8, `uv` 0.12.9, and
+  `codespell` 2.4.3, `yamllint` 1.38.0 and `python-typing-update` 0.8.1 in both
+  the pinned requirements and the pre-commit revisions.
+
 # Version 2026.8.8 (2026-08-29)
 
 ## What's Changed

--- a/docs/contributor/dev-environment.md
+++ b/docs/contributor/dev-environment.md
@@ -104,17 +104,18 @@ codespell               # Spell check
 
 ## Development Scripts
 
-| Script                              | Purpose                                                                           |
-| ----------------------------------- | --------------------------------------------------------------------------------- |
-| `script/sort_class_members.py`      | Organize class members                                                            |
-| `script/check_i18n.py`              | Validate translation usage                                                        |
-| `script/check_i18n_catalogs.py`     | Check translation completeness                                                    |
-| `script/lint_kwonly.py`             | Enforce keyword-only arguments                                                    |
-| `script/lint_package_imports.py`    | Enforce import conventions                                                        |
-| `script/lint_all_exports.py`        | Validate `__all__` exports                                                        |
-| `script/lint_event_tiers.py`        | Enforce event import boundaries (no internal event imports by external consumers) |
-| `script/lint_delegated_property.py` | Validate correct usage of DelegatedProperty descriptors                           |
-| `script/lint_rega_scripts.py`       | Validate ReGa script syntax and naming conventions                                |
+| Script                              | Purpose                                                                                           |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `script/sort_class_members.py`      | Organize class members                                                                            |
+| `script/check_i18n.py`              | Validate translation usage                                                                        |
+| `script/check_i18n_catalogs.py`     | Check translation completeness                                                                    |
+| `script/lint_kwonly.py`             | Enforce keyword-only arguments                                                                    |
+| `script/lint_package_imports.py`    | Enforce import conventions                                                                        |
+| `script/lint_all_exports.py`        | Validate `__all__` exports                                                                        |
+| `script/lint_event_tiers.py`        | Enforce event import boundaries (no internal event imports by external consumers)                 |
+| `script/lint_delegated_property.py` | Validate correct usage of DelegatedProperty descriptors                                           |
+| `script/lint_rega_scripts.py`       | Validate ReGa script syntax and naming conventions                                                |
+| `script/check_pre_commit_pins.py`   | Keep `.pre-commit-config.yaml` hook revisions and `requirements_test_pre_commit.txt` pins in sync |
 
 ## Pre-commit Hooks
 
@@ -124,12 +125,13 @@ The following hooks run automatically on commit:
 2. **check-i18n** - Validate translations
 3. **lint-package-imports** - Enforce package imports
 4. **lint-all-exports** - Validate exports
-5. **ruff** - Lint and format
-6. **mypy** - Type check
-7. **pylint** - Additional linting
-8. **codespell** - Spell check
-9. **bandit** - Security check
-10. **yamllint** - YAML validation
+5. **check-pre-commit-pins** - Keep hook revisions and pinned tool versions in sync
+6. **ruff** - Lint and format
+7. **mypy** - Type check
+8. **pylint** - Additional linting
+9. **codespell** - Spell check
+10. **bandit** - Security check
+11. **yamllint** - YAML validation
 
 To bypass hooks (not recommended):
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,12 +6,12 @@ coverage==7.16.0
 freezegun==1.5.5
 mypy==2.3.1
 pip==26.2.1
-prek==0.5.0
+prek==0.5.2
 pur==7.4.0
 pydevccu==0.2.6
 pylint-per-file-ignores==3.2.1
 pylint-strict-informational==0.1
-pylint==4.0.7
+pylint==4.0.8
 pymdown-extensions==11.0.2
 pyspelling==2.12.1
 pytest-aiohttp==1.1.1
@@ -23,4 +23,4 @@ pytest-timeout==2.4.0
 pytest-xdist==3.8.0
 pytest==9.1.1
 types-python-slugify==8.0.2.20240310
-uv==0.12.7
+uv==0.12.9

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,10 @@
-bandit==1.9.4
-codespell==2.4.3
-python-typing-update==v0.8.1
-ruff==0.16.5
-yamllint==1.38.0
+# Every pin below mirrors the `rev:` of a hook repo in .pre-commit-config.yaml.
+# The trailing `# pre-commit: <repo-url>` comment names that repo (use
+# `# pre-commit: local` for a tool backing a `repo: local` hook, which has no
+# `rev:`). script/check_pre_commit_pins.py reads those declarations and fails
+# when the two files drift apart.
+bandit==1.9.4  # pre-commit: https://github.com/PyCQA/bandit
+codespell==2.4.3  # pre-commit: https://github.com/codespell-project/codespell
+python-typing-update==v0.8.1  # pre-commit: https://github.com/cdce8p/python-typing-update
+ruff==0.16.5  # pre-commit: https://github.com/charliermarsh/ruff-pre-commit
+yamllint==1.38.0  # pre-commit: https://github.com/adrienverge/yamllint.git

--- a/script/check_pre_commit_pins.py
+++ b/script/check_pre_commit_pins.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""
+Pin-drift guard for ``.pre-commit-config.yaml``.
+
+Every remote hook repository in ``.pre-commit-config.yaml`` pins a tool version in its
+``rev:``, and ``requirements_test_pre_commit.txt`` pins the very same tools for the test
+environment. Nothing links the two files, so they are kept in sync by hand and drift
+apart silently — a hook then runs a different version than the test environment installs.
+
+This guard makes the link explicit and machine-checked. The mapping is **declared in the
+files themselves** and never inferred from repository or package names:
+
+* every pin in ``requirements_test_pre_commit.txt`` carries a trailing
+  ``# pre-commit: <repo-url>`` comment naming the hook repo it mirrors, or
+  ``# pre-commit: local`` when it backs a ``repo: local`` hook that has no ``rev:``;
+* every remote repo in ``.pre-commit-config.yaml`` that intentionally has no pin carries
+  a ``# no-pin: <reason>`` comment on the line directly above its ``- repo:`` line. That
+  marker has to sit on its own line: prettier rewrites a YAML trailing comment down to a
+  single leading space, which yamllint then rejects, so no trailing form passes both.
+
+Checked:
+
+1. **Version drift** — a declared pair whose two versions differ.
+2. **Unmapped hook repo** — a remote repo with a ``rev:`` that no pin maps to and that is
+   not marked ``# no-pin:``.
+3. **Orphaned mapping** — a pin naming a repo that the config does not contain (any more).
+4. **Undeclared pin** — a requirement line without a ``# pre-commit:`` comment.
+5. **Contradiction** — a repo that is both mapped by a pin and marked ``# no-pin:``.
+
+Versions are compared after stripping one leading ``v``: git tags carry it
+(``rev: v0.16.5``) and PEP 440 accepts it as an optional release-segment prefix, so
+``v0.16.5`` and ``0.16.5`` denote the same release. No other normalisation is applied —
+anything else (a commit hash in ``rev:``, a differing patch level) is reported as drift.
+
+Exits with code ``1`` if any issue is found, otherwise ``0``.
+
+Run manually::
+
+    python script/check_pre_commit_pins.py
+
+Or wire into prek (see ``.pre-commit-config.yaml``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_PATH = REPO_ROOT / ".pre-commit-config.yaml"
+REQUIREMENTS_PATH = REPO_ROOT / "requirements_test_pre_commit.txt"
+
+# Marker used in requirements comments for tools backing a `repo: local` hook.
+LOCAL_TARGET = "local"
+
+# A trailing comment is tolerated so the block is still recognised, but it is never read as a
+# marker: only a comment on its own line above the repo declares "# no-pin:".
+_REPO_LINE = re.compile(r"^\s*-\s+repo:\s+(?P<url>\S+)\s*(?:#.*)?$")
+_COMMENT_LINE = re.compile(r"^\s*#\s*(?P<comment>.+?)\s*$")
+_REV_LINE = re.compile(r"^\s{2,}rev:\s+(?P<rev>\S+)\s*(?:#.*)?$")
+_PIN_LINE = re.compile(r"^(?P<package>[A-Za-z0-9._-]+)\s*==\s*(?P<version>[^\s#]+)\s*(?:#\s*(?P<comment>.*?))?\s*$")
+_NO_PIN_COMMENT = re.compile(r"^no-pin:\s*(?P<reason>.+)$")
+_PRE_COMMIT_COMMENT = re.compile(r"^pre-commit:\s*(?P<target>\S+)\s*$")
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class HookRepo:
+    """Represent one remote ``- repo:`` block of the prek config."""
+
+    url: str
+    rev: str | None
+    line_no: int
+    no_pin_reason: str | None
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class Pin:
+    """Represent one ``package==version`` line of the requirements file."""
+
+    package: str
+    version: str
+    target: str | None
+    line_no: int
+
+
+def normalise_version(version: str) -> str:
+    """Return the version without a single leading ``v`` (an optional PEP 440 prefix)."""
+    return version.removeprefix("v")
+
+
+def parse_hook_repos(*, text: str) -> list[HookRepo]:
+    """Return the remote hook repos declared in the prek config, in file order."""
+    repos: list[HookRepo] = []
+    url: str | None = None
+    line_no = 0
+    comment: str | None = None
+    rev: str | None = None
+    pending_comment: str | None = None
+
+    def flush() -> None:
+        if url is None or url == LOCAL_TARGET:
+            return
+        reason = None
+        if comment and (match := _NO_PIN_COMMENT.match(comment)):
+            reason = match.group("reason").strip()
+        repos.append(HookRepo(url=url, rev=rev, line_no=line_no, no_pin_reason=reason))
+
+    for number, line in enumerate(text.splitlines(), start=1):
+        if comment_match := _COMMENT_LINE.match(line):
+            pending_comment = comment_match.group("comment")
+            continue
+        if repo_match := _REPO_LINE.match(line):
+            flush()
+            url = repo_match.group("url")
+            comment = pending_comment
+            line_no = number
+            rev = None
+        elif url is not None and (rev_match := _REV_LINE.match(line)):
+            rev = rev_match.group("rev")
+        pending_comment = None
+    flush()
+    return repos
+
+
+def parse_pins(*, text: str) -> list[Pin]:
+    """Return the version pins declared in the requirements file, in file order."""
+    pins: list[Pin] = []
+    for number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith(("#", "-r ")):
+            continue
+        if not (match := _PIN_LINE.match(stripped)):
+            continue
+        target = None
+        if (comment := match.group("comment")) and (target_match := _PRE_COMMIT_COMMENT.match(comment.strip())):
+            target = target_match.group("target")
+        pins.append(
+            Pin(
+                package=match.group("package"),
+                version=match.group("version"),
+                target=target,
+                line_no=number,
+            )
+        )
+    return pins
+
+
+def check(*, config_path: Path, requirements_path: Path) -> list[str]:
+    """Return one error message per pin-drift issue found between the two files."""
+    config_name = config_path.name
+    requirements_name = requirements_path.name
+    repos = parse_hook_repos(text=config_path.read_text(encoding="utf-8"))
+    pins = parse_pins(text=requirements_path.read_text(encoding="utf-8"))
+    repos_by_url = {repo.url: repo for repo in repos}
+    errors: list[str] = []
+    mapped_urls: set[str] = set()
+
+    for pin in pins:
+        location = f"{requirements_name}:{pin.line_no}"
+        if pin.target is None:
+            errors.append(
+                f"{location}: '{pin.package}' has no '# pre-commit: <repo-url>' comment. "
+                f"Add the hook repo it mirrors, or '# pre-commit: {LOCAL_TARGET}' for a local hook."
+            )
+            continue
+        if pin.target == LOCAL_TARGET:
+            continue
+        if (repo := repos_by_url.get(pin.target)) is None:
+            errors.append(f"{location}: '{pin.package}' maps to '{pin.target}', which is not a repo in {config_name}.")
+            continue
+        mapped_urls.add(repo.url)
+        if repo.no_pin_reason is not None:
+            errors.append(
+                f"{location}: '{pin.package}' maps to '{repo.url}', but {config_name}:{repo.line_no - 1} "
+                f"marks that repo '# no-pin:'. Remove one of the two declarations."
+            )
+            continue
+        if repo.rev is None:
+            errors.append(f"{location}: '{pin.package}' maps to '{repo.url}', which has no 'rev:' in {config_name}.")
+            continue
+        if normalise_version(repo.rev) != normalise_version(pin.version):
+            errors.append(
+                f"{location}: '{pin.package}=={pin.version}' drifted from "
+                f"{config_name}:{repo.line_no} 'rev: {repo.rev}' ({repo.url})."
+            )
+
+    for repo in repos:
+        if repo.rev is None or repo.url in mapped_urls or repo.no_pin_reason is not None:
+            continue
+        errors.append(
+            f"{config_name}:{repo.line_no}: '{repo.url}' pins 'rev: {repo.rev}' but nothing in "
+            f"{requirements_name} mirrors it. Add a pin with '# pre-commit: {repo.url}', "
+            "or mark the repo '# no-pin: <reason>'."
+        )
+
+    return errors
+
+
+def main() -> int:
+    """Run the pin-drift check and return a non-zero exit code when any issue is found."""
+    errors = check(config_path=CONFIG_PATH, requirements_path=REQUIREMENTS_PATH)
+    if errors:
+        print("pre-commit pin drift detected:\n")
+        for err in errors:
+            print(f"  - {err}")
+        print(f"\n{len(errors)} issue(s) found. See script/check_pre_commit_pins.py for details.")
+        return 1
+    print("pre-commit pins: no drift detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_pre_commit_pins.py
+++ b/tests/test_check_pre_commit_pins.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""Tests for the pre-commit pin-drift guard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Import from script directory
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "script"))
+from check_pre_commit_pins import CONFIG_PATH, REQUIREMENTS_PATH, check, normalise_version, parse_hook_repos, parse_pins
+
+CONFIG = """\
+repos:
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+  - repo: https://github.com/example/ruff-pre-commit
+    rev: v1.2.3
+    hooks:
+      - id: ruff
+  # no-pin: hook-only repo
+  - repo: https://github.com/example/hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-json
+"""
+
+REQUIREMENTS = """\
+# A leading comment.
+-r requirements.txt
+ruff==1.2.3  # pre-commit: https://github.com/example/ruff-pre-commit
+mypy==2.3.1  # pre-commit: local
+"""
+
+
+def _write(tmp_path: Path, *, config: str = CONFIG, requirements: str = REQUIREMENTS) -> tuple[Path, Path]:
+    """Write both source files into tmp_path and return their paths."""
+    config_path = tmp_path / ".pre-commit-config.yaml"
+    requirements_path = tmp_path / "requirements_test_pre_commit.txt"
+    config_path.write_text(config, encoding="utf-8")
+    requirements_path.write_text(requirements, encoding="utf-8")
+    return config_path, requirements_path
+
+
+def _check(tmp_path: Path, *, config: str = CONFIG, requirements: str = REQUIREMENTS) -> list[str]:
+    """Run the guard against files written into tmp_path."""
+    config_path, requirements_path = _write(tmp_path, config=config, requirements=requirements)
+    return check(config_path=config_path, requirements_path=requirements_path)
+
+
+class TestParsing:
+    """Tests for the two file parsers."""
+
+    def test_normalise_version_strips_single_leading_v(self) -> None:
+        """Test that only one leading `v` is stripped."""
+        assert normalise_version("v1.2.3") == "1.2.3"
+        assert normalise_version("1.2.3") == "1.2.3"
+        assert normalise_version("vv1.2.3") == "v1.2.3"
+
+    def test_parse_hook_repos_reads_no_pin_comment(self) -> None:
+        """Test that a `# no-pin:` comment on the preceding line is picked up."""
+        repo = parse_hook_repos(text=CONFIG)[1]
+        assert repo.no_pin_reason == "hook-only repo"
+
+    def test_parse_hook_repos_reads_rev_and_line(self) -> None:
+        """Test that rev and line number are read from the block."""
+        repo = parse_hook_repos(text=CONFIG)[0]
+        assert repo.rev == "v1.2.3"
+        assert repo.line_no == 6
+        assert repo.no_pin_reason is None
+
+    def test_parse_hook_repos_skips_local(self) -> None:
+        """Test that a `repo: local` block is not treated as a pinned hook repo."""
+        urls = [repo.url for repo in parse_hook_repos(text=CONFIG)]
+        assert urls == ["https://github.com/example/ruff-pre-commit", "https://github.com/example/hooks"]
+
+    def test_parse_pins_ignores_includes_and_comments(self) -> None:
+        """Test that `-r` includes and comment lines are not parsed as pins."""
+        assert len(parse_pins(text=REQUIREMENTS)) == 2
+
+    def test_parse_pins_reads_target(self) -> None:
+        """Test that the `# pre-commit:` comment is read as the mapping target."""
+        pins = parse_pins(text=REQUIREMENTS)
+        assert [(pin.package, pin.version, pin.target) for pin in pins] == [
+            ("ruff", "1.2.3", "https://github.com/example/ruff-pre-commit"),
+            ("mypy", "2.3.1", "local"),
+        ]
+
+    def test_parse_pins_records_missing_target(self) -> None:
+        """Test that a pin without a `# pre-commit:` comment has no target."""
+        assert parse_pins(text="ruff==1.2.3\n")[0].target is None
+
+
+class TestCheck:
+    """Tests for the drift checks."""
+
+    def test_commit_hash_rev_is_drift(self, tmp_path: Path) -> None:
+        """Test that a rev that is not the pinned version is reported, hash or not."""
+        errors = _check(tmp_path, config=CONFIG.replace("rev: v1.2.3", "rev: 0f1e2d3"))
+        assert len(errors) == 1
+        assert "drifted from" in errors[0]
+
+    def test_contradiction_between_no_pin_and_mapping(self, tmp_path: Path) -> None:
+        """Test that a repo both mapped and marked `# no-pin:` is reported."""
+        requirements = REQUIREMENTS + "hooks==6.0.0  # pre-commit: https://github.com/example/hooks\n"
+        errors = _check(tmp_path, requirements=requirements)
+        assert len(errors) == 1
+        assert "marks that repo '# no-pin:'" in errors[0]
+
+    def test_local_target_needs_no_repo(self, tmp_path: Path) -> None:
+        """Test that a `# pre-commit: local` pin is accepted without a matching repo."""
+        requirements = "mypy==2.3.1  # pre-commit: local\n"
+        config = CONFIG.replace("  - repo: https://github.com/example/ruff-pre-commit\n    rev: v1.2.3\n", "")
+        errors = _check(tmp_path, config=config, requirements=requirements)
+        assert errors == []
+
+    def test_mapped_repo_without_rev(self, tmp_path: Path) -> None:
+        """Test that a mapping to a repo that carries no rev is reported."""
+        config = CONFIG.replace("    rev: v1.2.3\n", "")
+        errors = _check(tmp_path, config=config)
+        assert len(errors) == 1
+        assert "has no 'rev:'" in errors[0]
+
+    def test_no_drift(self, tmp_path: Path) -> None:
+        """Test that consistent files produce no errors."""
+        assert _check(tmp_path) == []
+
+    def test_no_pin_marker_must_directly_precede_the_repo(self, tmp_path: Path) -> None:
+        """Test that a marker separated from its repo line by content does not apply."""
+        config = CONFIG.replace(
+            "  # no-pin: hook-only repo\n  - repo: https://github.com/example/hooks",
+            "  # no-pin: hook-only repo\n  - repo: https://github.com/example/other\n"
+            "    rev: v9.9.9\n    hooks:\n      - id: other\n  - repo: https://github.com/example/hooks",
+        )
+        errors = _check(tmp_path, config=config)
+        assert len(errors) == 1
+        assert "https://github.com/example/hooks" in errors[0]
+
+    def test_orphaned_mapping(self, tmp_path: Path) -> None:
+        """Test that a pin naming an absent repo is reported."""
+        requirements = REQUIREMENTS.replace("example/ruff-pre-commit", "example/gone")
+        errors = _check(tmp_path, requirements=requirements)
+        assert len(errors) == 2
+        assert any("is not a repo in .pre-commit-config.yaml" in err for err in errors)
+        assert any("nothing in requirements_test_pre_commit.txt mirrors it" in err for err in errors)
+
+    def test_trailing_no_pin_marker_is_not_honoured(self, tmp_path: Path) -> None:
+        """Test that a `# no-pin:` written as a trailing comment fails loudly, not silently."""
+        config = CONFIG.replace(
+            "  # no-pin: hook-only repo\n  - repo: https://github.com/example/hooks",
+            "  - repo: https://github.com/example/hooks  # no-pin: hook-only repo",
+        )
+        errors = _check(tmp_path, config=config)
+        assert len(errors) == 1
+        assert "nothing in requirements_test_pre_commit.txt mirrors it" in errors[0]
+
+    def test_undeclared_pin(self, tmp_path: Path) -> None:
+        """Test that a pin without a mapping comment is reported."""
+        requirements = REQUIREMENTS.replace("  # pre-commit: https://github.com/example/ruff-pre-commit", "")
+        errors = _check(tmp_path, requirements=requirements)
+        assert len(errors) == 2
+        assert any("has no '# pre-commit: <repo-url>' comment" in err for err in errors)
+
+    def test_unmapped_hook_repo(self, tmp_path: Path) -> None:
+        """Test that a pinned repo nothing mirrors is reported."""
+        config = CONFIG.replace("  # no-pin: hook-only repo\n", "")
+        errors = _check(tmp_path, config=config)
+        assert len(errors) == 1
+        assert "nothing in requirements_test_pre_commit.txt mirrors it" in errors[0]
+
+    def test_v_prefix_is_not_drift(self, tmp_path: Path) -> None:
+        """Test that a `v` prefix on the pin matches an unprefixed rev and vice versa."""
+        config = CONFIG.replace("rev: v1.2.3", "rev: 1.2.3")
+        assert _check(tmp_path, config=config, requirements=REQUIREMENTS.replace("ruff==1.2.3", "ruff==v1.2.3")) == []
+
+    def test_version_drift(self, tmp_path: Path) -> None:
+        """Test that a differing version is reported."""
+        errors = _check(tmp_path, requirements=REQUIREMENTS.replace("ruff==1.2.3", "ruff==1.2.4"))
+        assert len(errors) == 1
+        assert "drifted from" in errors[0]
+        assert "rev: v1.2.3" in errors[0]
+
+
+def test_repository_is_free_of_pin_drift() -> None:
+    """Test that the repository's own two files are in sync."""
+    assert check(config_path=CONFIG_PATH, requirements_path=REQUIREMENTS_PATH) == []


### PR DESCRIPTION
## Why

`.pre-commit-config.yaml` pins five tools in `rev:`, and `requirements_test_pre_commit.txt` pins the very same five for the test environment. Nothing linked the two files, so they were kept in sync by hand.

At the previous commit they were not in sync. Running the new guard against `git show HEAD:.pre-commit-config.yaml`:

| Tool | Hook ran with | Requirements installed |
| --- | --- | --- |
| codespell | `rev: v2.4.2` | `2.4.3` |
| yamllint | `rev: v1.37.1` | `1.38.0` |
| python-typing-update | `rev: v0.7.3` | `v0.8.1` |

A hook that lints with a different release than CI installs reports different findings in the two places — the kind of difference nobody goes looking for. The pending bumps in this PR repair those three; the guard is what keeps the next bump from re-opening the gap.

## What

`script/check_pre_commit_pins.py`, wired in as the `check-pre-commit-pins` prek hook. It runs only when one of the two files changes.

**The mapping is declared in the sources, never inferred.** Nothing in either file says that `charliermarsh/ruff-pre-commit` provides the package `ruff` — deriving that from the names would produce a check that looks right and silently mismatches the day a repo and its package stop sharing a name. So the declaration lives in the files themselves:

- every pin in `requirements_test_pre_commit.txt` names the hook repo it mirrors in a trailing `# pre-commit: <repo-url>` comment, or `# pre-commit: local` for a tool behind a `repo: local` hook;
- every remote repo in `.pre-commit-config.yaml` that deliberately carries no pin is marked `# no-pin: <reason>` on the line directly above its `- repo:` entry.

Checked, beyond plain version drift:

1. a hook repo with a `rev:` that no pin mirrors and that is not marked `# no-pin:` — catches *"new hook added, pin forgotten"*;
2. a pin naming a repo the config no longer contains;
3. a pin with no mapping comment at all;
4. a repo that is both mapped by a pin and marked `# no-pin:`.

Versions compare after stripping one leading `v` (git tags carry it, PEP 440 accepts it as an optional prefix). Anything else — a commit hash in `rev:`, a differing patch level — is reported as drift.

## Two things worth recording

**prettier and yamllint contradict each other on YAML trailing comments.** prettier rewrites `foo  # bar` down to a single leading space; yamllint's `comments.min-spaces-from-content: 2` then rejects it (`.pre-commit-config.yaml:81 too few spaces before comment: expected 2`). No trailing form passes both hooks, which is why the `# no-pin:` marker sits on its own line. Noted in the script docstring so the next person does not rediscover it.

**A test found a parser bug before it shipped.** Tightening the `- repo:` regex to reject trailing comments meant such a line was no longer recognised as a block start at all, so that block's `rev:` was attributed to the *previous* repo — a false drift report against the wrong tool. The regex now tolerates a trailing comment while never reading it as a marker; `test_trailing_no_pin_marker_is_not_honoured` pins the behaviour.

## Testing

- `tests/test_check_pre_commit_pins.py` — 20 tests: both parsers, each failure class, the `v`-prefix equivalence, marker placement semantics, and one asserting the repository's own two files agree.
- `prek run --all-files` clean and idempotent over every touched file.

## Also in this PR

The routine tooling bumps that were pending in the working tree: `prek` 0.5.2, `pylint` 4.0.8, `uv` 0.12.9, and `codespell` 2.4.3, `yamllint` 1.38.0, `python-typing-update` 0.8.1 in both the requirements and the revisions. They are the three drifts above, repaired.

Version bumped to `2026.9.1` (no `2026.9.*` tags existed).
