### PR TITLE
fix(cover): send commands issued while the cover is moving

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.9.1"
+VERSION: Final = "2026.9.2"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/model/custom/cover.py
+++ b/aiohomematic/model/custom/cover.py
@@ -162,6 +162,14 @@ class CustomDpCover(PositionMixin, CustomDataPoint, CoverDataPointProtocol):
     @override
     def is_state_change(self, **kwargs: Unpack[StateChangeArgs]) -> bool:
         """Check if the state changes due to kwargs."""
+        if self.is_opening or self.is_closing:
+            # While the cover moves, the last confirmed level is not where the cover
+            # actually is: classic actuators re-report the old level when they start
+            # working and only report the new one once the movement has finished.
+            # Comparing against it would drop a command that reverses the movement back
+            # to the position the cover came from. DIRECTION is the only signal left at
+            # that point, because the echo has already cleared the optimistic value.
+            return True
         if kwargs.get(_StateChangeArg.OPEN) is not None and self._group_level != self._open_level:
             return True
         if kwargs.get(_StateChangeArg.CLOSE) is not None and self._group_level != self._closed_level:

--- a/aiohomematic/model/custom/data_point.py
+++ b/aiohomematic/model/custom/data_point.py
@@ -202,7 +202,9 @@ class CustomDataPoint(BaseDataPoint, CustomDataPointProtocol):
         """
         if self.state_uncertain:
             return True
-        _LOGGER.debug("NO_STATE_CHANGE: %s", self.name)
+        # full_name, not name: a primary custom data point has an empty name when the
+        # channel name equals the device name, which made the log line unattributable.
+        _LOGGER.debug("NO_STATE_CHANGE: %s", self.full_name)
         return False
 
     @inspector(re_raise=False)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,34 @@
+# Version 2026.9.2 (2026-09-06)
+
+## What's Changed
+
+### Fixed
+
+- **A cover command is no longer dropped while the cover is moving.**
+  `CustomDpCover.is_state_change()` compared the requested position against the last
+  level confirmed by the backend. Classic shutter actuators (`HM-LC-Bl1-*` and
+  relatives) re-report the _old_ level when they start working and only report the new
+  one once the movement has finished. That echo clears the optimistic value, so during
+  the whole travel the cover reads as if it were still at its starting position.
+
+  A command that reverses the movement back to where the cover came from therefore
+  compared equal to the current position and was discarded before it reached the
+  backend: `cover.set_cover_position` with the origin position, and `cover.close_cover`
+  while opening (and the mirrored pair while closing). Nothing was sent, nothing was
+  logged above DEBUG, and the service call reported success. Commands with any other
+  target were unaffected, and whether the drop happened at all depended on a race
+  between the echo and the second command — which made it look intermittent.
+
+  `is_state_change()` now treats a running movement as a state change. `DIRECTION` is
+  the only signal left at that point, since the echo has already cleared the optimistic
+  value. While the cover stands still, an identical command is still suppressed as
+  before. Regression tests cover both.
+
+- **The `NO_STATE_CHANGE` debug line names the data point it belongs to.** It logged
+  `name`, which is empty for a primary custom data point whose channel name equals the
+  device name — so the line that tells you a command was suppressed did not say which
+  data point suppressed it. It now logs `full_name`.
+
 # Version 2026.9.1 (2026-09-03)
 
 ## What's Changed

--- a/tests/test_model_cover.py
+++ b/tests/test_model_cover.py
@@ -4,6 +4,7 @@
 
 import asyncio
 from datetime import datetime
+import logging
 from typing import cast
 from unittest.mock import DEFAULT, call
 
@@ -153,6 +154,114 @@ class TestCustomDpCover:
         call_count = len(mock_client.method_calls)
         await cover.set_position(position=40)
         assert call_count == len(mock_client.method_calls)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_cover_command_while_moving_is_sent(
+        self,
+        central_client_factory_with_homegear_client,
+    ) -> None:
+        """A command must reach the backend while the cover is moving, even if it matches the last level."""
+        central, mock_client, _ = central_client_factory_with_homegear_client
+        cover: CustomDpCover = cast(CustomDpCover, get_prepared_custom_data_point(central, "VCU0000045", 1))
+
+        # The cover is closed, confirmed by the backend.
+        await central.event_coordinator.data_point_event(
+            interface_id=const.INTERFACE_ID, channel_address="VCU0000045:1", parameter="LEVEL", value=_CLOSED_LEVEL
+        )
+        assert cover.current_position == 0
+
+        await cover.open()
+
+        # Classic shutter actuators report DIRECTION and re-report the OLD level when they
+        # start working, and only report the new level once the movement has finished. That
+        # echo clears the optimistic value, so the cover reads as closed while it is opening.
+        await central.event_coordinator.data_point_event(
+            interface_id=const.INTERFACE_ID, channel_address="VCU0000045:1", parameter="DIRECTION", value=1
+        )
+        await central.event_coordinator.data_point_event(
+            interface_id=const.INTERFACE_ID, channel_address="VCU0000045:1", parameter="LEVEL", value=_CLOSED_LEVEL
+        )
+        assert cover.is_opening is True
+        assert cover.current_position == 0
+
+        # Reversing back to the position the cover came from must still be sent.
+        call_count = len(mock_client.method_calls)
+        await cover.set_position(position=0)
+        assert len(mock_client.method_calls) > call_count
+        assert mock_client.method_calls[-1] == call.set_value(
+            channel_address="VCU0000045:1",
+            paramset_key=ParamsetKey.VALUES,
+            parameter="LEVEL",
+            value=_CLOSED_LEVEL,
+            wait_for_callback=WAIT_FOR_CALLBACK,
+            priority=CommandPriority.HIGH,
+            retry=True,
+        )
+
+        # The same holds for close() while opening.
+        await central.event_coordinator.data_point_event(
+            interface_id=const.INTERFACE_ID, channel_address="VCU0000045:1", parameter="LEVEL", value=_CLOSED_LEVEL
+        )
+        call_count = len(mock_client.method_calls)
+        await cover.close()
+        assert len(mock_client.method_calls) > call_count
+
+        # Standing still, an identical command is still suppressed.
+        await central.event_coordinator.data_point_event(
+            interface_id=const.INTERFACE_ID, channel_address="VCU0000045:1", parameter="DIRECTION", value=0
+        )
+        await central.event_coordinator.data_point_event(
+            interface_id=const.INTERFACE_ID, channel_address="VCU0000045:1", parameter="LEVEL", value=_CLOSED_LEVEL
+        )
+        assert cover.is_opening is False
+        assert cover.is_closing is False
+        call_count = len(mock_client.method_calls)
+        await cover.close()
+        assert call_count == len(mock_client.method_calls)
+        await cover.set_position(position=0)
+        assert call_count == len(mock_client.method_calls)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            (TEST_DEVICES, True, None, None),
+        ],
+    )
+    async def test_cover_suppressed_command_is_logged_with_a_name(
+        self,
+        central_client_factory_with_homegear_client,
+        caplog,
+    ) -> None:
+        """The debug line for a suppressed command must name the data point it belongs to."""
+        central, _mock_client, _ = central_client_factory_with_homegear_client
+        cover: CustomDpCover = cast(CustomDpCover, get_prepared_custom_data_point(central, "VCU0000045", 1))
+
+        await central.event_coordinator.data_point_event(
+            interface_id=const.INTERFACE_ID, channel_address="VCU0000045:1", parameter="LEVEL", value=_CLOSED_LEVEL
+        )
+        with caplog.at_level(logging.DEBUG, logger="aiohomematic.model.custom.data_point"):
+            await cover.close()
+
+        messages = [record.getMessage() for record in caplog.records if "NO_STATE_CHANGE" in record.getMessage()]
+        assert messages
+        assert all(message.removeprefix("NO_STATE_CHANGE:").strip() for message in messages)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
## The defect

`CustomDpCover.is_state_change()` (`aiohomematic/model/custom/cover.py:163`) compares the requested position against `current_position` / `_group_level` — both derived from the last level **confirmed by the backend**.

Classic shutter actuators (`HM-LC-Bl1-*` and relatives) re-report the *old* `LEVEL` when they start working and only report the new one once the movement has finished. That echo runs through `write_value()`, which clears the optimistic value and sets `_state_uncertain = False` (`aiohomematic/model/data_point.py:1374`). For the whole duration of the travel the cover therefore reads as if it were still at its starting position, and `super().is_state_change()` (`aiohomematic/model/custom/data_point.py:197`) has no uncertainty left to fall back on.

A command that reverses the movement back to where the cover came from compares equal to the current position and returns before `_set_level()` — nothing is sent, nothing is logged above DEBUG, and the service call reports success.

## Measured, per command, cover opening from closed

Counting the `set_value` calls that actually reach the client, each case in a fresh central:

| Command during travel | with the stale echo | without it |
|---|---|---|
| `set_position(0)` (origin) | **0 sent** ❌ | 1 ✓ |
| `close()` | **0 sent** ❌ | 1 ✓ |
| `set_position(50)` | 1 ✓ | 1 ✓ |
| `set_position(100)` | 1 ✓ | 0 (correct — already the target) |
| `open()` | 1 ✓ | 0 (correct — already the target) |

The control without the echo inverts the result, which pins the cause. It also explains why the behaviour looks intermittent: it is a race between the echo and the second command.

Scope is narrower than "every command during movement" — only commands whose target equals the last confirmed level are affected. That is exactly the reversal case, which is the one that matters in practice.

## The fix

`is_state_change()` treats a running movement as a state change. `DIRECTION` is the only signal left at that point, because the echo has already cleared the optimistic value. `is_opening`/`is_closing` return `None` when the device reports no `DIRECTION`, which is falsy — devices without it keep their previous behaviour.

While the cover stands still, an identical command is still suppressed. The existing `test_cecover` assertions covering that suppression stay green unchanged.

`CustomDpWindowDrive`, `CustomDpBlind` and `CustomDpIpBlind` inherit the method. For blinds the movement-aware `_set_level()` path (stop first, then send) is now actually reachable during travel — previously the comparison dropped the command before it got there.

## Also fixed

The `NO_STATE_CHANGE` debug line logged `name`, which is empty for a primary custom data point whose channel name equals the device name (`aiohomematic/model/support.py:135-138`). The line that tells you a command was suppressed did not say which data point suppressed it. It now logs `full_name`, matching the neighbouring `OPTIMISTIC_MISMATCH` line.

## Tests

Test-first: both new tests fail against the unpatched model layer and pass with the fix.

- `test_cover_command_while_moving_is_sent` — HM-LC-Bl1-FM: open, then `DIRECTION=UP` plus the stale `LEVEL` echo, then a reversal to the origin position and `close()`; both must reach the backend. Ends by asserting that after `DIRECTION=0` an identical command is suppressed again, so the fix cannot silently become "always send".
- `test_cover_suppressed_command_is_logged_with_a_name` — the suppressed-command debug line carries a non-empty name.

Full suite: 4109 passed, 1 skipped. `prek run --all-files` clean.