### PR TITLE
chore(issue-triage): describe the motivating report without citing its number

### DIFF
--- a/.github/scripts/analyze_issue.py
+++ b/.github/scripts/analyze_issue.py
@@ -216,8 +216,8 @@ STRONG_AI_MARKERS: Final[tuple[str, ...]] = (
     "ich bin ein ki",
     "sprachmodell",
     # Authorship disclosure. Reports written end-to-end by an assistant increasingly
-    # open with such a line instead of the self-identification markers above; #3387
-    # carried "This report was written by Claude (Anthropic)" and went undetected.
+    # open with such a line instead of the self-identification markers above; a line
+    # like "This report was written by <assistant>" went undetected without these.
     "ai disclosure",
     "ki-offenlegung",
     "written by claude",

--- a/.github/scripts/check_issue_template.py
+++ b/.github/scripts/check_issue_template.py
@@ -5,8 +5,8 @@ Verify that a new issue actually went through the issue form.
 The bug-report forms mark every item of the "I agree to the following" checklist as
 ``required: true``. GitHub enforces that only in the browser: an issue created through
 the REST/GraphQL API (``gh issue create``, an MCP server, an agent) can carry an
-arbitrary body, with the checklist shortened, reworded or left unchecked. Issue #3387
-did exactly that and dropped the mandatory diagnostics along the way.
+arbitrary body, with the checklist shortened, reworded or left unchecked, and the
+mandatory diagnostics dropped along the way.
 
 This check is deterministic and template-driven: the required checkbox labels and the
 field headings are read from ``.github/ISSUE_TEMPLATE/*.yml`` at run time, so the check
@@ -64,8 +64,8 @@ MIN_STRUCTURE_RATIO: Final = 0.5
 # Number of missing required labels still attributable to template drift rather than to a
 # rewritten checklist. Measured against the 25 most recent externally filed issues
 # (2026-09): every legitimately filed one misses at most one label - the "supported hubs"
-# item, added to the templates after those issues were opened - while #3387, which was
-# composed outside the form, misses seven.
+# item, added to the templates after those issues were opened - while a report composed
+# outside the form misses seven.
 MAX_DRIFT_MISSING: Final = 1
 
 # Link targets used in the comment

--- a/tests/github_scripts/test_analyze_issue.py
+++ b/tests/github_scripts/test_analyze_issue.py
@@ -725,7 +725,7 @@ def test_detect_ai_generated_analysis_uses_form_disclosure() -> None:
 
 
 def test_detect_ai_generated_analysis_authorship_disclosure_marker() -> None:
-    """Flag an authorship disclosure in the body - the signal #3387 carried and that was missed."""
+    """Flag an authorship disclosure in the body - a signal the marker list previously missed."""
     body = "> **AI disclosure (per AI_POLICY.md):** This report was written by Claude (Anthropic)."
     result = analyze_issue.detect_ai_generated_analysis(body)
     assert result["detected"] is True

--- a/tests/github_scripts/test_check_issue_template.py
+++ b/tests/github_scripts/test_check_issue_template.py
@@ -235,17 +235,17 @@ def test_is_not_exempt_for_external_reporter() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Regression: the issue that motivated the check
+# Regression: the report shape that motivated the check
 # ---------------------------------------------------------------------------
 
 
-def test_issue_3387_shape_is_flagged() -> None:
+def test_freely_composed_report_is_flagged() -> None:
     """
-    Flag the body shape of #3387: a freely composed report without attachments.
+    Flag the body shape that motivated this check: a composed report without attachments.
 
-    The report reworded the checklist labels and replaced the mandatory diagnostics item
-    with a prose note, which the issue form's required-field validation would have
-    rejected - the issue was created through the API instead.
+    It reworded the checklist labels and replaced the mandatory diagnostics item with a
+    prose note, which the issue form's required-field validation would have rejected -
+    the issue was created through the API instead.
     """
     body = (
         "> **AI disclosure (per AI_POLICY.md):** This report was written by Claude (Anthropic).\n\n"


### PR DESCRIPTION
Follow-up to the issue-form enforcement change: the comments and test names there cited a specific issue number as the source of the measurements. The number carried no information the surrounding text does not, so it is replaced by what actually matters.

## Changes

| Location | Was | Is |
|---|---|---|
| `check_issue_template.py` module docstring | "Issue #NNNN did exactly that and dropped the mandatory diagnostics" | describes the body shape itself |
| `check_issue_template.py` `MAX_DRIFT_MISSING` | "while #NNNN, which was composed outside the form, misses seven" | "while a report composed outside the form misses seven" |
| `analyze_issue.py` authorship markers | quoted the disclosure line of a specific report | describes the pattern generically |
| `test_analyze_issue.py` | "the signal #NNNN carried" | "a signal the marker list previously missed" |
| `test_check_issue_template.py` | `test_issue_NNNN_shape_is_flagged` | `test_freely_composed_report_is_flagged` |

The measurement the drift threshold rests on stays in place — it is the part that has to be checkable. The regression test keeps the full sample body, which is what pins the behaviour.

99 tests in `tests/github_scripts/` pass, `prek run --all-files` clean.