### PR TITLE
fix(client): log how many values the bulk device-data fetch returned

### DIFF
--- a/aiohomematic/client/json_rpc.py
+++ b/aiohomematic/client/json_rpc.py
@@ -932,7 +932,6 @@ class AioJsonRpcAioHttpClient(LogContextMixin):
         try:
             response = await self._post_script(script_name=RegaScript.FETCH_ALL_DEVICE_DATA, extra_params=params)
 
-            _LOGGER.debug("GET_ALL_DEVICE_DATA: Getting all device data for interface %s", interface)
             if json_result := response[_JsonKey.RESULT]:
                 all_device_data = {
                     unquote(string=k, encoding=ISO_8859_1): unquote(string=v, encoding=ISO_8859_1)
@@ -949,6 +948,10 @@ class AioJsonRpcAioHttpClient(LogContextMixin):
                 )
             ) from cerr
 
+        # The size is the only externally visible evidence of what the bulk fetch returned;
+        # an empty result is what distinguishes "the backend has no timestamped value" from
+        # "the value never reached the data point".
+        _LOGGER.debug("GET_ALL_DEVICE_DATA: Got %i values for interface %s", len(all_device_data), interface)
         return all_device_data
 
     async def get_all_programs(self, *, markers: tuple[DescriptionMarker | str, ...]) -> tuple[ProgramData, ...]:

--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,19 @@
   Twenty tests cover the parsers and each failure class, including a check that
   the repository's own two files agree.
 
+- **The bulk device-data fetch reports how many values it returned.**
+  `get_all_device_data` logged only the name of the ReGa script it invoked, never
+  anything about the response. That made the single most useful fact about a start
+  invisible from the outside: whether the fetch returned values at all. When a data
+  point stays unset after a restart, the size of that result is what separates "the
+  backend holds no timestamped value for it" from "the value arrived and was not
+  applied" — two causes with opposite fixes, previously indistinguishable without a
+  session recording. A `DEBUG` line now states the count per interface, and it is
+  emitted outside the result branch so an empty result — the interesting case — is
+  logged too. The count is deliberately all it carries: it answers the question,
+  while the keys themselves would add device addresses to the log for no further
+  diagnostic value.
+
 ### Fixed
 
 - **`HmIP-HEATING` groups no longer hang at the restored Home Assistant state when

--- a/tests/test_client_json_rpc_client.py
+++ b/tests/test_client_json_rpc_client.py
@@ -1018,6 +1018,49 @@ class TestJsonRpcClientOperations:
         )
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("script_result", "expected_count"),
+        [
+            ({"BidCos-RF.OEQ0123456:1.LEVEL": 0.5, "BidCos-RF.OEQ0123456:1.DIRECTION": 0}, 2),
+            ({}, 0),
+        ],
+        ids=["with_values", "empty"],
+    )
+    async def test_get_all_device_data_logs_result_size(
+        self,
+        aiohttp_session: ClientSession,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        script_result: dict[str, Any],
+        expected_count: int,
+    ) -> None:
+        """The bulk fetch reports how many values it returned, an empty result included."""
+        conn_state = hmcu.CentralConnectionState()
+        client = AioJsonRpcAioHttpClient(
+            username="u",
+            password="p",
+            device_url="http://example",
+            connection_state=conn_state,
+            client_session=aiohttp_session,
+            tls=False,
+        )
+
+        async def fake_post_script(*, script_name: str, extra_params=None, keep_session=True):  # type: ignore[no-untyped-def]
+            return {_JsonKey.ERROR: None, _JsonKey.RESULT: script_result}
+
+        monkeypatch.setattr(client, "_post_script", fake_post_script)
+
+        with caplog.at_level(logging.DEBUG, logger="aiohomematic.client.json_rpc"):
+            result = await client.get_all_device_data(interface=Interface.BIDCOS_RF)
+
+        assert len(result) == expected_count
+        size_records = [rec for rec in caplog.records if "GET_ALL_DEVICE_DATA: Got" in rec.message]
+        assert len(size_records) == 1
+        assert f"Got {expected_count} values for interface BidCos-RF" in size_records[0].message
+
+        await client.stop()
+
+    @pytest.mark.asyncio
     async def test_get_all_system_variables_type_mismatch_falls_back_to_string(
         self, aiohttp_session: ClientSession, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:


### PR DESCRIPTION
## Why

`get_all_device_data` logged only the name of the ReGa script it invoked (`json_rpc.py:935`), never anything about the response. That made the single most useful fact about a start invisible from the outside: **whether the fetch returned values at all.**

This surfaced while diagnosing #3381. A `cover` data point stays unset after a restart, and the question is whether the CCU holds a timestamped value for it. Two causes fit the symptom and need opposite fixes:

- the backend has nothing for that data point (the ReGa script filters it out) — then the init path is doing the right thing and the design decision from #3260 is what needs revisiting;
- the value arrived and was not applied — then it is a bug in this library.

Nothing in a full DEBUG log distinguishes them. The reporter was asked for a log, produced one, and it could not have answered the question no matter how complete it was — the line simply did not exist. Short of enabling the session recorder, the only remaining option was to have the reporter run the ReGa script by hand on the CCU.

## What

A `DEBUG` line stating the number of values per interface. It sits **outside** the result branch, so an empty result — the interesting case — is logged too:

```
GET_ALL_DEVICE_DATA: Got 0 values for interface BidCos-RF
```

The previous `"Getting all device data for interface %s"` line is replaced rather than kept: it fired before the result existed and said nothing that the neighbouring `POST_SCRIPT: method: ReGa.runScript [fetch_all_device_data.fn]` line did not already carry.

The count is deliberately all it carries. It answers the question; the keys themselves would add device addresses to the log for no further diagnostic value.

## Test

`test_get_all_device_data_logs_result_size`, parametrized over a populated and an empty script result, asserting the line is emitted exactly once in both cases and names the right count and interface. The empty case is the one that regressed before: it was inside the `if json_result:` branch and therefore silent.

## Verification

- `pytest tests/` — 4058 passed, 1 skipped
- `prek run --all-files` — all hooks pass