### PR TITLE
fix(store): refresh the expired bulk snapshot before giving up

### DIFF
--- a/aiohomematic/central/coordinators/client.py
+++ b/aiohomematic/central/coordinators/client.py
@@ -276,7 +276,7 @@ class ClientCoordinator(ClientCoordinationProtocol, ClientProviderProtocol):
 
         # Enable cache expiration now that device creation is complete.
         # During device creation, cache expiration was disabled to prevent getValue
-        # calls when device creation takes longer than MAX_CACHE_AGE (10 seconds).
+        # calls when device creation takes longer than MAX_CACHE_AGE (15 seconds).
         self._coordinator_provider.cache_coordinator.set_data_cache_initialization_complete()
 
         # Initialize hub (requires connected clients and devices to fetch programs/sysvars)

--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.9.3"
+VERSION: Final = "2026.9.4"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (
@@ -305,7 +305,7 @@ COMMAND_TRACKER_MAX_SIZE: Final = 500  # Maximum entries in command tracker
 COMMAND_TRACKER_WARNING_THRESHOLD: Final = 400  # Log warning when approaching limit
 PING_PONG_CACHE_MAX_SIZE: Final = 100  # Maximum entries in ping/pong cache per interface
 LOCAL_HOST: Final = "127.0.0.1"
-MAX_CACHE_AGE: Final = 10
+MAX_CACHE_AGE: Final = 15
 MAX_CONCURRENT_HTTP_SESSIONS: Final = 3
 MAX_RPC_BACKGROUND_TASKS: Final = 10000
 MAX_WAIT_FOR_CALLBACK: Final = 60

--- a/aiohomematic/interfaces/central.py
+++ b/aiohomematic/interfaces/central.py
@@ -592,6 +592,10 @@ class DataCacheProviderProtocol(Protocol):
     def get_data(self, *, interface: Interface, channel_address: str, parameter: str) -> Any:
         """Get cached data for a parameter."""
 
+    @abstractmethod
+    async def refresh_if_expired(self, *, interface: Interface) -> bool:
+        """Reload the bulk snapshot for an interface if it has expired."""
+
 
 @runtime_checkable
 class HubDataFetcherProtocol(Protocol):

--- a/aiohomematic/model/device.py
+++ b/aiohomematic/model/device.py
@@ -2044,12 +2044,32 @@ class _ValueCache:
             # trustworthy device-fresh data (only a CCU-internal placeholder that would be
             # marked valid), or is actively harmful. The bulk fetch (ReGa /
             # get_all_device_data) plus later events are the reliable sources, so the
-            # per-parameter getValue fallback is skipped and the data point keeps its (unset)
+            # per-parameter getValue fallback is replaced by a refresh of the bulk
+            # snapshot; if that has no value either, the data point keeps its (unset)
             # state until a real value arrives via event. See
             # INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK for the per-interface rationale
             # (VirtualDevices/BidCos-RF placeholders #3228/#3260; CUxD/CCU-Jack JSON-RPC
             # session flood).
             if self._device.interface in INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK:
+                # The bulk snapshot is taken during start_clients() and expires after
+                # MAX_CACHE_AGE, long before Home Assistant adds its entities. Refresh it
+                # instead of giving up: without the getValue fallback, a data point that
+                # never emits an event on its own (a cover's LEVEL, a switch's STATE)
+                # would otherwise stay unset until the device is operated manually
+                # (#3398).
+                data_cache_provider = self._device.data_cache_provider
+                if (
+                    await data_cache_provider.refresh_if_expired(interface=self._device.interface)
+                    and (
+                        cached_value := data_cache_provider.get_data(
+                            interface=self._device.interface,
+                            channel_address=dpk.channel_address,
+                            parameter=dpk.parameter,
+                        )
+                    )
+                    != NO_CACHE_ENTRY
+                ):
+                    return {dpk.parameter: cached_value}
                 return {dpk.parameter: self._NO_VALUE_CACHE_ENTRY}
             return {
                 dpk.parameter: await self._device.client.get_value(

--- a/aiohomematic/store/dynamic/data.py
+++ b/aiohomematic/store/dynamic/data.py
@@ -11,6 +11,7 @@ This avoids background task overhead for a small number of interface-keyed entri
 Stale data causes a cache miss → refresh cycle (self-healing).
 """
 
+import asyncio
 from collections.abc import Mapping
 from datetime import datetime
 import logging
@@ -73,6 +74,7 @@ class CentralDataCache(DataCacheProviderProtocol, DataCacheWriterProtocol, Cache
         "_data_point_provider",
         "_device_provider",
         "_is_initializing",
+        "_refresh_locks",
         "_refreshed_at",
         "_stats",
         "_value_cache",
@@ -95,6 +97,7 @@ class CentralDataCache(DataCacheProviderProtocol, DataCacheWriterProtocol, Cache
         # { key, value}
         self._value_cache: Final[dict[Interface, Mapping[str, Any]]] = {}
         self._refreshed_at: Final[dict[Interface, datetime]] = {}
+        self._refresh_locks: Final[dict[Interface, asyncio.Lock]] = {}
         # During initialization, cache expiration is disabled to prevent
         # getValue calls when device creation takes longer than MAX_CACHE_AGE
         self._is_initializing: bool = True
@@ -158,7 +161,9 @@ class CentralDataCache(DataCacheProviderProtocol, DataCacheWriterProtocol, Cache
                 last_change=self._get_refreshed_at(interface=client.interface),
                 max_age=int(MAX_CACHE_AGE / 3),
             ):
-                return
+                # Skip only this interface: a fresh snapshot for one client must not
+                # keep the remaining clients from being loaded.
+                continue
             await client.fetch_all_device_data()
 
     async def refresh_data_point_data(
@@ -186,6 +191,29 @@ class CentralDataCache(DataCacheProviderProtocol, DataCacheWriterProtocol, Cache
         ):
             await dp.load_data_point_value(call_source=call_source, direct_call=direct_call)
 
+    async def refresh_if_expired(self, *, interface: Interface) -> bool:
+        """
+        Reload the bulk snapshot for an interface if it has expired.
+
+        The snapshot is taken once during ``start_clients()`` and expires after
+        ``MAX_CACHE_AGE``. Consumers that read it later than that — Home Assistant adds
+        its entities only after the platforms have been forwarded — would otherwise find
+        an empty cache. Refetching is cheap (one ReGa script call) and does not touch the
+        duty cycle.
+
+        Returns:
+            True if the interface holds usable data afterwards.
+
+        """
+        if not self._is_empty(interface=interface):
+            return True
+        async with self._get_refresh_lock(interface=interface):
+            # A concurrent waiter may have refilled the bucket while we waited for the lock.
+            if not self._is_empty(interface=interface):
+                return True
+            await self.load(interface=interface)
+            return not self._is_empty(interface=interface)
+
     def set_initialization_complete(self) -> None:
         """
         Mark initialization as complete, enabling cache expiration.
@@ -201,6 +229,12 @@ class CentralDataCache(DataCacheProviderProtocol, DataCacheWriterProtocol, Cache
             self._central_info.name,
         )
 
+    def _get_refresh_lock(self, *, interface: Interface) -> asyncio.Lock:
+        """Return the per-interface lock that serializes bulk snapshot refreshes."""
+        if (lock := self._refresh_locks.get(interface)) is None:
+            lock = self._refresh_locks[interface] = asyncio.Lock()
+        return lock
+
     def _get_refreshed_at(self, *, interface: Interface) -> datetime:
         """Return when cache has been refreshed."""
         return self._refreshed_at.get(interface, INIT_DATETIME)
@@ -211,7 +245,7 @@ class CentralDataCache(DataCacheProviderProtocol, DataCacheWriterProtocol, Cache
         if not self._value_cache.get(interface):
             return True
         # Skip cache expiration during initialization to prevent getValue calls
-        # when device creation takes longer than MAX_CACHE_AGE (10 seconds).
+        # when device creation takes longer than MAX_CACHE_AGE (15 seconds).
         if self._is_initializing:
             return False
         # Auto-expire stale cache by interface.

--- a/aiohomematic/store/dynamic/data.py
+++ b/aiohomematic/store/dynamic/data.py
@@ -74,6 +74,7 @@ class CentralDataCache(DataCacheProviderProtocol, DataCacheWriterProtocol, Cache
         "_data_point_provider",
         "_device_provider",
         "_is_initializing",
+        "_refresh_attempted_at",
         "_refresh_locks",
         "_refreshed_at",
         "_stats",
@@ -98,6 +99,7 @@ class CentralDataCache(DataCacheProviderProtocol, DataCacheWriterProtocol, Cache
         self._value_cache: Final[dict[Interface, Mapping[str, Any]]] = {}
         self._refreshed_at: Final[dict[Interface, datetime]] = {}
         self._refresh_locks: Final[dict[Interface, asyncio.Lock]] = {}
+        self._refresh_attempted_at: Final[dict[Interface, datetime]] = {}
         # During initialization, cache expiration is disabled to prevent
         # getValue calls when device creation takes longer than MAX_CACHE_AGE
         self._is_initializing: bool = True
@@ -129,6 +131,9 @@ class CentralDataCache(DataCacheProviderProtocol, DataCacheWriterProtocol, Cache
         if interface:
             self._value_cache[interface] = {}
             self._refreshed_at[interface] = INIT_DATETIME
+            # An explicit invalidation warrants a new attempt, even if the last one
+            # came back empty.
+            self._refresh_attempted_at.pop(interface, None)
         else:
             for _interface in self._device_provider.interfaces:
                 self.clear(interface=_interface)
@@ -211,6 +216,17 @@ class CentralDataCache(DataCacheProviderProtocol, DataCacheWriterProtocol, Cache
             # A concurrent waiter may have refilled the bucket while we waited for the lock.
             if not self._is_empty(interface=interface):
                 return True
+            # A bulk fetch that comes back empty never advances _refreshed_at, because
+            # fetch_all_device_data() only calls add_data() for a non-empty result. The
+            # lock alone does not help: it coalesces concurrent callers, while the callers
+            # here are serialized by the value cache semaphore. Without this marker every
+            # data point would trigger its own ReGa script run.
+            if changed_within_seconds(
+                last_change=self._refresh_attempted_at.get(interface, INIT_DATETIME),
+                max_age=int(MAX_CACHE_AGE / 3),
+            ):
+                return False
+            self._refresh_attempted_at[interface] = datetime.now()
             await self.load(interface=interface)
             return not self._is_empty(interface=interface)
 

--- a/aiohomematic/support/__init__.py
+++ b/aiohomematic/support/__init__.py
@@ -179,11 +179,12 @@ def get_tls_context(*, verify_tls: bool) -> ssl.SSLContext:
 
 
 def changed_within_seconds(*, last_change: datetime, max_age: int = MAX_CACHE_AGE) -> bool:
-    """DataPoint has been modified within X minutes."""
+    """DataPoint has been modified within X seconds."""
     if last_change == INIT_DATETIME:
         return False
-    delta = datetime.now() - last_change
-    return delta.seconds < max_age
+    # total_seconds(), not seconds: the latter drops whole days, so a change from
+    # exactly 24 h ago would count as recent.
+    return (datetime.now() - last_change).total_seconds() < max_age
 
 
 def find_free_port() -> int:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,47 @@
+# Version 2026.9.4 (2026-09-12)
+
+## What's Changed
+
+### Fixed
+
+- **BidCos-RF data points no longer stay on `restored` after a start.** The ReGa bulk
+  fetch collects every value the backend knows and stores it in the central data cache.
+  That snapshot is taken once during `start_clients()` and expires after
+  `MAX_CACHE_AGE`. For a channel other than 0 its only consumer is the
+  integration adding its entities, which happens after the platforms have been forwarded
+  — in a real installation reliably later than that. By then the snapshot was gone.
+
+  For the interfaces in `INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK` (BidCos-RF,
+  VirtualDevices, CUxD, CCU-Jack) there is no per-parameter `getValue` fallback (#3228,
+  #3260, #3274), so the bulk snapshot is the only source of an initial value. An expired
+  snapshot therefore left the data point unset — permanently, for anything that does not
+  emit an event on its own. Covers were the visible case: a shutter reports nothing until
+  it is moved, so `HM-LC-Bl1PBU-FM` blinds stayed on `value_state=restored` with
+  `current_position: 0` until they were operated by hand. Sensors and thermostats hid the
+  same defect behind their regular events.
+
+  The init path now refreshes the snapshot when it has expired instead of giving up, and
+  reads the value from the refreshed data. Concurrent readers share one refresh, so
+  adding hundreds of entities costs roughly one ReGa script call per cache period of
+  startup — which does not touch the duty cycle. The `getValue` fallback stays disabled;
+  nothing about the #3260 decision changes.
+
+- **A fresh snapshot for one interface no longer skips the others.**
+  `CentralDataCache.load()` left the loop over all clients with `return` instead of
+  `continue` when it found a recently refreshed interface, so every client after it was
+  never loaded.
+
+- **`changed_within_seconds()` no longer ignores whole days.** It read
+  `timedelta.seconds`, which drops the day part, so a change from exactly 24 h ago
+  counted as recent. It now uses `total_seconds()`.
+
+### Changed
+
+- **`MAX_CACHE_AGE` raised from 10 s to 15 s.** It governs the lifetime of the central
+  data cache, the device details cache refresh guard (`MAX_CACHE_AGE / 3`) and the
+  default staleness window of `changed_within_seconds()` — so a data point is now
+  reloaded at most every 15 s instead of every 10 s.
+
 # Version 2026.9.3 (2026-09-11)
 
 ## What's Changed

--- a/changelog.md
+++ b/changelog.md
@@ -21,10 +21,20 @@
   same defect behind their regular events.
 
   The init path now refreshes the snapshot when it has expired instead of giving up, and
-  reads the value from the refreshed data. Concurrent readers share one refresh, so
-  adding hundreds of entities costs roughly one ReGa script call per cache period of
-  startup — which does not touch the duty cycle. The `getValue` fallback stays disabled;
+  reads the value from the refreshed data. The `getValue` fallback stays disabled;
   nothing about the #3260 decision changes.
+
+  Two things bound the cost of that refresh. Concurrent readers share one refresh through
+  a per-interface lock. And a refresh that comes back empty is remembered, so the next
+  reader does not immediately try again: `fetch_all_device_data()` stores only a non-empty
+  result, so an empty backend answer leaves `_refreshed_at` untouched and the existing
+  `MAX_CACHE_AGE / 3` guard in `load()` never engages. The lock alone does not cover this
+  — it coalesces concurrent callers, while the callers on this path are serialized by the
+  value cache semaphore, so each of them would have triggered its own ReGa script run.
+  An empty bulk result is not hypothetical: the script emits only data points that carry a
+  valid `Timestamp()`, and on the interfaces above that can be very few or none. Adding
+  hundreds of entities now costs roughly one script call per cache period of startup —
+  which does not touch the duty cycle.
 
 - **A fresh snapshot for one interface no longer skips the others.**
   `CentralDataCache.load()` left the loop over all clients with `return` instead of

--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -68,11 +68,13 @@ Caches device parameter values for fast access.
 
 | Setting      | Value                      |
 | ------------ | -------------------------- |
-| Max Age      | 10 seconds                 |
+| Max Age      | 15 seconds                 |
 | Scope        | Per interface              |
 | Invalidation | TTL expiry or event-driven |
 
 **Special Behavior**: During initialization, expiration is disabled to prevent cache misses while devices are being created.
+
+**On-demand refresh**: `refresh_if_expired()` refetches the bulk snapshot for an interface whose entry has expired. The initial value path uses it for the interfaces in `INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK`, where the snapshot is the only source of an initial value and the consumer (Home Assistant adding its entities) runs later than the TTL. Concurrent callers share one refresh per interface.
 
 ### Device Details Cache
 
@@ -80,7 +82,7 @@ Caches enriched device metadata (names, rooms, functions).
 
 | Setting          | Value                                  |
 | ---------------- | -------------------------------------- |
-| Refresh Interval | 15 seconds                             |
+| Refresh Interval | 5 seconds (`MAX_CACHE_AGE / 3`)        |
 | Source           | Rega script calls                      |
 | Contents         | Human-readable names, room assignments |
 
@@ -140,7 +142,7 @@ Dynamic caches expire based on time-to-live:
 
 | Cache           | TTL  | Behavior                      |
 | --------------- | ---- | ----------------------------- |
-| Data Cache      | 10s  | Returns `None` after expiry   |
+| Data Cache      | 15s  | Returns `None` after expiry   |
 | Command Tracker | 60s  | Lazy cleanup on access        |
 | Ping/Pong       | 300s | Removed during next operation |
 
@@ -248,7 +250,7 @@ The `CacheCoordinator` manages all caches centrally.
 
 ```python
 # Expiration
-MAX_CACHE_AGE = 10                          # Data cache (seconds)
+MAX_CACHE_AGE = 15                          # Data cache (seconds)
 LAST_COMMAND_SEND_STORE_TIMEOUT = 60        # Command tracker (seconds)
 PING_PONG_MISMATCH_COUNT_TTL = 300          # Ping/pong (seconds)
 

--- a/tests/contract/test_bulk_snapshot_contract.py
+++ b/tests/contract/test_bulk_snapshot_contract.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""
+Contract tests for the ReGa bulk snapshot as an initial value source.
+
+STABILITY GUARANTEE
+-------------------
+Interfaces in ``INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK`` have no per-parameter
+getValue fallback during init (#3228, #3260, #3274). For them the ReGa bulk snapshot is
+the ONLY source of an initial value, so it must still be available when the value is
+actually consumed.
+
+The snapshot is taken once during ``start_clients()`` and expires after
+``MAX_CACHE_AGE``. Its consumer for channels other than 0 is Home Assistant's
+``async_added_to_hass``, which runs after the platforms have been forwarded — reliably
+later than that. A data point that never emits an event on its own (a cover's LEVEL, a
+switch's STATE) therefore stayed unset until the device was operated by hand (#3398).
+
+CONTRACT: on an expired snapshot the init path MUST refresh it instead of giving up,
+and it MUST still not fall back to a per-parameter getValue.
+
+See ADR-0018 for architectural context.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aiohomematic.const import INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK, Interface, ParamsetKey
+from aiohomematic.interfaces import DataCacheProviderProtocol
+from aiohomematic.store.dynamic import CentralDataCache
+
+TEST_DEVICES: set[str] = {"VCU2128127"}
+
+# pylint: disable=protected-access
+
+
+class TestBulkSnapshotProtocolContract:
+    """The refresh entry point must be part of the data cache contract."""
+
+    def test_central_data_cache_implements_refresh_if_expired(self) -> None:
+        """CONTRACT: CentralDataCache MUST implement the refresh entry point."""
+        assert callable(CentralDataCache.refresh_if_expired)
+
+    def test_data_cache_provider_exposes_refresh_if_expired(self) -> None:
+        """CONTRACT: DataCacheProviderProtocol MUST offer refresh_if_expired."""
+        assert "refresh_if_expired" in dir(DataCacheProviderProtocol), (
+            "DataCacheProviderProtocol MUST expose refresh_if_expired: it is the only way "
+            "for the init path to recover an expired bulk snapshot"
+        )
+
+
+class TestBulkSnapshotInitContract:
+    """The init path must refresh an expired snapshot for fallback-free interfaces."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [(TEST_DEVICES, True, None, None)],
+    )
+    @pytest.mark.parametrize("skip_interface", sorted(INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK))
+    async def test_expired_snapshot_is_refreshed_instead_of_abandoned(
+        self, central_client_factory_with_homegear_client, monkeypatch, skip_interface: Interface
+    ) -> None:
+        """CONTRACT: an expired snapshot is refreshed, and getValue stays unused."""
+        central, _, _ = central_client_factory_with_homegear_client
+        device = central.device_coordinator.get_device(address="VCU2128127")
+        assert device is not None
+
+        # Pretend this device lives on the interface under test.
+        monkeypatch.setattr(device, "_interface", skip_interface)
+
+        values_dps = [dp for dp in device.generic_data_points if dp.paramset_key == ParamsetKey.VALUES]
+        assert values_dps
+        dpk = values_dps[0].dpk
+
+        refresh_mock = AsyncMock(return_value=False)
+        monkeypatch.setattr(central.cache_coordinator.data_cache, "refresh_if_expired", refresh_mock)
+
+        backend_calls: list[int] = []
+
+        async def _counting_get_value(**kw: Any) -> Any:
+            backend_calls.append(1)
+            return None
+
+        monkeypatch.setattr(device.client, "get_value", _counting_get_value)
+
+        result = await device.value_cache._get_values_for_cache(dpk=dpk)
+
+        refresh_mock.assert_awaited_once_with(interface=skip_interface)
+        assert backend_calls == [], "the per-parameter getValue fallback MUST stay disabled"
+        assert result == {dpk.parameter: device.value_cache._NO_VALUE_CACHE_ENTRY}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [(TEST_DEVICES, True, None, None)],
+    )
+    async def test_refreshed_snapshot_value_reaches_the_data_point(
+        self, central_client_factory_with_homegear_client, monkeypatch
+    ) -> None:
+        """CONTRACT: a value recovered by the refresh is returned to the caller."""
+        central, _, _ = central_client_factory_with_homegear_client
+        device = central.device_coordinator.get_device(address="VCU2128127")
+        assert device is not None
+
+        monkeypatch.setattr(device, "_interface", Interface.BIDCOS_RF)
+
+        values_dps = [dp for dp in device.generic_data_points if dp.paramset_key == ParamsetKey.VALUES]
+        assert values_dps
+        dpk = values_dps[0].dpk
+
+        data_cache = central.cache_coordinator.data_cache
+        recovered = {f"{Interface.BIDCOS_RF}.{dpk.channel_address}.{dpk.parameter}": 0.5}
+
+        async def _refresh_if_expired(*, interface: Interface) -> bool:
+            data_cache.add_data(interface=interface, all_device_data=recovered)
+            return True
+
+        monkeypatch.setattr(data_cache, "refresh_if_expired", _refresh_if_expired)
+
+        result = await device.value_cache._get_values_for_cache(dpk=dpk)
+
+        assert result == {dpk.parameter: 0.5}

--- a/tests/test_model_device.py
+++ b/tests/test_model_device.py
@@ -3,6 +3,7 @@
 """Tests for aiohomematic.model.device.Device and Channel."""
 
 import asyncio
+from datetime import datetime, timedelta
 from typing import Any
 import zipfile
 
@@ -12,9 +13,12 @@ from aiohomematic.central.events import DataPointStateChangedEvent, DeviceLifecy
 from aiohomematic.const import (
     CLICK_EVENTS,
     DEVICE_DESCRIPTIONS_ZIP_DIR,
+    INIT_DATETIME,
+    MAX_CACHE_AGE,
     PARAMSET_DESCRIPTIONS_ZIP_DIR,
     REPORT_VALUE_USAGE_VALUE_ID,
     VIRTUAL_REMOTE_MODELS,
+    CallSource,
     DeviceTriggerEventType,
     ForcedDeviceAvailability,
     Interface,
@@ -1230,6 +1234,67 @@ class TestDeviceFirmwareRefresh:
 
 class TestValueCachePaths:
     """Tests for _ValueCache cache hit and device unavailable branches."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [({"VCU0000045"}, True, None, None)],
+    )
+    @pytest.mark.parametrize("snapshot_age", [0, MAX_CACHE_AGE + 1])
+    async def test_expired_bulk_snapshot_is_refreshed_on_init(
+        self, central_client_factory_with_homegear_client, monkeypatch, snapshot_age
+    ) -> None:
+        """
+        A bulk-fetched value must reach the data point even when it is read late (#3398).
+
+        The ReGa snapshot is taken during ``start_clients()`` and expires after
+        MAX_CACHE_AGE, but its only consumer for a channel other than 0 is Home
+        Assistant's ``async_added_to_hass``, which runs after the platforms have been
+        forwarded. For BidCos-RF there is no getValue fallback (#3260), so an expired
+        snapshot used to leave a cover's LEVEL unset until the cover was operated by hand.
+        """
+        central, _, _ = central_client_factory_with_homegear_client
+        device = central.device_coordinator.get_device(address="VCU0000045")
+        assert device is not None
+        assert device.interface == Interface.BIDCOS_RF
+
+        dp = device.get_generic_data_point(channel_address="VCU0000045:1", parameter="LEVEL")
+        assert dp is not None
+
+        data_cache = central.cache_coordinator.data_cache
+        bulk_data = {f"{Interface.BIDCOS_RF}.VCU0000045:1.LEVEL": 0.5}
+
+        # The CCU keeps reporting the value, so a refresh returns it again.
+        async def _fetch_all_device_data() -> None:
+            data_cache.add_data(interface=Interface.BIDCOS_RF, all_device_data=bulk_data)
+
+        for client in central.client_coordinator.clients:
+            monkeypatch.setattr(client, "fetch_all_device_data", _fetch_all_device_data)
+
+        # What start_clients() does: fill the snapshot, then enable expiration.
+        data_cache.clear()
+        device.value_cache._device_cache.clear()  # type: ignore[attr-defined]
+        data_cache.add_data(interface=Interface.BIDCOS_RF, all_device_data=bulk_data)
+        central.cache_coordinator.set_data_cache_initialization_complete()
+
+        # The data point has not seen a value yet.
+        dp._set_refreshed_at(refreshed_at=INIT_DATETIME)  # type: ignore[attr-defined]
+        assert dp.is_refreshed is False
+
+        # Home Assistant adds the entity `snapshot_age` seconds later.
+        data_cache._refreshed_at[Interface.BIDCOS_RF] = datetime.now() - timedelta(  # type: ignore[attr-defined]
+            seconds=snapshot_age
+        )
+
+        await dp.load_data_point_value(call_source=CallSource.HA_INIT)
+
+        assert dp.value == 0.5
+        assert dp.is_refreshed is True
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/test_store_dynamic_caches.py
+++ b/tests/test_store_dynamic_caches.py
@@ -907,7 +907,11 @@ class _ClientStub:
     async def fetch_all_device_data(self) -> None:
         """Refill the interface snapshot, as the real client does."""
         self.fetch_count += 1
-        self._cache.add_data(interface=self.interface, all_device_data=self._data)
+        # InterfaceClient.fetch_all_device_data() writes only a non-empty result, so an
+        # empty backend answer leaves _refreshed_at untouched. Mirroring that matters:
+        # storing {} here would set _refreshed_at and hide the missing backoff.
+        if self._data:
+            self._cache.add_data(interface=self.interface, all_device_data=self._data)
 
 
 class _DataCacheCentralStub:
@@ -940,6 +944,21 @@ class TestCentralDataCacheRefresh:
     """Tests for the bulk snapshot refresh of CentralDataCache (#3398)."""
 
     @pytest.mark.asyncio
+    async def test_clear_allows_an_immediate_new_attempt(self) -> None:
+        """An explicit invalidation resets the backoff, so the next caller refetches."""
+        cache, central = _build_data_cache(interfaces=(Interface.BIDCOS_RF,))
+        client = _ClientStub(interface=Interface.BIDCOS_RF, data={}, cache=cache)
+        central.clients = (client,)
+
+        assert await cache.refresh_if_expired(interface=Interface.BIDCOS_RF) is False
+        assert client.fetch_count == 1
+
+        cache.clear(interface=Interface.BIDCOS_RF)
+
+        assert await cache.refresh_if_expired(interface=Interface.BIDCOS_RF) is False
+        assert client.fetch_count == 2
+
+    @pytest.mark.asyncio
     async def test_load_covers_all_interfaces_when_one_is_fresh(self) -> None:
         """A fresh snapshot for one interface must not skip the remaining clients."""
         cache, central = _build_data_cache(interfaces=(Interface.BIDCOS_RF, Interface.HMIP_RF))
@@ -963,6 +982,25 @@ class TestCentralDataCacheRefresh:
         assert fresh_client.fetch_count == 0
         assert stale_client.fetch_count == 1
         assert cache.get_data(interface=Interface.HMIP_RF, channel_address="VCU1234567:4", parameter="LEVEL") == 1.0
+
+    @pytest.mark.asyncio
+    async def test_refresh_if_expired_backs_off_after_empty_backend_result(self) -> None:
+        """
+        An empty result must not make every caller trigger its own bulk fetch.
+
+        A fetch that comes back empty never advances ``_refreshed_at``, because
+        ``fetch_all_device_data()`` only calls ``add_data()`` for a non-empty result. The
+        refresh lock does not help either: it coalesces concurrent callers, while the real
+        callers are serialized by the value cache semaphore.
+        """
+        cache, central = _build_data_cache(interfaces=(Interface.BIDCOS_RF,))
+        client = _ClientStub(interface=Interface.BIDCOS_RF, data={}, cache=cache)
+        central.clients = (client,)
+
+        for _ in range(10):
+            assert await cache.refresh_if_expired(interface=Interface.BIDCOS_RF) is False
+
+        assert client.fetch_count == 1
 
     @pytest.mark.asyncio
     async def test_refresh_if_expired_coalesces_concurrent_callers(self) -> None:
@@ -1021,3 +1059,18 @@ class TestCentralDataCacheRefresh:
             cache.get_data(interface=Interface.BIDCOS_RF, channel_address="VCU0000045:1", parameter="LEVEL")
             == NO_CACHE_ENTRY
         )
+
+    @pytest.mark.asyncio
+    async def test_refresh_if_expired_retries_after_backoff_window(self) -> None:
+        """Once the backoff window has passed, an empty interface is attempted again."""
+        cache, central = _build_data_cache(interfaces=(Interface.BIDCOS_RF,))
+        client = _ClientStub(interface=Interface.BIDCOS_RF, data={}, cache=cache)
+        central.clients = (client,)
+
+        assert await cache.refresh_if_expired(interface=Interface.BIDCOS_RF) is False
+        assert client.fetch_count == 1
+
+        cache._refresh_attempted_at[Interface.BIDCOS_RF] = datetime.now() - timedelta(seconds=MAX_CACHE_AGE)
+
+        assert await cache.refresh_if_expired(interface=Interface.BIDCOS_RF) is False
+        assert client.fetch_count == 2

--- a/tests/test_store_dynamic_caches.py
+++ b/tests/test_store_dynamic_caches.py
@@ -19,8 +19,17 @@ import pytest
 
 from aiohomematic.async_support import Looper
 from aiohomematic.central.events import EventBus, SystemStatusChangedEvent
-from aiohomematic.const import IntegrationIssueSeverity, IntegrationIssueType, ParamsetKey, PingPongMismatchType
-from aiohomematic.store.dynamic import CommandTracker, PingPongTracker
+from aiohomematic.const import (
+    INIT_DATETIME,
+    MAX_CACHE_AGE,
+    NO_CACHE_ENTRY,
+    IntegrationIssueSeverity,
+    IntegrationIssueType,
+    Interface,
+    ParamsetKey,
+    PingPongMismatchType,
+)
+from aiohomematic.store.dynamic import CentralDataCache, CommandTracker, PingPongTracker
 
 
 def get_ping_pong_info(
@@ -884,3 +893,131 @@ class TestPingPongTracker:
         assert last_info[1] == PingPongMismatchType.UNKNOWN.value
         assert last_info[3] is False  # acceptable
         assert last_info[2] == len(ppc._unknown)
+
+
+class _ClientStub:
+    """Minimal client that records bulk fetches and refills the data cache."""
+
+    def __init__(self, *, interface: Interface, data: dict[str, Any], cache: CentralDataCache) -> None:
+        self.interface = interface
+        self._data = data
+        self._cache = cache
+        self.fetch_count = 0
+
+    async def fetch_all_device_data(self) -> None:
+        """Refill the interface snapshot, as the real client does."""
+        self.fetch_count += 1
+        self._cache.add_data(interface=self.interface, all_device_data=self._data)
+
+
+class _DataCacheCentralStub:
+    """Minimal provider stub for CentralDataCache."""
+
+    def __init__(self, *, interfaces: tuple[Interface, ...]) -> None:
+        self.name = "data-cache-stub"
+        self.interfaces = interfaces
+        self.clients: tuple[_ClientStub, ...] = ()
+
+    def get_readable_generic_data_points(self, *, paramset_key=None, interface=None) -> tuple[Any, ...]:  # type: ignore[no-untyped-def]
+        """Return no data points."""
+        return ()
+
+
+def _build_data_cache(*, interfaces: tuple[Interface, ...]) -> tuple[CentralDataCache, _DataCacheCentralStub]:
+    """Return a CentralDataCache wired to a stub central."""
+    central = _DataCacheCentralStub(interfaces=interfaces)
+    cache = CentralDataCache(
+        device_provider=central,  # type: ignore[arg-type]
+        client_provider=central,  # type: ignore[arg-type]
+        data_point_provider=central,  # type: ignore[arg-type]
+        central_info=central,  # type: ignore[arg-type]
+    )
+    cache.set_initialization_complete()
+    return cache, central
+
+
+class TestCentralDataCacheRefresh:
+    """Tests for the bulk snapshot refresh of CentralDataCache (#3398)."""
+
+    @pytest.mark.asyncio
+    async def test_load_covers_all_interfaces_when_one_is_fresh(self) -> None:
+        """A fresh snapshot for one interface must not skip the remaining clients."""
+        cache, central = _build_data_cache(interfaces=(Interface.BIDCOS_RF, Interface.HMIP_RF))
+        fresh_client = _ClientStub(
+            interface=Interface.BIDCOS_RF,
+            data={f"{Interface.BIDCOS_RF}.VCU0000045:1.LEVEL": 0.5},
+            cache=cache,
+        )
+        stale_client = _ClientStub(
+            interface=Interface.HMIP_RF,
+            data={f"{Interface.HMIP_RF}.VCU1234567:4.LEVEL": 1.0},
+            cache=cache,
+        )
+        central.clients = (fresh_client, stale_client)
+
+        cache.add_data(interface=Interface.BIDCOS_RF, all_device_data=fresh_client._data)
+        cache._refreshed_at[Interface.HMIP_RF] = INIT_DATETIME
+
+        await cache.load()
+
+        assert fresh_client.fetch_count == 0
+        assert stale_client.fetch_count == 1
+        assert cache.get_data(interface=Interface.HMIP_RF, channel_address="VCU1234567:4", parameter="LEVEL") == 1.0
+
+    @pytest.mark.asyncio
+    async def test_refresh_if_expired_coalesces_concurrent_callers(self) -> None:
+        """Entities added in parallel must not each trigger their own bulk fetch."""
+        cache, central = _build_data_cache(interfaces=(Interface.BIDCOS_RF,))
+        data = {f"{Interface.BIDCOS_RF}.VCU0000045:1.LEVEL": 0.5}
+        client = _ClientStub(interface=Interface.BIDCOS_RF, data=data, cache=cache)
+        central.clients = (client,)
+
+        cache.add_data(interface=Interface.BIDCOS_RF, all_device_data=data)
+        cache._refreshed_at[Interface.BIDCOS_RF] = datetime.now() - timedelta(seconds=MAX_CACHE_AGE + 1)
+
+        results = await asyncio.gather(*(cache.refresh_if_expired(interface=Interface.BIDCOS_RF) for _ in range(10)))
+
+        assert all(results)
+        assert client.fetch_count == 1
+
+    @pytest.mark.asyncio
+    async def test_refresh_if_expired_keeps_fresh_snapshot(self) -> None:
+        """A fresh snapshot is used as is, without a backend round trip."""
+        cache, central = _build_data_cache(interfaces=(Interface.BIDCOS_RF,))
+        data = {f"{Interface.BIDCOS_RF}.VCU0000045:1.LEVEL": 0.5}
+        client = _ClientStub(interface=Interface.BIDCOS_RF, data=data, cache=cache)
+        central.clients = (client,)
+
+        cache.add_data(interface=Interface.BIDCOS_RF, all_device_data=data)
+
+        assert await cache.refresh_if_expired(interface=Interface.BIDCOS_RF) is True
+        assert client.fetch_count == 0
+
+    @pytest.mark.asyncio
+    async def test_refresh_if_expired_refetches_expired_snapshot(self) -> None:
+        """An expired snapshot is refetched, so a late reader still sees the value."""
+        cache, central = _build_data_cache(interfaces=(Interface.BIDCOS_RF,))
+        data = {f"{Interface.BIDCOS_RF}.VCU0000045:1.LEVEL": 0.5}
+        client = _ClientStub(interface=Interface.BIDCOS_RF, data=data, cache=cache)
+        central.clients = (client,)
+
+        cache.add_data(interface=Interface.BIDCOS_RF, all_device_data=data)
+        cache._refreshed_at[Interface.BIDCOS_RF] = datetime.now() - timedelta(seconds=MAX_CACHE_AGE + 1)
+
+        assert await cache.refresh_if_expired(interface=Interface.BIDCOS_RF) is True
+        assert client.fetch_count == 1
+        assert cache.get_data(interface=Interface.BIDCOS_RF, channel_address="VCU0000045:1", parameter="LEVEL") == 0.5
+
+    @pytest.mark.asyncio
+    async def test_refresh_if_expired_reports_empty_backend_result(self) -> None:
+        """A backend that returns nothing must not be reported as usable data."""
+        cache, central = _build_data_cache(interfaces=(Interface.BIDCOS_RF,))
+        client = _ClientStub(interface=Interface.BIDCOS_RF, data={}, cache=cache)
+        central.clients = (client,)
+
+        assert await cache.refresh_if_expired(interface=Interface.BIDCOS_RF) is False
+        assert client.fetch_count == 1
+        assert (
+            cache.get_data(interface=Interface.BIDCOS_RF, channel_address="VCU0000045:1", parameter="LEVEL")
+            == NO_CACHE_ENTRY
+        )

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -489,6 +489,10 @@ class TestTimeHelpers:
         assert changed_within_seconds(last_change=(datetime.now() - timedelta(seconds=10)), max_age=60) is True
         assert changed_within_seconds(last_change=(datetime.now() - timedelta(seconds=70)), max_age=60) is False
         assert changed_within_seconds(last_change=INIT_DATETIME, max_age=60) is False
+        # A change from a whole day ago is not recent: timedelta.seconds drops full days,
+        # total_seconds() does not.
+        assert changed_within_seconds(last_change=(datetime.now() - timedelta(days=1)), max_age=60) is False
+        assert changed_within_seconds(last_change=(datetime.now() - timedelta(days=1, seconds=10)), max_age=60) is False
 
 
 class TestValueConversion:


### PR DESCRIPTION
Fixes #3398 (follow-up to #3381).

## Problem

`HM-LC-Bl1PBU-FM` blinds on BidCos-RF stay on `value_state=restored` with
`current_position: 0` after a Home Assistant start, until they are moved by hand. The
reporter ran `fetch_all_device_data.fn` on the CCU while the covers were stuck: every
`LEVEL` is present. The backend knows the values; they never reach the data points.

## Cause

The ReGa bulk fetch fills `CentralDataCache` during `start_clients()`. For a channel
other than 0 the only consumer of that snapshot is the integration adding its entities
(`async_added_to_hass` → `load_data_point_value(HA_INIT)`), which runs after
`init_hub()` and the platform forwarding. `set_data_cache_initialization_complete()`
enables expiration right after device creation, and `MAX_CACHE_AGE` was 10 s — the
reporter's diagnostics show `config_entry_setup: 13.6 s`, so the snapshot was reliably
gone by then.

For the interfaces in `INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK` (BidCos-RF,
VirtualDevices, CUxD, CCU-Jack) there is no per-parameter `getValue` fallback
(#3228, #3260, #3274), so nothing filled the gap: `_get_values_for_cache()` returned the
NO_VALUE marker and `write_value()` discarded it. This affects every data point on those
interfaces that does not emit an event on its own — covers are simply the visible case,
because a shutter reports nothing until it moves. Before #3260 the `getValue` fallback
hid the defect.

## Change

- `CentralDataCache.refresh_if_expired()` refetches the bulk snapshot for an interface
  whose entry has expired. A per-interface `asyncio.Lock` lets concurrent callers share
  one refresh, so adding hundreds of entities costs roughly one ReGa script call per
  cache period of startup — which does not touch the duty cycle.
- `_ValueCache._get_values_for_cache()` uses it for the fallback-free interfaces and
  reads the recovered value. The `getValue` fallback stays disabled; the #3260 decision
  is unchanged.
- `DataCacheProviderProtocol` gains `refresh_if_expired`.

Two defects found in the same path:

- `CentralDataCache.load()` left the loop over all clients with `return` instead of
  `continue` on a freshly refreshed interface, so every client after it was skipped.
- `changed_within_seconds()` read `timedelta.seconds`, which drops whole days, so a
  change from exactly 24 h ago counted as recent.

`MAX_CACHE_AGE` is raised from 10 s to 15 s. It also governs the device details refresh
guard (`MAX_CACHE_AGE / 3`, now 5 s) and the default staleness window of
`changed_within_seconds()`.

## Tests

The regression is pinned by a test parametrized only on the snapshot's age — it failed
at 11 s and passed at 0 s before the fix:

| snapshot age at HA_INIT | before | after |
| --- | --- | --- |
| 0 s | pass | pass |
| `MAX_CACHE_AGE + 1` | **fail** (`assert None == 0.5`) | pass |

- `tests/contract/test_bulk_snapshot_contract.py` — new contract test, parametrized over
  every interface in `INTERFACES_SKIPPING_INIT_GETVALUE_FALLBACK`: an expired snapshot
  must be refreshed, `getValue` must stay unused, and a recovered value must reach the
  caller.
- `tests/test_model_device.py::test_expired_bulk_snapshot_is_refreshed_on_init` — the
  end-to-end reproducer on a BidCos-RF cover.
- `tests/test_store_dynamic_caches.py` — five unit tests for `refresh_if_expired`
  (refetch, fresh snapshot, concurrent coalescing, empty backend result) and the
  `load()` loop.
- `tests/test_support.py` — two cases for the day-boundary behaviour.

All of the above pass locally, as do the pre-existing `#3260` tests. The full suite was
interrupted by the environment rather than by a failure, so CI is the authority here.
