### PR TITLE
fix(model): refresh the expired bulk snapshot for ignored init parameters

### DIFF
--- a/aiohomematic/model/data_point.py
+++ b/aiohomematic/model/data_point.py
@@ -1133,21 +1133,29 @@ class BaseParameterDataPoint[
             CallSource.HM_INIT,
             CallSource.HA_INIT,
         ):
-            # For ignored parameters, only try to load from cache (no RPC call).
-            # This allows calculated data points to get their values on restart
+            # For ignored parameters, only try to load from cache (no per-parameter RPC
+            # call). This allows calculated data points to get their values on restart
             # without waking up battery-powered devices.
-            if (
-                self._paramset_key == ParamsetKey.VALUES
-                and (
-                    cached_value := self._device.data_cache_provider.get_data(
-                        interface=self._device.interface,
-                        channel_address=self._channel.address,
-                        parameter=self._parameter,
+            if self._paramset_key == ParamsetKey.VALUES:
+                # The bulk snapshot is taken during start_clients() and expires after
+                # MAX_CACHE_AGE, long before Home Assistant adds its entities. Refresh it
+                # instead of giving up: an ignored parameter has no getValue fallback, so
+                # the snapshot is its only source of an initial value. A battery sensor
+                # whose LOW_BAT does not change again would otherwise stay unset
+                # permanently.
+                data_cache_provider = self._device.data_cache_provider
+                if (
+                    await data_cache_provider.refresh_if_expired(interface=self._device.interface)
+                    and (
+                        cached_value := data_cache_provider.get_data(
+                            interface=self._device.interface,
+                            channel_address=self._channel.address,
+                            parameter=self._parameter,
+                        )
                     )
-                )
-                != NO_CACHE_ENTRY
-            ):
-                self.write_value(value=cached_value, write_at=datetime.now())
+                    != NO_CACHE_ENTRY
+                ):
+                    self.write_value(value=cached_value, write_at=datetime.now())
             return
 
         if direct_call is False and hms.changed_within_seconds(last_change=self._refreshed_at):

--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,25 @@
   hundreds of entities now costs roughly one script call per cache period of startup —
   which does not touch the duty cycle.
 
+- **Battery and diagnostic data points no longer stay on `restored` after a start.**
+  Parameters on the init ignore list (`LOW_BAT`, `LOWBAT`, `OPERATING_VOLTAGE`,
+  `DUTY_CYCLE`, `DUTYCYCLE`, plus the `ERROR_*`, `RSSI_*` and `*_ERROR` patterns, and
+  every data point of `HmIP-SWSD*` / `HmIP-SWD`) deliberately skip the per-parameter
+  `getValue` during init, so they do not wake a battery-powered device. That makes the
+  bulk snapshot their only source of an initial value — and unlike the regular init path,
+  this one read the snapshot without refreshing it first. Once it had expired, the data
+  point stayed unset: `is_valid` stays `False`, which the integration reports as
+  `value_state: restored`.
+
+  Unlike a cover's `LEVEL`, these parameters do not recover on their own. `LOW_BAT` is
+  sent only when it changes, so a device that reported a low battery before the start kept
+  showing a normal battery until the battery was replaced — while a direct
+  `get_device_value` on the same parameter returned the correct value all along.
+
+  This affects every interface, not only those without a `getValue` fallback. The ignored
+  parameters now refresh an expired snapshot the same way the regular init path does. No
+  `getValue` is added for them.
+
 - **A fresh snapshot for one interface no longer skips the others.**
   `CentralDataCache.load()` left the loop over all clients with `return` instead of
   `continue` when it found a recently refreshed interface, so every client after it was

--- a/tests/test_model_data_point.py
+++ b/tests/test_model_data_point.py
@@ -2,14 +2,22 @@
 # Copyright (c) 2021-2026
 """Tests for data point functionality of aiohomematic."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
 from aiohomematic.central.events import DataPointStateChangedEvent, DeviceLifecycleEvent, DeviceLifecycleEventType
-from aiohomematic.const import CallSource, DataPointUsage, Interface, ParameterStatus, ParamsetKey
+from aiohomematic.const import (
+    INIT_DATETIME,
+    MAX_CACHE_AGE,
+    CallSource,
+    DataPointUsage,
+    Interface,
+    ParameterStatus,
+    ParamsetKey,
+)
 from aiohomematic.model.custom import CustomDpSwitch, get_required_parameters
 from aiohomematic.model.generic import DpSensor, DpSwitch
 from aiohomematic.store.visibility import check_ignore_parameters_is_clean
@@ -513,6 +521,78 @@ class TestIgnoreOnInitialLoad:
         assert switch.value is None
 
         # Verify no RPC calls were made
+        assert len(mock_client.method_calls) == call_count_before
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            ({"VCU6153495"}, True, None, None),
+        ],
+    )
+    @pytest.mark.parametrize("snapshot_age", [0, MAX_CACHE_AGE + 1])
+    async def test_ignore_on_initial_load_refreshes_expired_bulk_snapshot(
+        self,
+        central_client_factory_with_homegear_client,
+        monkeypatch,
+        snapshot_age,
+    ) -> None:
+        """
+        An ignored parameter must still pick up its bulk value when the snapshot has expired.
+
+        The bulk snapshot is taken during ``start_clients()`` and expires after
+        MAX_CACHE_AGE, while Home Assistant adds its entities later. For an ignored
+        parameter the snapshot is the only source of an initial value - there is no
+        getValue fallback - so an expired snapshot left the data point unset. A battery
+        sensor whose LOW_BAT does not change again then stayed on value_state=restored
+        permanently.
+        """
+        central, mock_client, _ = central_client_factory_with_homegear_client
+        device = central.device_coordinator.get_device(address="VCU6153495")
+        assert device is not None
+
+        dp = device.get_generic_data_point(channel_address="VCU6153495:0", parameter="LOW_BAT")
+        assert dp is not None
+        assert dp.ignore_on_initial_load is True
+
+        data_cache = central.cache_coordinator.data_cache
+        bulk_data = {f"{Interface.BIDCOS_RF}.VCU6153495:0.LOW_BAT": True}
+
+        # The CCU keeps reporting the value, so a refresh returns it again.
+        async def _fetch_all_device_data() -> None:
+            data_cache.add_data(interface=Interface.BIDCOS_RF, all_device_data=bulk_data)
+
+        for client in central.client_coordinator.clients:
+            monkeypatch.setattr(client, "fetch_all_device_data", _fetch_all_device_data)
+
+        # What start_clients() does: fill the snapshot, then enable expiration.
+        data_cache.clear()
+        data_cache.add_data(interface=Interface.BIDCOS_RF, all_device_data=bulk_data)
+        central.cache_coordinator.set_data_cache_initialization_complete()
+
+        # The data point has not seen a value yet.
+        dp._set_refreshed_at(refreshed_at=INIT_DATETIME)
+        assert dp.is_refreshed is False
+
+        # Home Assistant adds the entity `snapshot_age` seconds later.
+        data_cache._refreshed_at[Interface.BIDCOS_RF] = datetime.now() - timedelta(seconds=snapshot_age)
+
+        call_count_before = len(mock_client.method_calls)
+
+        await dp.load_data_point_value(call_source=CallSource.HA_INIT)
+
+        # is_valid drives the integration's value_state: False shows up as "restored".
+        assert dp.is_refreshed is True
+        assert dp.is_valid is True
+        assert dp.value is True
+
+        # The ignored parameter must never be read per parameter - that is what the
+        # ignore list is for.
         assert len(mock_client.method_calls) == call_count_before
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Parameters on the init ignore list (`LOW_BAT`, `LOWBAT`, `OPERATING_VOLTAGE`,
`DUTY_CYCLE`, `DUTYCYCLE`, plus the `ERROR_*`, `RSSI_*` and `*_ERROR` patterns, and every
data point of `HmIP-SWSD*` / `HmIP-SWD`) deliberately skip the per-parameter `getValue`
during init so they do not wake a battery-powered device. That makes the bulk snapshot
their only source of an initial value.

Unlike the regular init path, this one read the snapshot without refreshing it first. The
snapshot is taken during `start_clients()` and expires after `MAX_CACHE_AGE`, long before
Home Assistant adds its entities — so the data point stayed unset. `is_valid` stays
`False`, which the integration reports as `value_state: restored`.

Unlike a cover's `LEVEL`, these parameters do not recover on their own. `LOW_BAT` is sent
only when it changes, so a device that reported a low battery before the start kept showing
a normal battery until the battery was replaced — while a direct `get_device_value` on the
same parameter returned the correct value all along.

This affects every interface, not only those without a `getValue` fallback.

## Change

`BaseParameterDataPoint.load_data_point_value()` now refreshes an expired snapshot before
reading it, the same way the regular init path already does in
`_ValueCache._get_values_for_cache()`. No `getValue` is added for the ignored parameters,
and the refresh stays bounded by the existing per-interface lock and the empty-result
backoff in `CentralDataCache.refresh_if_expired()`.

## Tests

`TestIgnoreOnInitialLoad::test_ignore_on_initial_load_refreshes_expired_bulk_snapshot`,
parametrized over `snapshot_age ∈ {0, MAX_CACHE_AGE + 1}`, using a real `HmIP-FCI1`
(`VCU6153495:0`, `LOW_BAT`) rather than a patched ignore flag. It asserts the value
arrives, that `is_valid` is `True`, and that no per-parameter RPC was made.

Verified failing before the change (`snapshot_age=16`: value stayed on the default
`False`, `is_refreshed` `False`) and passing after.

- `pytest tests/`: 4135 passed, 1 skipped
- `prek run --all-files`: all hooks pass

## Notes

No version bump: 2026.9.4 is not tagged or released yet, so the changelog entry was added
to that section and `VERSION` stays in sync.

Whether this resolves a given report depends on the ReGa data point carrying a valid
`Timestamp()` — `fetch_all_device_data.fn` emits only those. If it does not, a fresh
snapshot has nothing to offer either and the value arrives with the next event. The code
defect existed independently of that.
