### PR TITLE
chore(issue-template): ask which AI tool was used to write a report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,6 +63,19 @@ body:
         NO logs here!
 
         💡 **Tip:** For device-related issues (missing entities, wrong values, strange behavior), screenshots are much more helpful than long text descriptions! Show us what you see in Home Assistant or the CCU.
+  - type: input
+    id: ai_tool
+    validations:
+      required: false
+    attributes:
+      label: Did you use an AI tool to write this report?
+      placeholder: 'e.g.: no / ChatGPT for the translation / Claude wrote the text'
+      description: >-
+        If so, which one? That is perfectly fine and does not count against you — it only helps us
+        tell which statements you measured and which ones come from a derivation. Both are useful,
+        but we treat them differently. Please also mark AI-generated passages as a quoted block, as
+        described in the
+        [AI Policy](https://github.com/SukramJ/aiohomematic/blob/main/AI_POLICY.md).
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/bug_report_de.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_de.yml
@@ -63,6 +63,19 @@ body:
         Keine Protokolle hier!
 
         💡 **Tipp:** Bei Geräteproblemen (fehlende Entitäten, falsche Werte, seltsames Verhalten) sind Screenshots viel hilfreicher als lange Textbeschreibungen! Zeige uns, was Du in Home Assistant oder der CCU siehst.
+  - type: input
+    id: ai_tool
+    validations:
+      required: false
+    attributes:
+      label: Hast Du beim Erstellen dieses Reports ein KI-Tool eingesetzt?
+      placeholder: 'z. B.: nein / ChatGPT für die Übersetzung / Claude hat den Text formuliert'
+      description: >-
+        Wenn ja, welches? Das ist völlig in Ordnung und bringt Dir keinen Nachteil — es hilft uns
+        nur einzuordnen, welche Angaben Du gemessen hast und welche aus einer Herleitung stammen.
+        Beides ist nützlich, aber wir behandeln es unterschiedlich. Bitte kennzeichne KI-generierte
+        Textteile zusätzlich als Zitatblock, wie in der
+        [AI Policy](https://github.com/SukramJ/aiohomematic/blob/main/AI_POLICY.md) beschrieben.
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
## Why

`AI_POLICY.md` §4 asks contributors to mark AI-generated passages as a quoted block. That rule lives only in the policy file — not in the form people actually fill in. Reports arrive carrying a finished root-cause assignment instead of the raw artifacts, and nothing on the form invites the one piece of context that would let a maintainer tell a measurement from a derivation.

Detecting it after the fact does not work. A scan of the last 300 issues (July 2025 – today, bots and maintainer excluded) found no marker that identifies a tool, and no measurable increase in analysis-shaped reports: the rate of "structured headings + causal language + code/PR reference" sits between 0 % and 7 % across all 14 months. The one candidate signature in the report that prompted this — a stray `**` at the end of a line — turned out to come from this template's own `description` text, not from any tool.

Asking is the only thing that yields a fact.

## What

An optional free-text field (`id: ai_tool`, `required: false`) in both templates, placed right after the problem description and before the environment section — where the contributor has just written the text the question is about.

Free text rather than a dropdown: a yes/no choice invites evasion, while an open field allows the honest middle answer ("only for the translation"), which is the interesting one. The wording states explicitly that the answer carries no penalty — otherwise it gets answered wrong systematically — and it gives the reason that actually matters: telling a measurement from a derivation. The policy link sits at the point where the rule applies.

## Verification

`prek run --all-files` passes; both files parse as valid GitHub issue-form YAML (17 body elements each, `ai_tool` present).