### PR TITLE
fix(availability): re-measure device availability after a reconnect

### DIFF
--- a/aiohomematic/central/coordinators/connection_recovery.py
+++ b/aiohomematic/central/coordinators/connection_recovery.py
@@ -937,6 +937,7 @@ class ConnectionRecoveryCoordinator(RecoveryProviderForMetricsProtocol):
         """Refresh data for a specific interface after recovery."""
         try:
             client = self._client_provider.get_client(interface_id=interface_id)
+            await self._reload_availability_state(interface_id=interface_id)
             await self._device_data_refresher.load_and_refresh_data_point_data(interface=client.interface)
             _LOGGER.debug("CONNECTION_RECOVERY: Data refresh completed for %s", interface_id)
         except Exception:
@@ -945,11 +946,30 @@ class ConnectionRecoveryCoordinator(RecoveryProviderForMetricsProtocol):
                 interface_id,
             )
 
+    async def _reload_availability_state(self, *, interface_id: str) -> None:
+        """
+        Re-measure the availability of every device of an interface.
+
+        The backend sends UN_REACH only on change, so a device that became
+        reachable again while the connection was down is never announced. Doing
+        this before the data load also matters for the load itself: the value
+        cache refuses to read parameters of a device it considers unavailable.
+        """
+        await asyncio.gather(
+            *(
+                device.reload_availability_state()
+                for device in self._coordinator_provider.device_registry.devices
+                if device.interface_id == interface_id
+            ),
+            return_exceptions=True,
+        )
+
     async def _stage_data_load(self, *, interface_id: str) -> bool:
-        """Stage: Load device and paramset data, then refresh hub data."""
+        """Stage: Re-measure availability, load device and paramset data, then refresh hub data."""
         try:
             client = self._client_provider.get_client(interface_id=interface_id)
             interface = client.interface
+            await self._reload_availability_state(interface_id=interface_id)
             await self._device_data_refresher.load_and_refresh_data_point_data(interface=interface)
         except Exception:
             _LOGGER.exception(  # i18n-log: ignore

--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.9.2"
+VERSION: Final = "2026.9.3"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/interfaces/model.py
+++ b/aiohomematic/interfaces/model.py
@@ -1962,6 +1962,10 @@ class DeviceProtocol(
         """Refresh firmware data of the device."""
 
     @abstractmethod
+    async def reload_availability_state(self) -> None:
+        """Re-read the availability parameters of channel 0 from the backend."""
+
+    @abstractmethod
     async def reload_device_config(self) -> None:
         """Reload device configuration and master parameter values."""
 

--- a/aiohomematic/model/device.py
+++ b/aiohomematic/model/device.py
@@ -832,6 +832,49 @@ class Device(DeviceProtocol, LogContextMixin):
             interface_id=self._interface_id, address=self._address
         )
 
+    @inspector(scope=ServiceScope.INTERNAL)
+    async def reload_availability_state(self) -> None:
+        """
+        Re-read the availability parameters of channel 0 from the backend.
+
+        The backend announces UN_REACH only when the value changes. A transition
+        that happens while the connection is down is therefore never delivered,
+        and the device keeps the stale value for as long as the central runs.
+        Re-reading channel 0 after a reconnect closes that gap.
+
+        Values are applied through the regular event path, so a change reaches
+        every data point of the device. A read that fails, or a paramset that
+        does not carry the parameter, leaves the data point untouched: an
+        unavailable device must never become available by falling back to a
+        default.
+        """
+        if (channel := self.get_channel(channel_address=f"{self._address}{ADDRESS_SEPARATOR}0")) is None:
+            return
+        data_points = {
+            parameter: data_point
+            for parameter in RELEVANT_INIT_PARAMETERS
+            if (data_point := channel.get_generic_data_point(parameter=parameter, paramset_key=ParamsetKey.VALUES))
+            is not None
+        }
+        if not data_points:
+            return
+
+        try:
+            values = await self._client.get_paramset(channel_address=channel.address, paramset_key=ParamsetKey.VALUES)
+        except BaseHomematicException as bhexc:
+            _LOGGER.debug(
+                "RELOAD_AVAILABILITY_STATE: Failed to read %s for %s [%s]",
+                channel.address,
+                self._name,
+                extract_exc_args(exc=bhexc),
+            )
+            return
+
+        received_at = datetime.now()
+        for parameter, data_point in data_points.items():
+            if (value := values.get(parameter)) is not None:
+                await data_point.event(value=value, received_at=received_at)
+
     @inspector
     async def reload_device_config(self) -> None:
         """

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,44 @@
+# Version 2026.9.3 (2026-09-11)
+
+## What's Changed
+
+### Fixed
+
+- **Devices no longer stay unavailable after a reconnect.** The backend announces
+  `UNREACH` only when the value changes. If a device becomes reachable again while the
+  connection is down — a backend restart resets the flag, or the device recovers while
+  the proxy is gone — that transition is never delivered, and aiohomematic keeps the
+  stale `UNREACH=true` for as long as the central runs.
+
+  Nothing closed that gap, because `UN_REACH` and `STICKY_UN_REACH` are hidden
+  parameters and therefore carry `DataPointUsage.NO_CREATE`. `refresh_data_point_data()`
+  iterates `get_readable_generic_data_points()`, which excludes exactly those, so the
+  recovery data load never touched them. The only path that reads them via RPC is
+  `_ValueCache.init_base_data_points()`, and that runs solely for newly created devices.
+  The result: the client reconnects, events flow, commands work — and every device that
+  was marked unreachable before the outage stays unavailable in Home Assistant until the
+  integration is reloaded or `force_device_availability` is applied by hand.
+
+  `Device.reload_availability_state()` re-reads the channel 0 `VALUES` paramset and
+  applies `UN_REACH`, `STICKY_UN_REACH` and `CONFIG_PENDING` through the regular event
+  path, so the recovered availability reaches the data points of every channel. The
+  connection recovery now performs that re-read for all devices of the interface before
+  refreshing the remaining data — in the staged data load as well as in the circuit
+  breaker recovery — which also unblocks that refresh, since the value cache refuses to
+  read parameters of a device it considers unavailable.
+
+  The re-read deliberately uses `getParamset` instead of the per-parameter `getValue`
+  fallback: the latter is skipped for the interfaces in
+  `INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK` (BidCos-RF, VirtualDevices, CUxD,
+  CCU-Jack), so building on it would have produced a fix that silently does nothing on
+  four of six interfaces.
+
+  The value is measured, never defaulted: a read that fails, or a paramset that does not
+  carry the parameter, leaves the data point untouched. That distinction matters — a
+  boolean data point without a value falls back to its paramset default (`false`), so a
+  swallowed read error would have silently reported every unreachable device as
+  reachable. Contract tests pin both directions.
+
 # Version 2026.9.2 (2026-09-06)
 
 ## What's Changed

--- a/tests/contract/test_availability_resync_contract.py
+++ b/tests/contract/test_availability_resync_contract.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""
+Contract tests for availability re-sync after a reconnect.
+
+STABILITY GUARANTEE
+-------------------
+The backend announces UN_REACH only when the value changes. A transition that
+happens while the connection is down is therefore never delivered, and the
+device would keep the stale value for the whole lifetime of the central.
+
+These tests pin the contract that closes that gap:
+
+1. ``Device.reload_availability_state()`` re-reads channel 0 from the backend
+   and applies UN_REACH / STICKY_UN_REACH / CONFIG_PENDING.
+2. The value is *measured*, never defaulted: a failed or incomplete read leaves
+   the data points untouched.
+3. Connection recovery performs that re-read — in the staged data load as well
+   as in the circuit breaker recovery.
+
+See ADR-0018 for architectural context.
+"""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from aiohomematic.const import Parameter, ParamsetKey
+from aiohomematic.exceptions import ClientException
+from aiohomematic_test_support import const
+
+TEST_DEVICES: set[str] = {"VCU2128127"}
+TEST_DEVICE_ADDRESS = "VCU2128127"
+
+
+async def _mark_unreachable(central: Any, device: Any) -> None:
+    """Let the backend report the device as unreachable."""
+    await central.event_coordinator.data_point_event(
+        interface_id=const.INTERFACE_ID,
+        channel_address=f"{device.address}:0",
+        parameter=Parameter.UN_REACH,
+        value=1,
+    )
+
+
+class TestAvailabilityResyncContract:
+    """Contract: availability is re-measured after a reconnect."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("address_device_translation", "do_mock_client", "ignore_devices_on_create", "un_ignore_list"),
+        [(TEST_DEVICES, True, None, None)],
+    )
+    async def test_reload_does_not_default_on_absent_parameter(
+        self, central_client_factory_with_homegear_client
+    ) -> None:
+        """Contract: a paramset without UN_REACH must not flip the device to available."""
+        central, client, _ = central_client_factory_with_homegear_client
+        device = central.device_coordinator.get_device(address=TEST_DEVICE_ADDRESS)
+
+        await _mark_unreachable(central=central, device=device)
+
+        with patch.object(client, "get_paramset", return_value={"STATE": False}):
+            await device.reload_availability_state()
+
+        assert device.available is False, "an absent UN_REACH must not be treated as 'reachable'"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("address_device_translation", "do_mock_client", "ignore_devices_on_create", "un_ignore_list"),
+        [(TEST_DEVICES, True, None, None)],
+    )
+    async def test_reload_does_not_default_on_failed_read(self, central_client_factory_with_homegear_client) -> None:
+        """Contract: a failed read must not flip the device to available."""
+        central, client, _ = central_client_factory_with_homegear_client
+        device = central.device_coordinator.get_device(address=TEST_DEVICE_ADDRESS)
+
+        await _mark_unreachable(central=central, device=device)
+
+        with patch.object(client, "get_paramset", side_effect=ClientException("boom")):
+            await device.reload_availability_state()
+
+        assert device.available is False, "a failed read must not be treated as 'reachable'"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("address_device_translation", "do_mock_client", "ignore_devices_on_create", "un_ignore_list"),
+        [(TEST_DEVICES, True, None, None)],
+    )
+    async def test_reload_keeps_unavailable_when_backend_still_reports_unreachable(
+        self, central_client_factory_with_homegear_client
+    ) -> None:
+        """Contract: a device the backend still reports as unreachable stays unavailable."""
+        central, client, _ = central_client_factory_with_homegear_client
+        device = central.device_coordinator.get_device(address=TEST_DEVICE_ADDRESS)
+
+        await _mark_unreachable(central=central, device=device)
+
+        with patch.object(client, "get_paramset", return_value={Parameter.UN_REACH: True}):
+            await device.reload_availability_state()
+
+        assert device.available is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("address_device_translation", "do_mock_client", "ignore_devices_on_create", "un_ignore_list"),
+        [(TEST_DEVICES, True, None, None)],
+    )
+    async def test_reload_notifies_data_points(self, central_client_factory_with_homegear_client) -> None:
+        """Contract: the recovered availability reaches the data points of other channels."""
+        central, client, _ = central_client_factory_with_homegear_client
+        device = central.device_coordinator.get_device(address=TEST_DEVICE_ADDRESS)
+
+        other_channel_dp = next(dp for dp in device.generic_data_points if dp.channel.no not in (None, 0))
+
+        await _mark_unreachable(central=central, device=device)
+        assert other_channel_dp.available is False
+
+        updates: list[str] = []
+        unsubscribe = device.subscribe_to_device_updated(handler=lambda **kwargs: updates.append("updated"))
+        try:
+            with patch.object(client, "get_paramset", return_value={Parameter.UN_REACH: False}):
+                await device.reload_availability_state()
+        finally:
+            unsubscribe()
+
+        assert other_channel_dp.available is True
+        assert updates, "a recovered availability must publish a device updated event"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("address_device_translation", "do_mock_client", "ignore_devices_on_create", "un_ignore_list"),
+        [(TEST_DEVICES, True, None, None)],
+    )
+    async def test_reload_reads_channel_zero_values_paramset(self, central_client_factory_with_homegear_client) -> None:
+        """Contract: the re-read fetches the channel 0 VALUES paramset from the backend."""
+        central, client, _ = central_client_factory_with_homegear_client
+        device = central.device_coordinator.get_device(address=TEST_DEVICE_ADDRESS)
+
+        await _mark_unreachable(central=central, device=device)
+        assert device.available is False
+
+        with patch.object(
+            client, "get_paramset", return_value={Parameter.UN_REACH: False, Parameter.STICKY_UN_REACH: False}
+        ) as get_paramset_mock:
+            await device.reload_availability_state()
+
+        get_paramset_mock.assert_awaited_once()
+        kwargs = get_paramset_mock.await_args.kwargs
+        assert kwargs["channel_address"] == f"{TEST_DEVICE_ADDRESS}:0"
+        assert kwargs["paramset_key"] == ParamsetKey.VALUES
+        assert device.available is True
+
+
+class TestRecoveryResyncContract:
+    """Contract: connection recovery re-measures availability before refreshing data."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("address_device_translation", "do_mock_client", "ignore_devices_on_create", "un_ignore_list"),
+        [(TEST_DEVICES, True, None, None)],
+    )
+    async def test_data_load_stage_reloads_availability(self, central_client_factory_with_homegear_client) -> None:
+        """Contract: the data-load stage re-reads availability for every device of the interface."""
+        central, _, _ = central_client_factory_with_homegear_client
+        device = central.device_coordinator.get_device(address=TEST_DEVICE_ADDRESS)
+        recovery = central.connection_recovery_coordinator
+
+        with patch.object(type(device), "reload_availability_state") as reload_mock:
+            assert await recovery._stage_data_load(interface_id=const.INTERFACE_ID) is True
+
+        reload_mock.assert_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("address_device_translation", "do_mock_client", "ignore_devices_on_create", "un_ignore_list"),
+        [(TEST_DEVICES, True, None, None)],
+    )
+    async def test_interface_data_refresh_reloads_availability(
+        self, central_client_factory_with_homegear_client
+    ) -> None:
+        """Contract: the circuit-breaker recovery refresh re-reads availability as well."""
+        central, _, _ = central_client_factory_with_homegear_client
+        device = central.device_coordinator.get_device(address=TEST_DEVICE_ADDRESS)
+        recovery = central.connection_recovery_coordinator
+
+        with patch.object(type(device), "reload_availability_state") as reload_mock:
+            await recovery._refresh_interface_data(interface_id=const.INTERFACE_ID)
+
+        reload_mock.assert_awaited()


### PR DESCRIPTION
## Problem

The backend announces `UNREACH` only when the value changes. If a device becomes reachable again while the connection is down — a backend restart resets the flag, or the device recovers while the proxy is gone — that transition is never delivered, and aiohomematic keeps the stale `UNREACH=true` for as long as the central runs.

Nothing closed that gap:

- `UN_REACH` and `STICKY_UN_REACH` are in `HIDDEN_PARAMETERS`, so their data points carry `DataPointUsage.NO_CREATE`.
- `refresh_data_point_data()` iterates `get_readable_generic_data_points()`, which goes through `get_data_points(exclude_no_create=True)` — those parameters are excluded, so the recovery data load never touched them.
- The only path that reads them via RPC is `_ValueCache.init_base_data_points()`, reached from `finalize_init()`, which runs solely for newly created devices.

Net effect: the client reconnects, events flow, commands work — and every device that was marked unreachable before the outage stays unavailable in Home Assistant until the integration is reloaded or `force_device_availability` is applied by hand.

## Measured

From a user-supplied, gap-free DEBUG log (07:56:11–09:19:23, `rpc_server` DEBUG active throughout):

- Exactly two inbound `UNREACH`-related events, both value `1`. No `UNREACH=0` anywhere.
- After `init()` the CCU sends an initial burst (`STATE`/`WORKING` for many channels) — **without** `UNREACH`.
- Between the reconnect and the next HA restart (24 minutes) no `UNREACH` event arrived, although both affected modules were demonstrably working (`PRESS_SHORT`, `STATE` echoes).
- Diagnostics: `devices_available` 6/8 while the client was `connected` with `health_score 1.0`; 8/8 again only after a full restart, whose `getValue` calls on `UNREACH` succeeded without a single recorded incident.

## Change

`Device.reload_availability_state()` re-reads the channel 0 `VALUES` paramset and applies `UN_REACH`, `STICKY_UN_REACH` and `CONFIG_PENDING` through the regular event path (`data_point.event()`), so the recovered availability reaches the data points of every channel — `write_value()` would not, the notification lives in `GenericDataPoint.event()`.

Connection recovery performs that re-read for all devices of the interface before refreshing the remaining data, in `_stage_data_load` as well as in `_refresh_interface_data` (circuit breaker `HALF_OPEN → CLOSED`). Doing it first also unblocks the refresh itself: `_get_values_for_cache()` refuses to read parameters of a device it considers unavailable.

Two deliberate decisions:

- **`getParamset`, not the value cache.** The per-parameter `getValue` fallback is skipped for `INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK` (BidCos-RF, VirtualDevices, CUxD, CCU-Jack). Building on it would have produced a fix that silently does nothing on four of six interfaces.
- **No default fallback.** A failed read, or a paramset without the parameter, leaves the data point untouched. `DpBinarySensor._get_value()` falls back to its paramset default (`false`) when it has no value, so a swallowed read error would have reported every unreachable device as reachable.

`DeviceProtocol` gained the method (required by mypy strict).

## Tests

`tests/contract/test_availability_resync_contract.py`, 7 contract tests: the backend read is proven (`channel_address` and `paramset_key` asserted), three negative cases (backend still reports unreachable / read raises / parameter absent), propagation to data points on other channels, and the wiring of both recovery paths. Mutation-checked: with a no-op implementation the two positive tests fail while the negative ones keep passing.

Full suite 4116 passed / 1 skipped, `prek run --all-files` clean.

## Known limit

If the backend recovers without aiohomematic registering a connection loss, no recovery runs and nothing is re-read. In the reported incident the loss was detected, so the path applies. A periodic re-read would be the alternative — considerably more expensive, and there is no evidence that case occurs.

Fixes #3396 
