### PR TITLE
fix(climate): don't let a rarely reported SET_POINT_MODE invalidate IP heating groups

### DIFF
--- a/aiohomematic/model/custom/climate.py
+++ b/aiohomematic/model/custom/climate.py
@@ -682,9 +682,15 @@ class CustomDpIpThermostat(BaseCustomDpClimate):
     _dp_set_point_mode: Final = DataPointField(field=Field.SET_POINT_MODE, dpt=DpInteger)
     _dp_state: Final = DataPointField(field=Field.STATE, dpt=DpBinarySensor)
     _dp_temperature_offset: Final = DataPointField(field=Field.TEMPERATURE_OFFSET, dpt=DpFloat)
-    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset(
-        {Field.TEMPERATURE, Field.SETPOINT, Field.SET_POINT_MODE}
-    )
+    # SET_POINT_MODE is only reported when the operating mode actually changes, while
+    # ACTUAL_TEMPERATURE and SET_POINT_TEMPERATURE keep arriving. That hits heating groups
+    # (HmIP-HEATING on VirtualDevices) hardest: after a CCU restart the mode carries a
+    # Timestamp() but no LastTimestamp(), so the ReGa bulk fetch skips it, and
+    # VirtualDevices has no per-parameter getValue fallback (#3228) to make up for it. The
+    # group would stay at value_state=restored until the mode happens to change. Validity
+    # follows the two continuously reported values; mode falls back to AUTO until
+    # SET_POINT_MODE arrives.
+    _validity_relevant_fields: ClassVar[frozenset[Field]] = frozenset({Field.TEMPERATURE, Field.SETPOINT})
 
     optimum_start_stop: Final = DelegatedProperty[bool | None](path="_dp_optimum_start_stop.value")
     temperature_offset: Final = DelegatedProperty[float | None](path="_dp_temperature_offset.value")

--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,33 @@
   Twenty tests cover the parsers and each failure class, including a check that
   the repository's own two files agree.
 
+### Fixed
+
+- **`HmIP-HEATING` groups no longer hang at the restored Home Assistant state when
+  the operating mode stays untouched (#3376).** `CustomDpIpThermostat` gated its
+  validity on `SET_POINT_MODE`, which the CCU reports only when the operating mode
+  actually changes — unlike `ACTUAL_TEMPERATURE` and `SET_POINT_TEMPERATURE`, which
+  keep arriving.
+
+  Heating groups on the `VirtualDevices` interface have no second source to fall back
+  on. After a CCU restart the mode data point carries a `Timestamp()` but no
+  `LastTimestamp()`, so the ReGa bulk fetch skips it (that gate is deliberate, #3228),
+  and `VirtualDevices` has no per-parameter `getValue` fallback either — for a virtual
+  group `getValue` can only return the CCU-internal placeholder. A group whose mode had
+  not changed since the restart therefore stayed at `value_state=restored` with frozen
+  `current_temperature`/`target_temperature` for as long as the mode stayed put, while
+  the sibling `sensor.*` entities kept updating from the very same events.
+
+  Validity now follows `TEMPERATURE` and `SETPOINT`; until `SET_POINT_MODE` arrives,
+  `mode` reports its existing `AUTO` fallback. Same failure class and same remedy as
+  the classic RF thermostats in `2026.8.5` and the earlier heating-group fixes (#3255,
+  #3279). A regression test covers a group that reports temperature and setpoint but
+  never `SET_POINT_MODE`, and the validity contract test is updated.
+
+  This does not cover a group whose `ACTUAL_TEMPERATURE` is missing from the bulk
+  result as well — such a group has no value at all and still waits for the first
+  event.
+
 ### Changed
 
 - Routine tooling bumps: `prek` 0.5.2, `pylint` 4.0.8, `uv` 0.12.9, and

--- a/tests/contract/test_cdp_validity_contract.py
+++ b/tests/contract/test_cdp_validity_contract.py
@@ -47,7 +47,7 @@ EXPECTED_VALIDITY_RELEVANT_FIELDS: dict[str, frozenset[Field]] = {
     "CustomDpIpRGBWLight": frozenset({Field.LEVEL}),
     "CustomDpIpSiren": frozenset({Field.ACOUSTIC_ALARM_ACTIVE, Field.OPTICAL_ALARM_ACTIVE}),
     "CustomDpIpSirenSmoke": frozenset({Field.SMOKE_DETECTOR_ALARM_STATUS}),
-    "CustomDpIpThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT, Field.SET_POINT_MODE}),
+    "CustomDpIpThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT}),
     "CustomDpRfLock": frozenset({Field.STATE}),
     "CustomDpRfThermostat": frozenset({Field.TEMPERATURE, Field.SETPOINT}),
     "CustomDpSimpleRfThermostat": frozenset({Field.TEMPERATURE}),

--- a/tests/test_model_climate.py
+++ b/tests/test_model_climate.py
@@ -2767,6 +2767,51 @@ class TestClimateValidityIrrelevantDataPoints:
             (TEST_DEVICES, True, None, None),
         ],
     )
+    async def test_ip_thermostat_set_point_mode_excluded_from_validity(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """SET_POINT_MODE must not block is_valid for an IP heating group (#3376)."""
+        central, _mock_client, _ = central_client_factory_with_homegear_client
+        climate = cast(CustomDpIpThermostat, get_prepared_custom_data_point(central, "VCU5778428", 1))
+        # Precondition: SET_POINT_MODE is a real, readable data point on the group channel.
+        assert climate._dp_set_point_mode.is_readable
+        assert climate._dp_set_point_mode not in climate._relevant_data_points
+        # A heating group reports ACTUAL_TEMPERATURE every few minutes and
+        # SET_POINT_TEMPERATURE whenever the setpoint changes, but SET_POINT_MODE only when
+        # the operating mode actually changes. After a CCU restart the mode therefore has a
+        # Timestamp() but no LastTimestamp(), which keeps it out of the ReGa bulk result -
+        # and VirtualDevices has no per-parameter getValue fallback to make up for it.
+        for parameter, value in (
+            ("ACTUAL_TEMPERATURE", 23.9),
+            ("SET_POINT_TEMPERATURE", 21.0),
+        ):
+            await central.event_coordinator.data_point_event(
+                interface_id=const.INTERFACE_ID,
+                channel_address="VCU5778428:1",
+                parameter=parameter,
+                value=value,
+            )
+        assert climate._dp_set_point_mode.is_refreshed is False
+        # The climate must be valid so Home Assistant leaves the restored state behind.
+        assert climate.is_valid is True
+        assert climate.current_temperature == 23.9
+        assert climate.target_temperature == 21.0
+        # Until SET_POINT_MODE arrives, mode reports its existing AUTO fallback.
+        assert climate.mode == ClimateMode.AUTO
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
     async def test_rf_thermostat_control_mode_excluded_from_validity(
         self,
         central_client_factory_with_homegear_client,


### PR DESCRIPTION
Fixes #3376

## Problem

`CustomDpIpThermostat` gated its validity on `SET_POINT_MODE`, which the CCU reports only when the operating mode actually changes — unlike `ACTUAL_TEMPERATURE` and `SET_POINT_TEMPERATURE`, which keep arriving.

Heating groups on the `VirtualDevices` interface have no second source to fall back on:

- After a CCU restart the mode data point carries a `Timestamp()` but no `LastTimestamp()`, so the ReGa bulk fetch skips it. That gate is deliberate (#3228) and is left untouched here.
- `VirtualDevices` has no per-parameter `getValue` fallback either (`INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK`) — for a virtual group `getValue` can only ever return the CCU-internal placeholder.

A group whose mode had not changed since the restart therefore stayed at `value_state=restored` with frozen `current_temperature`/`target_temperature`, while the sibling `sensor.*` entities kept updating from the very same events.

## Evidence from the reporter's data

Diagnostics timestamp 16:32:11. Value events on channel `:1` across the whole unfiltered log:

| Group | Address | Value events `:1` | Reported |
| --- | --- | --- | --- |
| Bad | INT0000003 | 16:27:22 | **valid** |
| Büro | INT0000001 | 16:31:51 | restored |
| Schlafzimmer | INT0000004 | none | restored |
| WC | INT0000005 | none | restored, null |
| Wohnzimmer | INT0000002 | none | restored |

The three groups without any event never saw a `SET_POINT_MODE` at all, in either setup run. Their displayed temperatures can only have come from the bulk fetch — which delivered `ACTUAL_TEMPERATURE` and `SET_POINT_TEMPERATURE`, but not the mode. All five groups sit at `SET_POINT_MODE = 1` and effectively never change it, so it stays without a second write — and thus out of the bulk result — indefinitely.

## Change

Validity now follows `TEMPERATURE` and `SETPOINT`. Until `SET_POINT_MODE` arrives, `mode` reports its existing `AUTO` fallback (`climate.py`, unchanged behaviour).

Same failure class and same remedy as the classic RF thermostats in `2026.8.5` (`CONTROL_MODE`) and the earlier heating-group fixes #3255 / #3279.

## Not covered

A group whose `ACTUAL_TEMPERATURE` is missing from the bulk result as well — it has no value at all and still waits for the first event. That is the `WC` case above and needs a separate change (repeating the bulk fetch for `VirtualDevices` after startup while validity-relevant data points are still unrefreshed).

## Tests

- New regression test `test_ip_thermostat_set_point_mode_excluded_from_validity` against the `HmIP-HEATING` test device `VCU5778428`: the group receives `ACTUAL_TEMPERATURE` and `SET_POINT_TEMPERATURE` by event but never `SET_POINT_MODE`; asserts `is_valid`, both temperatures, and the `AUTO` fallback. Written test-first — it failed on the expected assertion before the fix.
- `tests/contract/test_cdp_validity_contract.py` updated.
- `pytest tests/` — 4056 passed, 1 skipped.
- `prek run --all-files` — all hooks green.