### PR TITLE
fix(sysvar): keep a type-mismatched system variable as text (#3377)

### DIFF
--- a/aiohomematic/client/json_rpc.py
+++ b/aiohomematic/client/json_rpc.py
@@ -408,6 +408,8 @@ class AioJsonRpcAioHttpClient(LogContextMixin):
                 )
             )
         self._script_cache: Final[dict[RegaScript, str]] = {}
+        # Sysvar ids already reported with a declared-type/value mismatch, to log them only once.
+        self._sysvar_type_mismatches: Final[set[str]] = set()
         self._last_session_id_refresh: datetime | None = None
         self._session_id: str | None = None
         self._session_recorder: Final = session_recorder
@@ -1028,16 +1030,16 @@ class AioJsonRpcAioHttpClient(LogContextMixin):
                     continue
 
                 legacy_name = RENAME_SYSVAR_BY_NAME.get(var[_JsonKey.NAME], var[_JsonKey.NAME])
-                if (
-                    variable := _build_sysvar_record(
+                variables.append(
+                    _build_sysvar_record(
                         var=var,
                         var_id=var_id,
                         legacy_name=legacy_name,
                         description=descriptions.get(var_id),
                         enabled_default=enabled_default,
+                        type_mismatches=self._sysvar_type_mismatches,
                     )
-                ) is not None:
-                    variables.append(variable)
+                )
 
         return tuple(variables)
 
@@ -2475,7 +2477,8 @@ def _build_sysvar_record(
     legacy_name: str,
     description: str | None,
     enabled_default: bool,
-) -> SystemVariableData | None:
+    type_mismatches: set[str],
+) -> SystemVariableData:
     """Build a ``SystemVariableData`` record from the raw JSON response entry."""
     org_data_type = var[_JsonKey.TYPE]
     raw_value = var[_JsonKey.VALUE]
@@ -2504,15 +2507,26 @@ def _build_sysvar_record(
         if raw_min_value := var.get(_JsonKey.MIN_VALUE):
             min_value = parse_sys_var(data_type=data_type, raw_value=raw_min_value)
     except (ValueError, TypeError) as vterr:
-        _LOGGER.error(
-            i18n.tr(
-                key="log.client.json_rpc.get_all_system_variables.parse_failed",
-                exc_type=vterr.__class__.__name__,
-                reason=extract_exc_args(exc=vterr),
-                legacy_name=legacy_name,
+        # The backend declares a numeric/list type while the stored value is not convertible
+        # (e.g. a variable created by a script without setting its value type). Keep the
+        # variable and expose the raw value as a string instead of dropping it.
+        if var_id not in type_mismatches:
+            type_mismatches.add(var_id)
+            _LOGGER.warning(
+                i18n.tr(
+                    key="log.client.json_rpc.get_all_system_variables.type_mismatch",
+                    legacy_name=legacy_name,
+                    data_type=org_data_type,
+                    exc_type=vterr.__class__.__name__,
+                    reason=extract_exc_args(exc=vterr),
+                )
             )
-        )
-        return None
+        data_type = HubValueType.STRING
+        value = raw_value
+        max_value = None
+        min_value = None
+        # The declared type is untrustworthy, so don't offer a writable data point for it.
+        extended_sysvar = False
 
     return SystemVariableData(
         vid=var_id,

--- a/aiohomematic/strings.json
+++ b/aiohomematic/strings.json
@@ -192,7 +192,7 @@
   "log.client.json_rpc.download_firmware.invalid_url": "DOWNLOAD_FIRMWARE failed: Invalid firmware URL scheme (only http/https allowed): {url}",
   "log.client.json_rpc.download_firmware.no_session": "DOWNLOAD_FIRMWARE failed: No session ID available",
   "log.client.json_rpc.get_alarm_messages.decode_failed": "GET_ALARM_MESSAGES failed: Unable to decode json: {reason}",
-  "log.client.json_rpc.get_all_system_variables.parse_failed": "GET_ALL_SYSTEM_VARIABLES failed: {exc_type} [{reason}] Failed to parse SysVar {legacy_name}",
+  "log.client.json_rpc.get_all_system_variables.type_mismatch": "GET_ALL_SYSTEM_VARIABLES: SysVar {legacy_name} is declared as {data_type} by the backend, but its value cannot be parsed ({exc_type} [{reason}]). It is treated as STRING.",
   "log.client.json_rpc.get_backend_info.failed": "GET_BACKEND_INFO failed: Unable to decode json: {reason}",
   "log.client.json_rpc.get_inbox_devices.decode_failed": "GET_INBOX_DEVICES failed: Unable to decode json: {reason}",
   "log.client.json_rpc.get_program_descriptions.decode_failed": "GET_PROGRAM_DESCRIPTIONS failed: Unable to decode json: {reason}",

--- a/aiohomematic/translations/de.json
+++ b/aiohomematic/translations/de.json
@@ -192,7 +192,7 @@
   "log.client.json_rpc.download_firmware.invalid_url": "DOWNLOAD_FIRMWARE fehlgeschlagen: Ungültiges URL-Schema für Firmware (nur http/https erlaubt): {url}",
   "log.client.json_rpc.download_firmware.no_session": "DOWNLOAD_FIRMWARE fehlgeschlagen: Keine Session-ID verfügbar",
   "log.client.json_rpc.get_alarm_messages.decode_failed": "GET_ALARM_MESSAGES fehlgeschlagen: JSON konnte nicht dekodiert werden: {reason}",
-  "log.client.json_rpc.get_all_system_variables.parse_failed": "GET_ALL_SYSTEM_VARIABLES fehlgeschlagen: {exc_type} [{reason}] SysVar {legacy_name} konnte nicht geparst werden",
+  "log.client.json_rpc.get_all_system_variables.type_mismatch": "GET_ALL_SYSTEM_VARIABLES: SysVar {legacy_name} wird vom Backend als {data_type} deklariert, der Wert lässt sich aber nicht parsen ({exc_type} [{reason}]). Sie wird als STRING behandelt.",
   "log.client.json_rpc.get_backend_info.failed": "GET_BACKEND_INFO fehlgeschlagen: JSON konnte nicht dekodiert werden: {reason}",
   "log.client.json_rpc.get_inbox_devices.decode_failed": "GET_INBOX_DEVICES fehlgeschlagen: JSON konnte nicht dekodiert werden: {reason}",
   "log.client.json_rpc.get_program_descriptions.decode_failed": "GET_PROGRAM_DESCRIPTIONS fehlgeschlagen: JSON konnte nicht dekodiert werden: {reason}",

--- a/aiohomematic/translations/en.json
+++ b/aiohomematic/translations/en.json
@@ -192,7 +192,7 @@
   "log.client.json_rpc.download_firmware.invalid_url": "DOWNLOAD_FIRMWARE failed: Invalid firmware URL scheme (only http/https allowed): {url}",
   "log.client.json_rpc.download_firmware.no_session": "DOWNLOAD_FIRMWARE failed: No session ID available",
   "log.client.json_rpc.get_alarm_messages.decode_failed": "GET_ALARM_MESSAGES failed: Unable to decode json: {reason}",
-  "log.client.json_rpc.get_all_system_variables.parse_failed": "GET_ALL_SYSTEM_VARIABLES failed: {exc_type} [{reason}] Failed to parse SysVar {legacy_name}",
+  "log.client.json_rpc.get_all_system_variables.type_mismatch": "GET_ALL_SYSTEM_VARIABLES: SysVar {legacy_name} is declared as {data_type} by the backend, but its value cannot be parsed ({exc_type} [{reason}]). It is treated as STRING.",
   "log.client.json_rpc.get_backend_info.failed": "GET_BACKEND_INFO failed: Unable to decode json: {reason}",
   "log.client.json_rpc.get_inbox_devices.decode_failed": "GET_INBOX_DEVICES failed: Unable to decode json: {reason}",
   "log.client.json_rpc.get_program_descriptions.decode_failed": "GET_PROGRAM_DESCRIPTIONS failed: Unable to decode json: {reason}",

--- a/changelog.md
+++ b/changelog.md
@@ -61,6 +61,23 @@
   result as well — such a group has no value at all and still waits for the first
   event.
 
+- **A system variable whose declared type does not match its value is kept as text
+  instead of being dropped (#3377).** `SysVar.getAll` reports a type per variable,
+  and `_build_sysvar_record` trusted it: a `NUMBER` without a decimal point became
+  `INTEGER`, and `parse_sys_var` then ran `int()` over the raw value. Variables
+  created by a script or add-on without setting their value type carry a numeric
+  type and a string value, so the conversion raised, the record was discarded, and
+  no data point ever appeared for the variable. The `ERROR` was logged on every
+  scan — in the reported case 4075 times at a 60 s scan interval, for one variable
+  named `V.Pushover.UserKey`.
+
+  The record now survives: on a conversion failure the variable falls back to
+  `STRING`, keeps the raw value, and drops `minValue`/`maxValue`. It also drops
+  `extended_sysvar`, so a declared type we could not verify never yields a writable
+  data point — writing a string back to a variable the backend holds as a float
+  would silently store `0`. The log moves to `WARNING` and is emitted once per
+  variable id per client, and names the type the backend declared.
+
 ### Changed
 
 - Routine tooling bumps: `prek` 0.5.2, `pylint` 4.0.8, `uv` 0.12.9, and

--- a/changelog.md
+++ b/changelog.md
@@ -63,20 +63,25 @@
 
 - **A system variable whose declared type does not match its value is kept as text
   instead of being dropped (#3377).** `SysVar.getAll` reports a type per variable,
-  and `_build_sysvar_record` trusted it: a `NUMBER` without a decimal point became
-  `INTEGER`, and `parse_sys_var` then ran `int()` over the raw value. Variables
-  created by a script or add-on without setting their value type carry a numeric
-  type and a string value, so the conversion raised, the record was discarded, and
-  no data point ever appeared for the variable. The `ERROR` was logged on every
-  scan — in the reported case 4075 times at a 60 s scan interval, for one variable
-  named `V.Pushover.UserKey`.
+  and `_build_sysvar_record` trusted it: `LIST` and `INTEGER` went through `int()`,
+  and a `NUMBER` without a decimal point was treated as `INTEGER` first.
+
+  The reported variable is a value list holding a single entry — the way to park a
+  string on a CCU that would not take it as a plain string variable. For that
+  constellation the backend returns the entry itself as the value, not its index,
+  so `int()` raised, the record was discarded, and no data point ever appeared.
+  The `ERROR` was logged on every scan: 4075 times in the submitted log, at a 60 s
+  scan interval, for one variable named `V.Pushover.UserKey`. Disabling it in the
+  integration does not help — `enabled_default` is resolved before the value is
+  parsed.
 
   The record now survives: on a conversion failure the variable falls back to
   `STRING`, keeps the raw value, and drops `minValue`/`maxValue`. It also drops
   `extended_sysvar`, so a declared type we could not verify never yields a writable
-  data point — writing a string back to a variable the backend holds as a float
-  would silently store `0`. The log moves to `WARNING` and is emitted once per
-  variable id per client, and names the type the backend declared.
+  data point — a select whose only option is the payload, or a string written back
+  to a variable the backend holds as a float, would both be wrong. The log moves to
+  `WARNING`, is emitted once per variable id per client, and names the type the
+  backend declared.
 
 ### Changed
 

--- a/tests/test_client_json_rpc_client.py
+++ b/tests/test_client_json_rpc_client.py
@@ -5,6 +5,7 @@
 import asyncio
 from collections.abc import Mapping
 from datetime import datetime
+import logging
 from typing import Any, Self
 
 from aiohttp import ClientConnectorCertificateError, ClientSession, ContentTypeError
@@ -31,6 +32,8 @@ from aiohomematic.exceptions import (
     UnsupportedException,
 )
 from aiohomematic.support import cleanup_text_from_html_tags
+
+_MISMATCH_LOG_KEY = "log.client.json_rpc.get_all_system_variables.type_mismatch"
 
 
 class _FakeResponse:
@@ -1015,10 +1018,10 @@ class TestJsonRpcClientOperations:
         )
 
     @pytest.mark.asyncio
-    async def test_get_all_system_variables_parsing_error_is_logged_and_skipped(
-        self, aiohttp_session: ClientSession, monkeypatch: pytest.MonkeyPatch
+    async def test_get_all_system_variables_type_mismatch_falls_back_to_string(
+        self, aiohttp_session: ClientSession, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """When parse_sys_var raises, the variable is skipped and the warning path is exercised."""
+        """A sysvar declared numeric with a non-numeric value is kept as STRING and reported once."""
         conn_state = hmcu.CentralConnectionState()
         client = AioJsonRpcAioHttpClient(
             username="u",
@@ -1029,43 +1032,84 @@ class TestJsonRpcClientOperations:
             tls=False,
         )
 
-        # Prepare a fake response with one system variable entry
         fake_result = [
             {
-                _JsonKey.ID: 1,
-                _JsonKey.NAME: "Var1",
+                _JsonKey.ID: "4711",
+                _JsonKey.NAME: "V.Pushover.UserKey",
                 _JsonKey.IS_INTERNAL: False,
                 _JsonKey.TYPE: HubValueType.NUMBER,
-                _JsonKey.VALUE: "123",
+                _JsonKey.VALUE: "uk2v8r19miw2tpufjotzv7j8tg57nu",
                 _JsonKey.UNIT: "",
-            }
+                _JsonKey.MIN_VALUE: "0",
+                _JsonKey.MAX_VALUE: "100",
+            },
+            {
+                _JsonKey.ID: "4712",
+                _JsonKey.NAME: "Extended",
+                _JsonKey.IS_INTERNAL: False,
+                _JsonKey.TYPE: HubValueType.LIST,
+                _JsonKey.VALUE: "not-an-index",
+                _JsonKey.UNIT: "",
+                _JsonKey.VALUE_LIST: "a;b;c",
+            },
+            {
+                _JsonKey.ID: "4713",
+                _JsonKey.NAME: "Intact",
+                _JsonKey.IS_INTERNAL: False,
+                _JsonKey.TYPE: HubValueType.NUMBER,
+                _JsonKey.VALUE: "42",
+                _JsonKey.UNIT: "",
+            },
         ]
 
         async def fake_do_post(*, session_id=False, method=None, extra_params=None, use_default_params=True):  # type: ignore[no-untyped-def]
-            # Short-circuit both login and target call
             if str(method).endswith("Session.login"):
                 return {_JsonKey.ERROR: None, _JsonKey.RESULT: {"sessionId": "s"}}
             return {_JsonKey.ERROR: None, _JsonKey.RESULT: fake_result}
 
         monkeypatch.setattr(client, "_do_post", fake_do_post)
 
-        # Avoid touching _post_script (descriptions) by returning an empty list
         async def fake_post_script(*, script_name: str, extra_params=None, keep_session=True):  # type: ignore[no-untyped-def]
-            return {_JsonKey.ERROR: None, _JsonKey.RESULT: []}
+            return {
+                _JsonKey.ERROR: None,
+                _JsonKey.RESULT: [{_JsonKey.ID: "4712", _JsonKey.DESCRIPTION: DescriptionMarker.HAHM}],
+            }
 
         monkeypatch.setattr(client, "_post_script", fake_post_script)
 
-        # Force parse_sys_var to raise a ValueError
-        from aiohomematic import support as hms
+        with caplog.at_level(logging.WARNING, logger="aiohomematic.client.json_rpc"):
+            vars_out = await client.get_all_system_variables(markers=())
 
-        def raise_value_error(*args: Any, **kwargs: Any):
-            raise ValueError("bad value")
+        by_id = {var.vid: var for var in vars_out}
+        assert set(by_id) == {"4711", "4712", "4713"}
 
-        monkeypatch.setattr(hms, "parse_sys_var", raise_value_error)
+        mismatched = by_id["4711"]
+        assert mismatched.data_type == HubValueType.STRING
+        assert mismatched.value == "uk2v8r19miw2tpufjotzv7j8tg57nu"
+        assert mismatched.min_value is None
+        assert mismatched.max_value is None
 
-        vars_out = await client.get_all_system_variables(markers=(DescriptionMarker.INTERNAL,))
-        # Should return an empty tuple because the only entry failed to parse
-        assert isinstance(vars_out, tuple) and len(vars_out) == 0
+        # A declared type we cannot trust must not produce a writable data point.
+        extended = by_id["4712"]
+        assert extended.data_type == HubValueType.STRING
+        assert extended.value == "not-an-index"
+        assert extended.extended_sysvar is False
+
+        # Untouched variables still parse into their declared type.
+        assert by_id["4713"].data_type == HubValueType.INTEGER
+        assert by_id["4713"].value == 42
+
+        # One warning per affected variable, at WARNING level (the i18n catalog is not
+        # loaded in tests, so the raw message key is what reaches the log record).
+        mismatch_records = [rec for rec in caplog.records if _MISMATCH_LOG_KEY in rec.message]
+        assert len(mismatch_records) == 2
+        assert {rec.levelno for rec in mismatch_records} == {logging.WARNING}
+
+        # A second scan must not repeat the warnings.
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="aiohomematic.client.json_rpc"):
+            await client.get_all_system_variables(markers=())
+        assert not [rec for rec in caplog.records if _MISMATCH_LOG_KEY in rec.message]
 
         await client.stop()
 

--- a/tests/test_client_json_rpc_client.py
+++ b/tests/test_client_json_rpc_client.py
@@ -1021,7 +1021,7 @@ class TestJsonRpcClientOperations:
     async def test_get_all_system_variables_type_mismatch_falls_back_to_string(
         self, aiohttp_session: ClientSession, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A sysvar declared numeric with a non-numeric value is kept as STRING and reported once."""
+        """A sysvar whose declared type does not match its value is kept as STRING and reported once."""
         conn_state = hmcu.CentralConnectionState()
         client = AioJsonRpcAioHttpClient(
             username="u",
@@ -1033,24 +1033,27 @@ class TestJsonRpcClientOperations:
         )
 
         fake_result = [
+            # The constellation reported in #3377: a value list holding a single entry,
+            # used to carry a string the CCU refuses to store as a plain string variable.
+            # The backend returns that entry as the value instead of its index.
             {
                 _JsonKey.ID: "4711",
                 _JsonKey.NAME: "V.Pushover.UserKey",
                 _JsonKey.IS_INTERNAL: False,
-                _JsonKey.TYPE: HubValueType.NUMBER,
+                _JsonKey.TYPE: HubValueType.LIST,
                 _JsonKey.VALUE: "uk2v8r19miw2tpufjotzv7j8tg57nu",
                 _JsonKey.UNIT: "",
-                _JsonKey.MIN_VALUE: "0",
-                _JsonKey.MAX_VALUE: "100",
+                _JsonKey.VALUE_LIST: "uk2v8r19miw2tpufjotzv7j8tg57nu",
             },
             {
                 _JsonKey.ID: "4712",
-                _JsonKey.NAME: "Extended",
+                _JsonKey.NAME: "Numeric",
                 _JsonKey.IS_INTERNAL: False,
-                _JsonKey.TYPE: HubValueType.LIST,
-                _JsonKey.VALUE: "not-an-index",
+                _JsonKey.TYPE: HubValueType.NUMBER,
+                _JsonKey.VALUE: "not-a-number",
                 _JsonKey.UNIT: "",
-                _JsonKey.VALUE_LIST: "a;b;c",
+                _JsonKey.MIN_VALUE: "0",
+                _JsonKey.MAX_VALUE: "100",
             },
             {
                 _JsonKey.ID: "4713",
@@ -1072,7 +1075,7 @@ class TestJsonRpcClientOperations:
         async def fake_post_script(*, script_name: str, extra_params=None, keep_session=True):  # type: ignore[no-untyped-def]
             return {
                 _JsonKey.ERROR: None,
-                _JsonKey.RESULT: [{_JsonKey.ID: "4712", _JsonKey.DESCRIPTION: DescriptionMarker.HAHM}],
+                _JsonKey.RESULT: [{_JsonKey.ID: "4711", _JsonKey.DESCRIPTION: DescriptionMarker.HAHM}],
             }
 
         monkeypatch.setattr(client, "_post_script", fake_post_script)
@@ -1086,14 +1089,15 @@ class TestJsonRpcClientOperations:
         mismatched = by_id["4711"]
         assert mismatched.data_type == HubValueType.STRING
         assert mismatched.value == "uk2v8r19miw2tpufjotzv7j8tg57nu"
-        assert mismatched.min_value is None
-        assert mismatched.max_value is None
+        # A declared type we cannot trust must not produce a writable data point,
+        # even though the description carries the marker for an extended sysvar.
+        assert mismatched.extended_sysvar is False
 
-        # A declared type we cannot trust must not produce a writable data point.
-        extended = by_id["4712"]
-        assert extended.data_type == HubValueType.STRING
-        assert extended.value == "not-an-index"
-        assert extended.extended_sysvar is False
+        numeric = by_id["4712"]
+        assert numeric.data_type == HubValueType.STRING
+        assert numeric.value == "not-a-number"
+        assert numeric.min_value is None
+        assert numeric.max_value is None
 
         # Untouched variables still parse into their declared type.
         assert by_id["4713"].data_type == HubValueType.INTEGER


### PR DESCRIPTION
Fixes #3377

## Problem

`SysVar.getAll` reports a type per variable, and `_build_sysvar_record` trusted it: `LIST` and `INTEGER` went through `int()`, and a `NUMBER` without a decimal point was treated as `INTEGER` first.

The reported variable is a **value list holding a single entry** — the reporter's way to park a string on a CCU that would not take it as a plain string variable. For that constellation the backend returns the entry itself as the value, not its index. `int()` raised, the record was discarded (`return None`), and no data point ever appeared for the variable:

```
ERROR [aiohomematic.client.json_rpc] GET_ALL_SYSTEM_VARIABLES failed:
ValueError [invalid literal for int() with base 10: 'uk2v8r19miw2tpufjotzv7j8tg57nu']
Failed to parse SysVar V.Pushover.UserKey
```

The `ERROR` was logged on every scan — **4075 times** in the submitted log, at a 60 s scan interval. Disabling the variable in the integration does not help: `_resolve_sysvar_enabled_default()` only sets `enabled_default`, the parse runs regardless.

## Change

On a conversion failure the variable now survives:

- falls back to `HubValueType.STRING`, keeps the raw value, drops `minValue`/`maxValue`
- drops `extended_sysvar`, so a declared type we could not verify never yields a writable data point — a select whose only option is the payload, or a string written back to a variable the backend holds as a float, would both be wrong
- log moves from `ERROR` to `WARNING`, is emitted **once per variable id per client**, and names the type the backend declared

The i18n key changes accordingly (`…get_all_system_variables.parse_failed` → `…get_all_system_variables.type_mismatch`) because the statement itself changed.

## Test

`test_get_all_system_variables_parsing_error_is_logged_and_skipped` is replaced by `test_get_all_system_variables_type_mismatch_falls_back_to_string`.

The old test never reached the parse path: with `markers=(INTERNAL,)` and `is_internal=False` the variable was filtered out by `_resolve_sysvar_enabled_default()` beforehand, and the monkeypatch on `hms.parse_sys_var` had no effect because `json_rpc.py:119` imports the symbol directly. It passed for the wrong reason.

The new test covers the confirmed constellation from #3377 (`LIST` with a one-entry `valueList` returning the entry as its value, plus an `HAHM` marker, asserting `extended_sysvar is False`), a generic `NUMBER` with a non-numeric value and `minValue`/`maxValue` (asserting both are reset), an intact `NUMBER` as a control, and "exactly one warning per variable, none on the second scan".

## Verification

- `pytest tests/` — 4056 passed, 1 skipped
- `prek run --all-files` — all hooks pass